### PR TITLE
Replace the Budgets/Envelope switch with a single Ready to Assign toggle (#100)

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -177,7 +177,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 61;
+  int get schemaVersion => 62;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -517,6 +517,20 @@ class AppDatabase extends _$AppDatabase {
         // screen and Envelope Mode's Ready to Assign as the primary
         // budgeting system. Neither system's own data changes.
         await _addColumnIfMissing(m, settings, settings.budgetingMode);
+      }
+      if (from < 62) {
+        // GitHub #100 v2 — Budget (the ceiling system) is now always on for
+        // everyone; the old Budgets-vs-Envelope choice becomes a single
+        // Ready to Assign on/off switch instead. Backfill from the old
+        // enum rather than defaulting everyone to off, so an existing
+        // Envelope-mode user's accounts don't silently fall out of the pool.
+        await _addColumnIfMissing(m, settings, settings.rtaEnabled);
+        final current = await select(settings).getSingleOrNull();
+        if (current != null && current.budgetingMode == BudgetingMode.envelope) {
+          await update(
+            settings,
+          ).write(const SettingsCompanion(rtaEnabled: Value(true)));
+        }
       }
     },
     beforeOpen: (details) async {
@@ -2544,11 +2558,10 @@ class AppDatabase extends _$AppDatabase {
     }
 
     return transaction(() async {
-      // GitHub #100 — while Envelope is the primary budgeting system, every
-      // account joins the shared pool automatically, including a new one;
-      // there's no separate "turn on Envelope Mode" step to remember.
-      final envelopeByDefault =
-          (await getSettings()).budgetingMode == BudgetingMode.envelope;
+      // GitHub #100 v2 — while Ready to Assign is on, every account joins
+      // the shared pool automatically, including a new one; there's no
+      // separate "turn on" step to remember.
+      final envelopeByDefault = (await getSettings()).rtaEnabled;
       return into(accounts).insert(
         AccountsCompanion.insert(
           name: name,
@@ -2644,8 +2657,10 @@ class AppDatabase extends _$AppDatabase {
   /// with transaction history would orphan every row that named it, exactly
   /// like [archiveCategory] above. Removal only ever succeeds on an account
   /// nothing has touched yet — no transaction, no debit card drawing from it,
-  /// no reminder or merchant rule naming it.
-  Future<void> deleteAccount(int id) async {
+  /// no reminder or merchant rule naming it. Returns whether deleting it
+  /// also auto-disabled Ready to Assign (it was the last pool account) — see
+  /// [_maybeAutoDisableRta].
+  Future<bool> deleteAccount(int id) async {
     final linkedCard = await (select(
       accounts,
     )..where((a) => a.linkedAccountId.equals(id))).getSingleOrNull();
@@ -2688,7 +2703,7 @@ class AppDatabase extends _$AppDatabase {
         'that in Settings first.',
       );
     }
-    await transaction(() async {
+    return transaction(() async {
       // A goal account's own target/deadline row has no reason to outlive
       // it — nothing else ever references GoalDetails. Same for a credit
       // card's statement-tracking row.
@@ -2697,6 +2712,7 @@ class AppDatabase extends _$AppDatabase {
         creditCardDetails,
       )..where((c) => c.accountId.equals(id))).go();
       await (delete(accounts)..where((a) => a.id.equals(id))).go();
+      return _maybeAutoDisableRta();
     });
   }
 
@@ -2891,11 +2907,36 @@ class AppDatabase extends _$AppDatabase {
   /// Per-account, not global — every other account keeps working exactly as
   /// it does today. Switching this off never deletes [Allocations] rows (see
   /// [Allocations] doc); they simply stop being read while it's off, and
-  /// reappear if it's switched back on.
-  Future<void> setEnvelopeMode(int accountId, bool enabled) =>
-      (update(accounts)..where((a) => a.id.equals(accountId))).write(
-        AccountsCompanion(envelopeMode: Value(enabled)),
-      );
+  /// reappear if it's switched back on. Returns whether turning it off also
+  /// auto-disabled Ready to Assign (it was the last pool account) — see
+  /// [_maybeAutoDisableRta].
+  Future<bool> setEnvelopeMode(int accountId, bool enabled) =>
+      transaction(() async {
+        await (update(accounts)..where((a) => a.id.equals(accountId))).write(
+          AccountsCompanion(envelopeMode: Value(enabled)),
+        );
+        return enabled ? false : _maybeAutoDisableRta();
+      });
+
+  /// Turns Ready to Assign off, automatically, the moment its pool would
+  /// otherwise go empty — called from inside the same [transaction] as
+  /// whatever just removed the last pool account ([setEnvelopeMode] turning
+  /// one off, or [deleteAccount] removing one). Returns whether it actually
+  /// fired, so the caller can surface a non-blocking notice; never throws
+  /// and never blocks the action that triggered it (GitHub #100 v2 — no
+  /// confirmation prompt on the account-side action, only a heads-up after).
+  Future<bool> _maybeAutoDisableRta() async {
+    final settingsRow = await getSettings();
+    if (!settingsRow.rtaEnabled) return false;
+    final remaining = await (select(
+      accounts,
+    )..where((a) => a.envelopeMode.equals(true))).get();
+    if (remaining.isNotEmpty) return false;
+    await update(
+      settings,
+    ).write(const SettingsCompanion(rtaEnabled: Value(false)));
+    return true;
+  }
 
   /// Every allocation, across every account — the provider layer sums these
   /// per (account, category) rather than this querying once per pair.
@@ -4235,17 +4276,18 @@ class AppDatabase extends _$AppDatabase {
     settings,
   ).write(SettingsCompanion(moreScreenViewMode: Value(mode)));
 
-  /// Switching to [BudgetingMode.envelope] is meant to be the only step —
-  /// GitHub #100 asked that every account join the shared pool at once
-  /// rather than needing its own trip to Account Detail's Envelope Mode
-  /// toggle. Switching back to `budgets` leaves every account's flag as-is
-  /// (nothing here reads it while Budgets is the active mode), so flipping
-  /// back to Envelope later doesn't lose anything.
-  Future<void> setBudgetingMode(BudgetingMode mode) => transaction(() async {
+  /// Turning Ready to Assign on is meant to be the only step — GitHub #100
+  /// asked that every account join the shared pool at once rather than
+  /// needing its own trip to Account Detail's on-budget toggle; users opt
+  /// individual accounts back out from there afterward. Turning it off
+  /// leaves every account's [Accounts.envelopeMode] flag as-is (nothing
+  /// reads it while RTA is off), so turning it back on re-enrolls everyone
+  /// anyway per the branch below — no data is lost either direction.
+  Future<void> setRtaEnabled(bool enabled) => transaction(() async {
     await update(
       settings,
-    ).write(SettingsCompanion(budgetingMode: Value(mode)));
-    if (mode == BudgetingMode.envelope) {
+    ).write(SettingsCompanion(rtaEnabled: Value(enabled)));
+    if (enabled) {
       await update(
         accounts,
       ).write(const AccountsCompanion(envelopeMode: Value(true)));

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -8908,6 +8908,21 @@ class $SettingsTable extends Settings
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _rtaEnabledMeta = const VerificationMeta(
+    'rtaEnabled',
+  );
+  @override
+  late final GeneratedColumn<bool> rtaEnabled = GeneratedColumn<bool>(
+    'rta_enabled',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("rta_enabled" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _paypalEnabledMeta = const VerificationMeta(
     'paypalEnabled',
   );
@@ -9436,6 +9451,7 @@ class $SettingsTable extends Settings
     myCashapp,
     myRevolut,
     upiEnabled,
+    rtaEnabled,
     paypalEnabled,
     venmoEnabled,
     cashappEnabled,
@@ -9616,6 +9632,12 @@ class $SettingsTable extends Settings
       context.handle(
         _upiEnabledMeta,
         upiEnabled.isAcceptableOrUnknown(data['upi_enabled']!, _upiEnabledMeta),
+      );
+    }
+    if (data.containsKey('rta_enabled')) {
+      context.handle(
+        _rtaEnabledMeta,
+        rtaEnabled.isAcceptableOrUnknown(data['rta_enabled']!, _rtaEnabledMeta),
       );
     }
     if (data.containsKey('paypal_enabled')) {
@@ -10020,6 +10042,10 @@ class $SettingsTable extends Settings
         DriftSqlType.bool,
         data['${effectivePrefix}upi_enabled'],
       )!,
+      rtaEnabled: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}rta_enabled'],
+      )!,
       paypalEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}paypal_enabled'],
@@ -10274,6 +10300,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
   /// entirely, rather than leaving a permanently-disabled button around.
   final bool upiEnabled;
 
+  /// Whether Ready to Assign is turned on globally.
+  final bool rtaEnabled;
+
   /// Same as [upiEnabled], for PayPal.
   final bool paypalEnabled;
 
@@ -10483,6 +10512,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     this.myCashapp,
     this.myRevolut,
     required this.upiEnabled,
+    required this.rtaEnabled,
     required this.paypalEnabled,
     required this.venmoEnabled,
     required this.cashappEnabled,
@@ -10559,6 +10589,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       map['my_revolut'] = Variable<String>(myRevolut);
     }
     map['upi_enabled'] = Variable<bool>(upiEnabled);
+    map['rta_enabled'] = Variable<bool>(rtaEnabled);
     map['paypal_enabled'] = Variable<bool>(paypalEnabled);
     map['venmo_enabled'] = Variable<bool>(venmoEnabled);
     map['cashapp_enabled'] = Variable<bool>(cashappEnabled);
@@ -10674,6 +10705,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ? const Value.absent()
           : Value(myRevolut),
       upiEnabled: Value(upiEnabled),
+      rtaEnabled: Value(rtaEnabled),
       paypalEnabled: Value(paypalEnabled),
       venmoEnabled: Value(venmoEnabled),
       cashappEnabled: Value(cashappEnabled),
@@ -10765,6 +10797,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       myCashapp: serializer.fromJson<String?>(json['myCashapp']),
       myRevolut: serializer.fromJson<String?>(json['myRevolut']),
       upiEnabled: serializer.fromJson<bool>(json['upiEnabled']),
+      rtaEnabled: serializer.fromJson<bool>(json['rtaEnabled']),
       paypalEnabled: serializer.fromJson<bool>(json['paypalEnabled']),
       venmoEnabled: serializer.fromJson<bool>(json['venmoEnabled']),
       cashappEnabled: serializer.fromJson<bool>(json['cashappEnabled']),
@@ -10864,6 +10897,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       'myCashapp': serializer.toJson<String?>(myCashapp),
       'myRevolut': serializer.toJson<String?>(myRevolut),
       'upiEnabled': serializer.toJson<bool>(upiEnabled),
+      'rtaEnabled': serializer.toJson<bool>(rtaEnabled),
       'paypalEnabled': serializer.toJson<bool>(paypalEnabled),
       'venmoEnabled': serializer.toJson<bool>(venmoEnabled),
       'cashappEnabled': serializer.toJson<bool>(cashappEnabled),
@@ -10942,6 +10976,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     Value<String?> myCashapp = const Value.absent(),
     Value<String?> myRevolut = const Value.absent(),
     bool? upiEnabled,
+    bool? rtaEnabled,
     bool? paypalEnabled,
     bool? venmoEnabled,
     bool? cashappEnabled,
@@ -11004,6 +11039,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     myCashapp: myCashapp.present ? myCashapp.value : this.myCashapp,
     myRevolut: myRevolut.present ? myRevolut.value : this.myRevolut,
     upiEnabled: upiEnabled ?? this.upiEnabled,
+    rtaEnabled: rtaEnabled ?? this.rtaEnabled,
     paypalEnabled: paypalEnabled ?? this.paypalEnabled,
     venmoEnabled: venmoEnabled ?? this.venmoEnabled,
     cashappEnabled: cashappEnabled ?? this.cashappEnabled,
@@ -11098,6 +11134,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       upiEnabled: data.upiEnabled.present
           ? data.upiEnabled.value
           : this.upiEnabled,
+      rtaEnabled: data.rtaEnabled.present
+          ? data.rtaEnabled.value
+          : this.rtaEnabled,
       paypalEnabled: data.paypalEnabled.present
           ? data.paypalEnabled.value
           : this.paypalEnabled,
@@ -11242,6 +11281,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ..write('myCashapp: $myCashapp, ')
           ..write('myRevolut: $myRevolut, ')
           ..write('upiEnabled: $upiEnabled, ')
+          ..write('rtaEnabled: $rtaEnabled, ')
           ..write('paypalEnabled: $paypalEnabled, ')
           ..write('venmoEnabled: $venmoEnabled, ')
           ..write('cashappEnabled: $cashappEnabled, ')
@@ -11308,6 +11348,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     myCashapp,
     myRevolut,
     upiEnabled,
+    rtaEnabled,
     paypalEnabled,
     venmoEnabled,
     cashappEnabled,
@@ -11371,6 +11412,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           other.myCashapp == this.myCashapp &&
           other.myRevolut == this.myRevolut &&
           other.upiEnabled == this.upiEnabled &&
+          other.rtaEnabled == this.rtaEnabled &&
           other.paypalEnabled == this.paypalEnabled &&
           other.venmoEnabled == this.venmoEnabled &&
           other.cashappEnabled == this.cashappEnabled &&
@@ -11434,6 +11476,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
   final Value<String?> myCashapp;
   final Value<String?> myRevolut;
   final Value<bool> upiEnabled;
+  final Value<bool> rtaEnabled;
   final Value<bool> paypalEnabled;
   final Value<bool> venmoEnabled;
   final Value<bool> cashappEnabled;
@@ -11493,6 +11536,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.myCashapp = const Value.absent(),
     this.myRevolut = const Value.absent(),
     this.upiEnabled = const Value.absent(),
+    this.rtaEnabled = const Value.absent(),
     this.paypalEnabled = const Value.absent(),
     this.venmoEnabled = const Value.absent(),
     this.cashappEnabled = const Value.absent(),
@@ -11553,6 +11597,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.myCashapp = const Value.absent(),
     this.myRevolut = const Value.absent(),
     this.upiEnabled = const Value.absent(),
+    this.rtaEnabled = const Value.absent(),
     this.paypalEnabled = const Value.absent(),
     this.venmoEnabled = const Value.absent(),
     this.cashappEnabled = const Value.absent(),
@@ -11613,6 +11658,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Expression<String>? myCashapp,
     Expression<String>? myRevolut,
     Expression<bool>? upiEnabled,
+    Expression<bool>? rtaEnabled,
     Expression<bool>? paypalEnabled,
     Expression<bool>? venmoEnabled,
     Expression<bool>? cashappEnabled,
@@ -11677,6 +11723,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       if (myCashapp != null) 'my_cashapp': myCashapp,
       if (myRevolut != null) 'my_revolut': myRevolut,
       if (upiEnabled != null) 'upi_enabled': upiEnabled,
+      if (rtaEnabled != null) 'rta_enabled': rtaEnabled,
       if (paypalEnabled != null) 'paypal_enabled': paypalEnabled,
       if (venmoEnabled != null) 'venmo_enabled': venmoEnabled,
       if (cashappEnabled != null) 'cashapp_enabled': cashappEnabled,
@@ -11753,6 +11800,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Value<String?>? myCashapp,
     Value<String?>? myRevolut,
     Value<bool>? upiEnabled,
+    Value<bool>? rtaEnabled,
     Value<bool>? paypalEnabled,
     Value<bool>? venmoEnabled,
     Value<bool>? cashappEnabled,
@@ -11815,6 +11863,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       myCashapp: myCashapp ?? this.myCashapp,
       myRevolut: myRevolut ?? this.myRevolut,
       upiEnabled: upiEnabled ?? this.upiEnabled,
+      rtaEnabled: rtaEnabled ?? this.rtaEnabled,
       paypalEnabled: paypalEnabled ?? this.paypalEnabled,
       venmoEnabled: venmoEnabled ?? this.venmoEnabled,
       cashappEnabled: cashappEnabled ?? this.cashappEnabled,
@@ -11926,6 +11975,9 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     }
     if (upiEnabled.present) {
       map['upi_enabled'] = Variable<bool>(upiEnabled.value);
+    }
+    if (rtaEnabled.present) {
+      map['rta_enabled'] = Variable<bool>(rtaEnabled.value);
     }
     if (paypalEnabled.present) {
       map['paypal_enabled'] = Variable<bool>(paypalEnabled.value);
@@ -12101,6 +12153,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
           ..write('myCashapp: $myCashapp, ')
           ..write('myRevolut: $myRevolut, ')
           ..write('upiEnabled: $upiEnabled, ')
+          ..write('rtaEnabled: $rtaEnabled, ')
           ..write('paypalEnabled: $paypalEnabled, ')
           ..write('venmoEnabled: $venmoEnabled, ')
           ..write('cashappEnabled: $cashappEnabled, ')
@@ -30978,6 +31031,7 @@ typedef $$SettingsTableCreateCompanionBuilder =
       Value<String?> myCashapp,
       Value<String?> myRevolut,
       Value<bool> upiEnabled,
+      Value<bool> rtaEnabled,
       Value<bool> paypalEnabled,
       Value<bool> venmoEnabled,
       Value<bool> cashappEnabled,
@@ -31039,6 +31093,7 @@ typedef $$SettingsTableUpdateCompanionBuilder =
       Value<String?> myCashapp,
       Value<String?> myRevolut,
       Value<bool> upiEnabled,
+      Value<bool> rtaEnabled,
       Value<bool> paypalEnabled,
       Value<bool> venmoEnabled,
       Value<bool> cashappEnabled,
@@ -31201,6 +31256,11 @@ class $$SettingsTableFilterComposer
 
   ColumnFilters<bool> get upiEnabled => $composableBuilder(
     column: $table.upiEnabled,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -31530,6 +31590,11 @@ class $$SettingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get paypalEnabled => $composableBuilder(
     column: $table.paypalEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -31830,6 +31895,11 @@ class $$SettingsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get paypalEnabled => $composableBuilder(
     column: $table.paypalEnabled,
     builder: (column) => column,
@@ -32099,6 +32169,7 @@ class $$SettingsTableTableManager
                 Value<String?> myCashapp = const Value.absent(),
                 Value<String?> myRevolut = const Value.absent(),
                 Value<bool> upiEnabled = const Value.absent(),
+                Value<bool> rtaEnabled = const Value.absent(),
                 Value<bool> paypalEnabled = const Value.absent(),
                 Value<bool> venmoEnabled = const Value.absent(),
                 Value<bool> cashappEnabled = const Value.absent(),
@@ -32160,6 +32231,7 @@ class $$SettingsTableTableManager
                 myCashapp: myCashapp,
                 myRevolut: myRevolut,
                 upiEnabled: upiEnabled,
+                rtaEnabled: rtaEnabled,
                 paypalEnabled: paypalEnabled,
                 venmoEnabled: venmoEnabled,
                 cashappEnabled: cashappEnabled,
@@ -32221,6 +32293,7 @@ class $$SettingsTableTableManager
                 Value<String?> myCashapp = const Value.absent(),
                 Value<String?> myRevolut = const Value.absent(),
                 Value<bool> upiEnabled = const Value.absent(),
+                Value<bool> rtaEnabled = const Value.absent(),
                 Value<bool> paypalEnabled = const Value.absent(),
                 Value<bool> venmoEnabled = const Value.absent(),
                 Value<bool> cashappEnabled = const Value.absent(),
@@ -32282,6 +32355,7 @@ class $$SettingsTableTableManager
                 myCashapp: myCashapp,
                 myRevolut: myRevolut,
                 upiEnabled: upiEnabled,
+                rtaEnabled: rtaEnabled,
                 paypalEnabled: paypalEnabled,
                 venmoEnabled: venmoEnabled,
                 cashappEnabled: cashappEnabled,

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -450,6 +450,34 @@ final categoryBalanceProvider = Provider.family<Money, int>((
   return balance;
 });
 
+/// The three-state (RTA on) / two-state (RTA off) funding indicator for a
+/// category with a [Budgets] ceiling — GitHub #100 v2. `overspent` always
+/// wins regardless of funding; `funded`/`underfunded` only distinguish
+/// whether the pooled envelope balance ([categoryBalanceProvider]) fully
+/// backs the ceiling yet. Callers should only use this while
+/// [rtaEnabledProvider] is on — with RTA off, fall back to
+/// [BudgetProgress.nearingLimit] instead, which this deliberately doesn't
+/// touch or replace.
+enum CategoryFundingState { overspent, funded, underfunded }
+
+/// Returns null when [categoryId] has no [Budgets] row — there's nothing to
+/// color either way, in RTA on or off.
+final categoryFundingStateProvider = Provider.family<CategoryFundingState?, int>((
+  ref,
+  categoryId,
+) {
+  final p = ref
+      .watch(budgetProgressProvider)
+      .where((p) => p.budget.categoryId == categoryId)
+      .firstOrNull;
+  if (p == null) return null;
+  if (p.overspent) return CategoryFundingState.overspent;
+  final balance = ref.watch(categoryBalanceProvider(categoryId));
+  return balance >= p.budget.amount
+      ? CategoryFundingState.funded
+      : CategoryFundingState.underfunded;
+});
+
 /// `Σ(currentBalance) − Σ(category_balance > 0)`, across every account in
 /// [envelopeModeAccountsProvider] — GitHub #48: one shared Ready to Assign
 /// figure, not one per account. A category that has gone negative
@@ -872,10 +900,12 @@ final hideAmountsProvider = Provider<bool>((ref) {
   return ref.watch(settingsProvider).valueOrNull?.hideAmounts ?? false;
 });
 
-/// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
-final budgetingModeProvider = Provider<BudgetingMode>((ref) {
-  return ref.watch(settingsProvider).valueOrNull?.budgetingMode ??
-      BudgetingMode.budgets;
+/// Whether Ready to Assign — the shared envelope pool — is turned on
+/// globally (GitHub #100 v2). Budget (the per-category ceiling system) is
+/// always on regardless of this flag; see [BudgetingMode]'s doc comment for
+/// the superseded enum this replaces.
+final rtaEnabledProvider = Provider<bool>((ref) {
+  return ref.watch(settingsProvider).valueOrNull?.rtaEnabled ?? false;
 });
 
 /// A standing notification with "Add expense" / "Add income" shortcuts —

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -113,14 +113,13 @@ enum LockScreenStyle { classic, bigNumpad, scrambled }
 /// row instead, still grouped the same way.
 enum MoreScreenViewMode { list, cards }
 
-/// Which budgeting system the Dashboard and More hub surface as primary
-/// (GitHub #100). `budgets` shows the classic per-category spending-ceiling
-/// system (`BudgetsScreen`). `envelope` shows Ready to Assign / category
-/// envelopes instead. Both systems keep working and keep their own data
-/// either way — this only decides which one the Dashboard highlights and
-/// which one the More hub's "Budgets" tile opens; a user can still reach
-/// the other from wherever it's already linked from today (Account Detail's
-/// Envelope Mode toggle, or `/more/budgets` directly).
+/// Legacy — superseded by `Settings.rtaEnabled` (GitHub #100 v2). Budget
+/// (the per-category ceiling system) is now always on for everyone, and
+/// Ready to Assign is a single on/off layer on top of it rather than a
+/// mutually-exclusive alternative. This enum/column is kept only so the
+/// `from < 62` migration can read a pre-existing user's choice once, to
+/// decide whether to backfill `rtaEnabled = true` — nothing writes to it
+/// anymore.
 enum BudgetingMode { budgets, envelope }
 
 // ─── Converters ─────────────────────────────────────────────────────────────
@@ -194,11 +193,16 @@ class Accounts extends Table {
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
-  /// Turns this one account into "every rupee has a job" budgeting — an
-  /// expense on it must carry a category, and that category's balance is
-  /// funded from this account's own Ready to Assign via [Allocations]. Off
-  /// by default and per-account: every other account keeps working exactly
-  /// as it does today. See `AppDatabase.categoryBalance` / `readyToAssign`.
+  /// Whether this account is "on-budget" — inside the shared Ready to
+  /// Assign pool — rather than off-budget/tracking-only (a balance-only
+  /// account, outside the pool, like a vending-machine key fob). Only
+  /// meaningful while `Settings.rtaEnabled` is on: turning RTA on globally
+  /// sets this to true for every account at once, and turning it off for
+  /// the last pool account while RTA is on turns RTA off automatically
+  /// (see `AppDatabase.setRtaEnabled` / `_maybeAutoDisableRta`). An
+  /// on-budget account's expenses are funded from the pool via
+  /// [Allocations] — see `categoryBalanceProvider` / `readyToAssignProvider`
+  /// in `data/providers.dart`.
   BoolColumn get envelopeMode => boolean().withDefault(const Constant(false))();
 
   /// Whether this account's balance counts toward Net Worth (dashboard,
@@ -803,12 +807,22 @@ class Settings extends Table {
   TextColumn get moreScreenViewMode =>
       textEnum<MoreScreenViewMode>().withDefault(const Constant('list'))();
 
-  /// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
-  /// Defaults to `budgets` so existing users see no change; switching to
-  /// `envelope` doesn't touch either system's data, it only changes which
-  /// one the Dashboard and More hub's "Budgets" tile surface.
+  /// Legacy — see [BudgetingMode]. Superseded by [rtaEnabled]; kept only for
+  /// the `from < 62` migration's one-time backfill read. Nothing writes to
+  /// this column anymore.
   TextColumn get budgetingMode =>
       textEnum<BudgetingMode>().withDefault(const Constant('budgets'))();
+
+  /// Whether Ready to Assign — the shared envelope pool — is turned on
+  /// globally (GitHub #100 v2). Off by default. Budget (the per-category
+  /// spending ceiling) is always on regardless of this flag; this only
+  /// decides whether accounts also participate in the shared RTA pool via
+  /// [Accounts.envelopeMode]. Replaces [BudgetingMode] as a mutually
+  /// exclusive Budgets-vs-Envelope choice — enabling this auto-enrolls
+  /// every account into the pool (see `AppDatabase.setRtaEnabled`), and it
+  /// turns itself back off automatically the moment the pool would
+  /// otherwise go empty (see `AppDatabase._maybeAutoDisableRta`).
+  BoolColumn get rtaEnabled => boolean().withDefault(const Constant(false))();
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the

--- a/lib/features/accounts/accounts_screen.dart
+++ b/lib/features/accounts/accounts_screen.dart
@@ -518,8 +518,9 @@ class _AccountTile extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(account.id);
+      rtaAutoDisabled = await ref.read(dbProvider).deleteAccount(account.id);
     } on ArgumentError catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context)
@@ -534,7 +535,16 @@ class _AccountTile extends ConsumerWidget {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Account removed')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Account removed. Ready to Assign turned off — no '
+                      'accounts left in the pool.'
+                : 'Account removed',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/accounts/envelope_section.dart
+++ b/lib/features/accounts/envelope_section.dart
@@ -5,11 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 
-/// The Envelope Mode toggle for [account]. The shared Ready to Assign figure
-/// and category envelope list this account feeds once it's on live on
+/// The on-budget (pool participation) toggle for [account] — only shown
+/// while Ready to Assign is on globally (GitHub #100 v2); there's nothing to
+/// configure here until then. The shared Ready to Assign figure and category
+/// envelope list this account feeds once it's on-budget live on
 /// [lib/features/budgets/ready_to_assign_screen.dart] instead — GitHub #48:
-/// every Envelope-Mode account pools into one figure and one balance per
-/// category, so there's nothing account-scoped left to show here.
+/// every pool account pools into one figure and one balance per category, so
+/// there's nothing account-scoped left to show here.
 class EnvelopeSection extends ConsumerWidget {
   const EnvelopeSection({required this.account, super.key});
 
@@ -17,6 +19,7 @@ class EnvelopeSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(rtaEnabledProvider)) return const SizedBox.shrink();
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final poolSize = ref.watch(envelopeModeAccountsProvider).length;
@@ -27,12 +30,13 @@ class EnvelopeSection extends ConsumerWidget {
         Card(
           margin: const EdgeInsets.fromLTRB(20, 8, 20, 4),
           child: SwitchListTile(
-            title: const Text('Envelope Mode'),
+            title: const Text('On-budget'),
             subtitle: Text(
               account.envelopeMode
-                  ? 'Every rupee here has a job. An expense needs a category.'
-                  : 'Optional — "every rupee has a job" budgeting for just '
-                        'this account.',
+                  ? 'In the shared Ready to Assign pool. An expense needs a '
+                        'category.'
+                  : 'Off-budget — balance-only, like a vending-machine key '
+                        'fob. Outside the shared pool.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: cs.onSurfaceVariant,
               ),
@@ -73,7 +77,7 @@ class EnvelopeSection extends ConsumerWidget {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (dialogContext) => AlertDialog(
-          title: const Text('Turn on Envelope Mode?'),
+          title: const Text('Mark this account on-budget?'),
           content: const Text(
             'Money you assign to a category becomes reserved for it. '
             'Unassigned money sits in Ready to Assign. From now on, an '
@@ -93,6 +97,18 @@ class EnvelopeSection extends ConsumerWidget {
       );
       if (confirmed != true) return;
     }
-    await ref.read(dbProvider).setEnvelopeMode(account.id, enabled);
+    final rtaAutoDisabled = await ref
+        .read(dbProvider)
+        .setEnvelopeMode(account.id, enabled);
+    if (rtaAutoDisabled && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Ready to Assign turned off — this was the last account in the '
+            'pool.',
+          ),
+        ),
+      );
+    }
   }
 }

--- a/lib/features/budgets/budget_detail_screen.dart
+++ b/lib/features/budgets/budget_detail_screen.dart
@@ -37,6 +37,10 @@ class BudgetDetailScreen extends ConsumerWidget {
         .watch(budgetProgressProvider)
         .where((p) => p.category.id == categoryId)
         .firstOrNull;
+    final rtaOn = ref.watch(rtaEnabledProvider);
+    final fundingState = rtaOn
+        ? ref.watch(categoryFundingStateProvider(categoryId))
+        : null;
     final txs = ref.watch(categoryTransactionsProvider(categoryId));
     final accounts = ref.watch(accountMapProvider);
 
@@ -68,6 +72,8 @@ class BudgetDetailScreen extends ConsumerWidget {
             color: catColor,
             periodLabel: periodLabel,
             progress: progress,
+            rtaOn: rtaOn,
+            fundingState: fundingState,
           ),
           const SizedBox(height: 24),
           Text(
@@ -134,11 +140,15 @@ class _SummaryCard extends StatelessWidget {
     required this.color,
     required this.periodLabel,
     required this.progress,
+    required this.rtaOn,
+    required this.fundingState,
   });
 
   final Color color;
   final String periodLabel;
   final BudgetProgress? progress;
+  final bool rtaOn;
+  final CategoryFundingState? fundingState;
 
   @override
   Widget build(BuildContext context) {
@@ -189,7 +199,14 @@ class _SummaryCard extends StatelessWidget {
                   value: p.fraction.clamp(0.0, 1.0),
                   minHeight: 10,
                   backgroundColor: cs.surfaceContainerHighest,
-                  color: p.overspent ? AppColors.expense : color,
+                  color: !rtaOn
+                      ? (p.overspent ? AppColors.expense : color)
+                      : switch (fundingState) {
+                          CategoryFundingState.overspent => AppColors.expense,
+                          CategoryFundingState.funded => AppColors.income,
+                          CategoryFundingState.underfunded => Colors.amber,
+                          null => color,
+                        },
                 ),
               ),
               const SizedBox(height: 12),

--- a/lib/features/budgets/budgets_screen.dart
+++ b/lib/features/budgets/budgets_screen.dart
@@ -333,7 +333,7 @@ class _SummaryCard extends StatelessWidget {
 /// button. Tapping anywhere opens the set/edit sheet. [compact] renders a
 /// visibly smaller tile for a subcategory threaded under its parent — see
 /// [_ChildBudgetThread].
-class _BudgetTile extends StatelessWidget {
+class _BudgetTile extends ConsumerWidget {
   const _BudgetTile({
     required this.category,
     required this.progress,
@@ -347,10 +347,14 @@ class _BudgetTile extends StatelessWidget {
   final bool compact;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final catColor = Color(category.colorValue);
     final p = progress;
     final iconSize = compact ? 32.0 : 44.0;
+    final rtaOn = ref.watch(rtaEnabledProvider);
+    final fundingState = rtaOn
+        ? ref.watch(categoryFundingStateProvider(category.id))
+        : null;
 
     return Card(
       margin: compact ? EdgeInsets.zero : const EdgeInsets.only(bottom: 12),
@@ -378,7 +382,7 @@ class _BudgetTile extends StatelessWidget {
               Expanded(
                 child: p == null
                     ? _noBudget(context)
-                    : _withBudget(context, p, catColor),
+                    : _withBudget(context, p, catColor, rtaOn, fundingState),
               ),
             ],
           ),
@@ -419,15 +423,31 @@ class _BudgetTile extends StatelessWidget {
     );
   }
 
-  Widget _withBudget(BuildContext context, BudgetProgress p, Color catColor) {
+  Widget _withBudget(
+    BuildContext context,
+    BudgetProgress p,
+    Color catColor,
+    bool rtaOn,
+    CategoryFundingState? fundingState,
+  ) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final pct = (p.fraction * 100).round();
-    final barColor = p.overspent
-        ? AppColors.expense
-        : p.nearingLimit
-        ? Colors.amber
-        : catColor;
+    // RTA off: unchanged from before — overspent/nearing-limit/plain.
+    // RTA on: the three-state funding indicator replaces nearing-limit
+    // (GitHub #100 v2) — overspent still wins regardless of funding.
+    final barColor = !rtaOn
+        ? (p.overspent
+              ? AppColors.expense
+              : p.nearingLimit
+              ? Colors.amber
+              : catColor)
+        : switch (fundingState) {
+            CategoryFundingState.overspent => AppColors.expense,
+            CategoryFundingState.funded => AppColors.income,
+            CategoryFundingState.underfunded => Colors.amber,
+            null => catColor,
+          };
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/budgets/ready_to_assign_screen.dart
+++ b/lib/features/budgets/ready_to_assign_screen.dart
@@ -69,7 +69,7 @@ class ReadyToAssignScreen extends ConsumerWidget {
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Envelope')),
+      appBar: AppBar(title: const Text('Ready to Assign')),
       body: poolAccounts.isEmpty
           ? const _EmptyState()
           : ListView(
@@ -153,7 +153,17 @@ class _CategoryEnvelopeRow extends ConsumerWidget {
     final theme = Theme.of(context);
     final catColor = Color(category.colorValue);
     final balance = ref.watch(categoryBalanceProvider(category.id));
-    final overspent = balance.isNegative;
+    // A category with a Budgets ceiling gets the full three-state funding
+    // color; one with only an envelope balance and no ceiling (still
+    // possible — the two systems are independent) falls back to today's
+    // red-if-negative/plain look.
+    final fundingState = ref.watch(categoryFundingStateProvider(category.id));
+    final balanceColor = switch (fundingState) {
+      CategoryFundingState.overspent => AppColors.expense,
+      CategoryFundingState.funded => AppColors.income,
+      CategoryFundingState.underfunded => Colors.amber,
+      null => balance.isNegative ? AppColors.expense : null,
+    };
 
     return ListTile(
       leading: Container(
@@ -171,7 +181,7 @@ class _CategoryEnvelopeRow extends ConsumerWidget {
         balance,
         style: theme.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w600,
-          color: overspent ? AppColors.expense : null,
+          color: balanceColor,
         ),
       ),
       onTap: () => showModalBottomSheet<void>(

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -970,17 +970,17 @@ class _AccountCard extends StatelessWidget {
   }
 }
 
-// ── 3¼. Ready to Assign (Envelope Mode) ──────────────────────────────────
+// ── 3¼. Ready to Assign ──────────────────────────────────────────────────
 
-/// The one shared Ready to Assign figure, pooled across every account with
-/// Envelope Mode on (GitHub #48 — one pool, not one per account). Hidden
-/// entirely when no account has Envelope Mode on.
+/// The one shared Ready to Assign figure, pooled across every on-budget
+/// account (GitHub #48 — one pool, not one per account). Hidden entirely
+/// while Ready to Assign is off globally, or no account is on-budget yet.
 class _ReadyToAssignSection extends ConsumerWidget {
   const _ReadyToAssignSection();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (ref.watch(budgetingModeProvider) != BudgetingMode.envelope) {
+    if (!ref.watch(rtaEnabledProvider)) {
       return const SizedBox.shrink();
     }
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
@@ -991,7 +991,7 @@ class _ReadyToAssignSection extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SectionHeader('Envelope'),
+          const _SectionHeader('Ready to Assign'),
           InkWell(
             borderRadius: BorderRadius.circular(_cardRadius),
             onTap: () => context.push('/more/ready-to-assign'),
@@ -1374,12 +1374,11 @@ class _BudgetsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (ref.watch(budgetingModeProvider) != BudgetingMode.budgets) {
-      return const SizedBox.shrink();
-    }
     final progress = ref.watch(budgetProgressProvider);
 
     if (progress.isEmpty) return const _SetBudgetCard();
+
+    final rtaOn = ref.watch(rtaEnabledProvider);
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 24),
@@ -1407,6 +1406,13 @@ class _BudgetsSection extends ConsumerWidget {
                         budget: p.budget.amount,
                         spent: p.spent,
                         color: Color(p.category.colorValue),
+                        fundingColor: rtaOn
+                            ? _fundingColor(
+                                ref.watch(
+                                  categoryFundingStateProvider(p.category.id),
+                                ),
+                              )
+                            : null,
                       ),
                   ],
                 ),
@@ -1417,6 +1423,13 @@ class _BudgetsSection extends ConsumerWidget {
       ),
     );
   }
+
+  static Color? _fundingColor(CategoryFundingState? state) => switch (state) {
+    CategoryFundingState.overspent => AppColors.expense,
+    CategoryFundingState.funded => AppColors.income,
+    CategoryFundingState.underfunded => Colors.amber,
+    null => null,
+  };
 }
 
 class _SetBudgetCard extends StatelessWidget {

--- a/lib/features/more/more_screen.dart
+++ b/lib/features/more/more_screen.dart
@@ -6,7 +6,7 @@ import '../../core/branding/app_info.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../data/providers.dart';
-import '../../data/tables.dart';
+import '../../data/tables.dart' show MoreScreenViewMode;
 
 /// Hub page. Grouped, not a flat dump. Every tile navigates to a real route.
 class MoreScreen extends ConsumerWidget {
@@ -18,33 +18,15 @@ class MoreScreen extends ConsumerWidget {
     final cs = theme.colorScheme;
 
     // ── Live badges ──────────────────────────────────────────────────────────
-    final budgetingMode = ref.watch(budgetingModeProvider);
+    final rtaEnabled = ref.watch(rtaEnabledProvider);
     final progress = ref.watch(budgetProgressProvider);
     final overCount = progress.where((p) => p.overspent).length;
-
-    final String budgetTileLabel;
-    final String budgetTileRoute;
-    final IconData budgetTileIcon;
-    final String budgetSubtitle;
-    final Color budgetSubtitleColor;
-    if (budgetingMode == BudgetingMode.envelope) {
-      final readyToAssign = ref.watch(readyToAssignProvider);
-      budgetTileLabel = 'Envelope';
-      budgetTileRoute = '/more/ready-to-assign';
-      budgetTileIcon = Icons.savings_outlined;
-      budgetSubtitle = '${MoneyFormat.compact(readyToAssign)} unassigned';
-      budgetSubtitleColor = cs.onSurfaceVariant;
-    } else {
-      budgetTileLabel = 'Budgets';
-      budgetTileRoute = '/more/budgets';
-      budgetTileIcon = Icons.donut_large_rounded;
-      budgetSubtitle = overCount > 0
-          ? '$overCount over budget'
-          : '${progress.length} active';
-      budgetSubtitleColor = overCount > 0
-          ? AppColors.expense
-          : cs.onSurfaceVariant;
-    }
+    final budgetSubtitle = overCount > 0
+        ? '$overCount over budget'
+        : '${progress.length} active';
+    final budgetSubtitleColor = overCount > 0
+        ? AppColors.expense
+        : cs.onSurfaceVariant;
 
     final netWorth =
         ref.watch(netWorthProvider).valueOrNull ?? const Money.zero();
@@ -76,12 +58,21 @@ class MoreScreen extends ConsumerWidget {
           subtitle: 'Who owes you, who you owe',
         ),
         _Item(
-          budgetTileIcon,
-          budgetTileLabel,
-          route: budgetTileRoute,
+          Icons.donut_large_rounded,
+          'Budgets',
+          route: '/more/budgets',
           subtitle: budgetSubtitle,
           subtitleColor: budgetSubtitleColor,
         ),
+        if (rtaEnabled)
+          _Item(
+            Icons.savings_outlined,
+            'Ready to Assign',
+            route: '/more/ready-to-assign',
+            subtitle:
+                '${MoneyFormat.compact(ref.watch(readyToAssignProvider))} '
+                'unassigned',
+          ),
         _Item(
           Icons.autorenew_rounded,
           'Auto',

--- a/lib/features/reports/chart_widgets.dart
+++ b/lib/features/reports/chart_widgets.dart
@@ -236,7 +236,14 @@ class _LegendChip extends StatelessWidget {
 class BudgetRadialChart extends StatefulWidget {
   const BudgetRadialChart({required this.slices, super.key});
 
-  final List<({String label, Money budget, Money spent, Color color})> slices;
+  /// [fundingColor], when set (GitHub #100 v2, only while Ready to Assign is
+  /// on), overrides [color] for this slice's fill — green/amber for
+  /// funded/underfunded. The overspent hazard-stripe + red ring stays
+  /// keyed off [spent]/[budget] regardless, so it still overlays either way.
+  final List<
+    ({String label, Money budget, Money spent, Color color, Color? fundingColor})
+  >
+  slices;
 
   @override
   State<BudgetRadialChart> createState() => _BudgetRadialChartState();
@@ -283,7 +290,9 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
     final data = <_BudgetSlice>[];
     if (positive.length > 6) {
       for (final s in positive.take(5)) {
-        data.add(_BudgetSlice(s.label, s.budget, s.spent, s.color));
+        data.add(
+          _BudgetSlice(s.label, s.budget, s.spent, s.color, s.fundingColor),
+        );
       }
       var restBudget = const Money.zero();
       var restSpent = const Money.zero();
@@ -291,10 +300,14 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
         restBudget += s.budget;
         restSpent += s.spent;
       }
+      // Folded into "Other": a single funding color can't represent several
+      // categories at once, so this tail always falls back to its own grey.
       data.add(_BudgetSlice('Other', restBudget, restSpent, Colors.grey));
     } else {
       for (final s in positive) {
-        data.add(_BudgetSlice(s.label, s.budget, s.spent, s.color));
+        data.add(
+          _BudgetSlice(s.label, s.budget, s.spent, s.color, s.fundingColor),
+        );
       }
     }
 
@@ -344,12 +357,23 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
 }
 
 class _BudgetSlice {
-  const _BudgetSlice(this.label, this.budget, this.spent, this.color);
+  const _BudgetSlice(
+    this.label,
+    this.budget,
+    this.spent,
+    this.color, [
+    this.fundingColor,
+  ]);
 
   final String label;
   final Money budget;
   final Money spent;
   final Color color;
+  final Color? fundingColor;
+
+  /// The color actually painted for the wedge fill — [fundingColor] when
+  /// set, else the category's own [color].
+  Color get fillColor => fundingColor ?? color;
 
   bool get overspent => spent > budget;
 
@@ -386,7 +410,10 @@ class _BudgetSectorPainter extends CustomPainter {
       final sweep = share - gap;
       final wedge = _wedge(center, outerRect, start, sweep);
 
-      canvas.drawPath(wedge, Paint()..color = slice.color.withValues(alpha: 0.16));
+      canvas.drawPath(
+        wedge,
+        Paint()..color = slice.fillColor.withValues(alpha: 0.16),
+      );
 
       if (slice.fraction > 0) {
         final filledRadius = outerRadius * math.sqrt(slice.fraction);
@@ -397,7 +424,7 @@ class _BudgetSectorPainter extends CustomPainter {
             start,
             sweep,
           ),
-          Paint()..color = slice.color,
+          Paint()..color = slice.fillColor,
         );
       }
 

--- a/lib/features/savings/loan_detail_screen.dart
+++ b/lib/features/savings/loan_detail_screen.dart
@@ -334,8 +334,9 @@ class LoanDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(loan.account.id);
+      rtaAutoDisabled = await ref.read(dbProvider).deleteAccount(loan.account.id);
     } on ArgumentError catch (e) {
       messenger
         ..hideCurrentSnackBar()
@@ -348,7 +349,16 @@ class LoanDetailScreen extends ConsumerWidget {
     navigator.pop();
     messenger
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Loan deleted')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Loan deleted. Ready to Assign turned off — no accounts '
+                      'left in the pool.'
+                : 'Loan deleted',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/savings/savings_goal_detail_screen.dart
+++ b/lib/features/savings/savings_goal_detail_screen.dart
@@ -448,8 +448,11 @@ class SavingsGoalDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(progress.account.id);
+      rtaAutoDisabled = await ref
+          .read(dbProvider)
+          .deleteAccount(progress.account.id);
     } on ArgumentError catch (e) {
       messenger
         ..hideCurrentSnackBar()
@@ -462,7 +465,16 @@ class SavingsGoalDetailScreen extends ConsumerWidget {
     navigator.pop();
     messenger
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Goal deleted')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Goal deleted. Ready to Assign turned off — no accounts '
+                      'left in the pool.'
+                : 'Goal deleted',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,7 +6,6 @@ import '../../core/branding/app_info.dart';
 import '../../core/branding/brand_mark.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
-import '../../data/tables.dart' show BudgetingMode;
 import 'lock_screen_style_sheet.dart';
 import 'master_phrase_attempts_sheet.dart';
 import 'more_screen_layout_sheet.dart';
@@ -47,7 +46,7 @@ class SettingsScreen extends ConsumerWidget {
     final pinTimeoutMinutes = ref.watch(pinTimeoutMinutesProvider);
     final lockScreenStyle = ref.watch(lockScreenStyleProvider);
     final moreScreenViewMode = ref.watch(moreScreenViewModeProvider);
-    final budgetingMode = ref.watch(budgetingModeProvider);
+    final rtaEnabled = ref.watch(rtaEnabledProvider);
     final hasMasterPhrase = ref.watch(hasMasterPhraseProvider);
     final masterPhraseAttemptThreshold = ref.watch(
       masterPhraseAttemptThresholdProvider,
@@ -195,53 +194,23 @@ class SettingsScreen extends ConsumerWidget {
           // ── Budgeting ──────────────────────────────────────────────────────
           _sectionLabel(context, 'Budgeting'),
           Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      const Icon(Icons.donut_large_outlined),
-                      const SizedBox(width: 12),
-                      Text(
-                        'Budgeting mode',
-                        style: theme.textTheme.titleSmall,
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Budgets sets a spending ceiling per category. Envelope '
-                    '(Ready to Assign) instead assigns money you actually '
-                    'have into categories first. Both keep working either '
-                    'way — this only picks which one the Dashboard and More '
-                    'hub show.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: cs.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  SegmentedButton<BudgetingMode>(
-                    segments: const [
-                      ButtonSegment(
-                        value: BudgetingMode.budgets,
-                        label: Text('Budgets'),
-                        icon: Icon(Icons.donut_large_outlined),
-                      ),
-                      ButtonSegment(
-                        value: BudgetingMode.envelope,
-                        label: Text('Envelope'),
-                        icon: Icon(Icons.savings_outlined),
-                      ),
-                    ],
-                    selected: {budgetingMode},
-                    onSelectionChanged: (selection) => ref
-                        .read(dbProvider)
-                        .setBudgetingMode(selection.first),
-                  ),
-                ],
+            child: SwitchListTile(
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              secondary: const Icon(Icons.savings_outlined),
+              title: const Text('Ready to Assign'),
+              subtitle: Text(
+                'Budget (a spending ceiling per category) is always on. '
+                'Ready to Assign adds an optional layer on top: assign the '
+                'money you actually have into categories first, pooled '
+                'across every on-budget account. Turning this on enrolls '
+                'every account at once — opt individual ones out from '
+                'their own Account Detail screen.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
               ),
+              value: rtaEnabled,
+              onChanged: (v) => _onRtaToggle(context, ref, v),
             ),
           ),
 
@@ -1044,6 +1013,42 @@ class SettingsScreen extends ConsumerWidget {
         ..hideCurrentSnackBar()
         ..showSnackBar(SnackBar(content: Text("Couldn't clear data: $e")));
     }
+  }
+
+  /// Turning Ready to Assign on is a bulk action — every account joins the
+  /// shared pool at once — so it gets the same confirm-on-enable treatment
+  /// as the per-account on-budget toggle; turning it off needs no
+  /// confirmation, same as there.
+  Future<void> _onRtaToggle(
+    BuildContext context,
+    WidgetRef ref,
+    bool enabled,
+  ) async {
+    if (enabled) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Turn on Ready to Assign?'),
+          content: const Text(
+            'Every account joins the shared pool right away. You can opt '
+            'individual accounts back out afterward from their own Account '
+            'Detail screen.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Turn on'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+    }
+    await ref.read(dbProvider).setRtaEnabled(enabled);
   }
 
   Future<void> _toggleNotifications(WidgetRef ref, bool value) async {

--- a/test/auto_backup_test.dart
+++ b/test/auto_backup_test.dart
@@ -89,6 +89,7 @@ void main() {
       moreScreenViewMode: MoreScreenViewMode.list,
       frequentIconKeys: '',
       budgetingMode: BudgetingMode.budgets,
+      rtaEnabled: false,
     );
 
     final now = DateTime(2026, 8, 5, 12);

--- a/test/budget_radial_chart_test.dart
+++ b/test/budget_radial_chart_test.dart
@@ -63,6 +63,7 @@ void main() {
                       budget: budget,
                       spent: spent,
                       color: categoryColor,
+                      fundingColor: null,
                     ),
                   ],
                 ),

--- a/test/envelope_mode_test.dart
+++ b/test/envelope_mode_test.dart
@@ -56,10 +56,10 @@ void main() {
           .firstWhere((c) => c.name == name)
           .id;
 
-  group('setBudgetingMode — GitHub #100', () {
+  group('setRtaEnabled — GitHub #100 v2', () {
     test(
-      'switching to envelope enrolls every existing account, including one '
-      'never touched before',
+      'turning RTA on enrolls every existing account, including one never '
+      'touched before',
       () async {
         final cash = await cashId();
         final bank = await db.addAccount(
@@ -70,7 +70,7 @@ void main() {
           openingBalance: Money.fromRupees(5000),
         );
 
-        await db.setBudgetingMode(BudgetingMode.envelope);
+        await db.setRtaEnabled(true);
 
         final accounts = await db.watchAccounts().first;
         expect(
@@ -85,22 +85,22 @@ void main() {
     );
 
     test(
-      'switching back to budgets leaves every account\'s flag untouched',
+      'turning RTA off leaves every account\'s flag untouched',
       () async {
         final cash = await cashId();
-        await db.setBudgetingMode(BudgetingMode.envelope);
-        await db.setBudgetingMode(BudgetingMode.budgets);
+        await db.setRtaEnabled(true);
+        await db.setRtaEnabled(false);
 
         final after = await db.watchAccounts().first;
         expect(after.firstWhere((a) => a.id == cash).envelopeMode, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
       },
     );
 
     test(
-      'a new account created while Envelope is the active mode joins the '
-      'pool automatically',
+      'a new account created while RTA is on joins the pool automatically',
       () async {
-        await db.setBudgetingMode(BudgetingMode.envelope);
+        await db.setRtaEnabled(true);
 
         final newAccount = await db.addAccount(
           name: 'New Wallet',
@@ -118,8 +118,7 @@ void main() {
     );
 
     test(
-      'a new account created while Budgets is the active mode does not '
-      'join the pool',
+      'a new account created while RTA is off does not join the pool',
       () async {
         final newAccount = await db.addAccount(
           name: 'New Wallet',
@@ -135,6 +134,76 @@ void main() {
         expect(row.envelopeMode, isFalse);
       },
     );
+  });
+
+  group('auto-disable RTA — GitHub #100 v2', () {
+    test(
+      'turning off the last pool account via setEnvelopeMode while RTA is '
+      'on also turns RTA off, and reports it',
+      () async {
+        final cash = await cashId();
+        await db.setRtaEnabled(true);
+
+        final autoDisabled = await db.setEnvelopeMode(cash, false);
+
+        expect(autoDisabled, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
+      },
+    );
+
+    test(
+      'turning off a non-last pool account leaves RTA on, and reports '
+      'nothing happened',
+      () async {
+        final cash = await cashId();
+        final bank = await db.addAccount(
+          name: 'IPPB',
+          type: AccountType.bank,
+          colorValue: 0,
+          iconKey: 'bank',
+          openingBalance: Money.fromRupees(5000),
+        );
+        await db.setRtaEnabled(true);
+
+        final autoDisabled = await db.setEnvelopeMode(cash, false);
+
+        expect(autoDisabled, isFalse);
+        expect((await db.getSettings()).rtaEnabled, isTrue);
+        final bankRow = await (db.select(
+          db.accounts,
+        )..where((a) => a.id.equals(bank))).getSingle();
+        expect(bankRow.envelopeMode, isTrue);
+      },
+    );
+
+    test(
+      'deleting the last pool account also turns RTA off, and reports it',
+      () async {
+        final newAccount = await db.addAccount(
+          name: 'New Wallet',
+          type: AccountType.cash,
+          colorValue: 0,
+          iconKey: 'wallet',
+          openingBalance: const Money.zero(),
+        );
+        await db.setRtaEnabled(true);
+        // Every other pool account has to stop being on-budget first, or
+        // deleting this one wouldn't actually empty the pool.
+        final cash = await cashId();
+        await db.setEnvelopeMode(cash, false);
+
+        final autoDisabled = await db.deleteAccount(newAccount);
+
+        expect(autoDisabled, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
+      },
+    );
+
+    test('is a no-op while RTA is already off', () async {
+      final cash = await cashId();
+      final autoDisabled = await db.setEnvelopeMode(cash, false);
+      expect(autoDisabled, isFalse);
+    });
   });
 
   group('addAllocation', () {

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -423,13 +423,13 @@ void main() {
   });
 
   testWidgets(
-    'Account detail: Envelope Mode links to the shared Ready to Assign '
-    'screen once turned on',
+    'Account detail: On-budget links to the shared Ready to Assign screen '
+    'once turned on',
     (tester) async {
       late int cash;
       await tester.runAsync(() async {
         cash = (await seed()).cash;
-        await db.setEnvelopeMode(cash, true);
+        await db.setRtaEnabled(true);
         await db.addAllocation(
           accountId: cash,
           categoryId: await (db.watchCategories(CategoryKind.expense).first)
@@ -439,7 +439,7 @@ void main() {
       });
       await pump(tester, AccountDetailScreen(accountId: cash));
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope Mode'), findsOneWidget);
+      expect(find.text('On-budget'), findsOneWidget);
       expect(find.text('View shared budget'), findsOneWidget);
       await unmount(tester);
     },
@@ -509,16 +509,22 @@ void main() {
   );
 
   testWidgets(
-    'Account detail: turning Envelope Mode on asks for confirmation first',
+    'Account detail: turning On-budget on asks for confirmation first',
     (tester) async {
       late int cash;
-      await tester.runAsync(() async => cash = (await seed()).cash);
+      await tester.runAsync(() async {
+        cash = (await seed()).cash;
+        // RTA has to be on for the On-budget toggle to render at all — then
+        // opt this one account back out so there's something to turn on.
+        await db.setRtaEnabled(true);
+        await db.setEnvelopeMode(cash, false);
+      });
       await pump(tester, AccountDetailScreen(accountId: cash));
       expect(tester.takeException(), isNull);
 
-      await tester.tap(find.text('Envelope Mode'));
+      await tester.tap(find.text('On-budget'));
       await tester.pump();
-      expect(find.text('Turn on Envelope Mode?'), findsOneWidget);
+      expect(find.text('Mark this account on-budget?'), findsOneWidget);
 
       late List<AccountRow> account;
       await tester.runAsync(
@@ -715,22 +721,24 @@ void main() {
   });
 
   testWidgets(
-    'Settings: Budgeting mode defaults to Budgets and switching to '
-    'Envelope persists (GitHub #100)',
+    'Settings: Ready to Assign defaults off and turning it on persists '
+    '(GitHub #100 v2)',
     (tester) async {
       await pump(tester, const SettingsScreen());
       expect(tester.takeException(), isNull);
 
-      await tester.scrollUntilVisible(find.text('Envelope'), 300);
-      await tester.ensureVisible(find.text('Envelope'));
+      await tester.scrollUntilVisible(find.text('Ready to Assign'), 300);
+      await tester.ensureVisible(find.text('Ready to Assign'));
       await tester.pumpAndSettle();
-      expect(find.text('Budgets'), findsWidgets);
-      expect(find.text('Envelope'), findsOneWidget);
+      expect(find.text('Ready to Assign'), findsOneWidget);
 
       final initial = await db.getSettings();
-      expect(initial.budgetingMode, BudgetingMode.budgets);
+      expect(initial.rtaEnabled, isFalse);
 
-      await tester.tap(find.text('Envelope'));
+      await tester.tap(find.text('Ready to Assign'));
+      await tester.pump();
+      expect(find.text('Turn on Ready to Assign?'), findsOneWidget);
+      await tester.tap(find.text('Turn on'));
       await tester.pump();
       await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 200)),
@@ -740,21 +748,32 @@ void main() {
 
       await tester.runAsync(() async {
         final updated = await db.getSettings();
-        expect(updated.budgetingMode, BudgetingMode.envelope);
+        expect(updated.rtaEnabled, isTrue);
       });
       await unmount(tester);
     },
   );
 
   testWidgets(
-    'More hub: the Budgets tile becomes Envelope in Envelope mode '
-    '(GitHub #100)',
+    'More hub: a Ready to Assign tile appears alongside Budgets once RTA '
+    'is on (GitHub #100 v2)',
     (tester) async {
-      await db.setBudgetingMode(BudgetingMode.envelope);
+      await db.setRtaEnabled(true);
       await pump(tester, const MoreScreen());
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope'), findsOneWidget);
-      expect(find.text('Budgets'), findsNothing);
+      expect(find.text('Ready to Assign'), findsOneWidget);
+      expect(find.text('Budgets'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'More hub: only the Budgets tile shows while RTA is off',
+    (tester) async {
+      await pump(tester, const MoreScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Budgets'), findsOneWidget);
+      expect(find.text('Ready to Assign'), findsNothing);
       await unmount(tester);
     },
   );

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -108,8 +108,8 @@ void main() {
   });
 
   testWidgets(
-    'Dashboard shows the shared Ready to Assign pool only in Envelope '
-    'budgeting mode, once an account is in Envelope Mode (GitHub #100)',
+    'Dashboard shows the shared Ready to Assign pool only once RTA is on '
+    'globally and an account is on-budget (GitHub #100 v2)',
     (tester) async {
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
@@ -121,25 +121,21 @@ void main() {
         await db.setEnvelopeMode(cash, true);
       });
 
-      // Still hidden under the default Budgets mode, even with a pool
-      // account — the Settings switch decides which system the Dashboard
-      // surfaces.
+      // Still hidden while RTA is off globally, even with an on-budget
+      // account — the Settings switch is what surfaces this section.
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
       expect(find.text('Ready to Assign'), findsNothing);
       await unmount(tester);
 
-      await tester.runAsync(
-        () => db.setBudgetingMode(BudgetingMode.envelope),
-      );
+      await tester.runAsync(() => db.setRtaEnabled(true));
 
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope'), findsOneWidget);
-      // The pooled RTA card's own label (GitHub #48 — one shared card, not
-      // one per account, so the account name itself is no longer shown
-      // here).
-      expect(find.text('Ready to Assign'), findsOneWidget);
+      // The section header and the pooled RTA card's own label (GitHub
+      // #48 — one shared card, not one per account, so the account name
+      // itself is no longer shown here).
+      expect(find.text('Ready to Assign'), findsNWidgets(2));
       await unmount(tester);
     },
   );


### PR DESCRIPTION
## Summary

Implements the redesign proposed in #100 by @serrq: instead of a Settings-level switch that decides whether the Dashboard/More hub shows **Budgets** or **Envelope**, Budget (the per-category spending ceiling) is now always on for everyone, and **Ready to Assign** becomes a single optional on/off layer on top of it.

- Settings gets a single **Ready to Assign** switch (confirm-on-enable) replacing the old segmented Budgets/Envelope control. Turning it on auto-enrolls every account into the shared pool; users opt individual accounts back out from Account Detail's new **On-budget** toggle (renamed from "Envelope Mode").
- **Automatic safety net**: if the last on-budget account is turned off or deleted while Ready to Assign is on, it turns itself off automatically and shows a non-blocking notice — no confirmation prompt blocks the action that caused it.
- **Budgets is now always visible** in the More hub and Dashboard (no longer hidden behind the old mode switch); a second **Ready to Assign** tile/section appears alongside it once RTA is on.
- New three-state funding indicator per category once RTA is on: 🟢 funded / 🟡 underfunded / 🔴 overspent (overspent always wins). RTA-off behavior is unchanged (amber "nearing limit" warning, red "over").
- Data model: `Settings.rtaEnabled` (schema v62) replaces `Settings.budgetingMode` for new writes; the old column is kept, unused, for a one-time migration backfill — no destructive schema change.

## Test plan

- [x] `flutter analyze` — clean across the whole project
- [x] `flutter test` — full suite (661 tests) passes, including new coverage for the auto-disable-RTA consistency check (`setEnvelopeMode` and `deleteAccount`, both trigger points; non-last-account and already-off no-op cases)
- [ ] Manual smoke test on a device/emulator (not available in this environment): toggle RTA on/off, verify the auto-disable SnackBar, verify the three funding colors on a real category

🤖 Generated with [Claude Code](https://claude.com/claude-code)