### PR TITLE
Remember last-used account + category spend percentages with drill-down

### DIFF
--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -255,7 +255,19 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     } else if (widget.duplicateFromId != null) {
       _loading = true;
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadForDuplicate());
+    } else {
+      // Pre-select the last-used account on a brand-new transaction, once the
+      // one-shot query resolves. Still freely changeable via "Paid via", and
+      // the guard on `_accountId` below means it never overwrites a
+      // selection the user already made while this was loading.
+      _seedLastUsedAccount();
     }
+  }
+
+  Future<void> _seedLastUsedAccount() async {
+    final txs = await ref.read(dbProvider).watchTransactions(limit: 1).first;
+    if (!mounted || _accountId != null || txs.isEmpty) return;
+    setState(() => _accountId = txs.first.accountId);
   }
 
   void _onFieldFocusChanged() => setState(() {});

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -1557,6 +1557,7 @@ class _SpendByCategorySection extends ConsumerWidget {
                             color: cats[e.key] != null
                                 ? Color(cats[e.key]!.colorValue)
                                 : theme.colorScheme.secondary,
+                            id: e.key,
                           ),
                       ],
                     ),

--- a/lib/features/reports/account_reports_screen.dart
+++ b/lib/features/reports/account_reports_screen.dart
@@ -173,6 +173,7 @@ class _BalanceSplitCard extends ConsumerWidget {
                   label: a.name,
                   value: a.currentBalance,
                   color: Color(a.colorValue),
+                  id: null,
                 ),
             ],
           )

--- a/lib/features/reports/chart_widgets.dart
+++ b/lib/features/reports/chart_widgets.dart
@@ -46,10 +46,23 @@ class _NoData extends StatelessWidget {
 /// Account Reports want that at-a-glance list; the Dashboard's compact card
 /// doesn't).
 class CategoryPieChart extends StatefulWidget {
-  const CategoryPieChart({required this.slices, this.showLegend = true, super.key});
+  const CategoryPieChart({
+    required this.slices,
+    this.showLegend = true,
+    this.onSliceTap,
+    super.key,
+  });
 
-  final List<({String label, Money value, Color color})> slices;
+  /// [id] is whatever the caller wants back via [onSliceTap] — e.g. a
+  /// category id to drill into. Null for a slice nothing should navigate to
+  /// (the synthetic "Other" tail always gets null; a non-category chart like
+  /// the accounts-balance one can leave every slice's id null).
+  final List<({String label, Money value, Color color, int? id})> slices;
   final bool showLegend;
+
+  /// Tapping a legend chip whose slice carries a non-null id calls this with
+  /// that id. Left null (the default) makes the legend non-interactive.
+  final ValueChanged<int>? onSliceTap;
 
   @override
   State<CategoryPieChart> createState() => _CategoryPieChartState();
@@ -65,17 +78,18 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
 
     if (positive.isEmpty) return const _NoData(height: 220);
 
-    final data = <({String label, Money value, Color color})>[];
+    final data = <({String label, Money value, Color color, int? id})>[];
     if (positive.length > 6) {
       data.addAll(positive.take(5));
       var rest = const Money.zero();
       for (final s in positive.skip(5)) {
         rest += s.value;
       }
-      data.add((label: 'Other', value: rest, color: Colors.grey));
+      data.add((label: 'Other', value: rest, color: Colors.grey, id: null));
     } else {
       data.addAll(positive);
     }
+    final total = data.fold<int>(0, (sum, d) => sum + d.value.paise);
 
     final touched = _touchedIndex >= 0 && _touchedIndex < data.length
         ? data[_touchedIndex]
@@ -131,7 +145,16 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
               spacing: 16,
               runSpacing: 10,
               alignment: WrapAlignment.center,
-              children: [for (final s in data) _LegendChip(slice: s)],
+              children: [
+                for (final s in data)
+                  _LegendChip(
+                    slice: s,
+                    percentOfTotal: total == 0 ? null : s.value.paise / total * 100,
+                    onTap: (widget.onSliceTap == null || s.id == null)
+                        ? null
+                        : () => widget.onSliceTap!(s.id!),
+                  ),
+              ],
             ),
           ],
         ],
@@ -144,7 +167,7 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
 class _CenterLabel extends StatelessWidget {
   const _CenterLabel({required this.slice});
 
-  final ({String label, Money value, Color color}) slice;
+  final ({String label, Money value, Color color, int? id}) slice;
 
   @override
   Widget build(BuildContext context) {
@@ -180,44 +203,67 @@ class _CenterLabel extends StatelessWidget {
 }
 
 class _LegendChip extends StatelessWidget {
-  const _LegendChip({required this.slice});
+  const _LegendChip({required this.slice, this.percentOfTotal, this.onTap});
 
-  final ({String label, Money value, Color color}) slice;
+  final ({String label, Money value, Color color, int? id}) slice;
+  final double? percentOfTotal;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return ConstrainedBox(
+    final valueLine = percentOfTotal == null
+        ? MoneyFormat.compact(slice.value)
+        : '${MoneyFormat.compact(slice.value)} (${percentOfTotal!.round()}%)';
+
+    final chip = ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 150),
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 10,
-            height: 10,
-            decoration: BoxDecoration(color: slice.color, shape: BoxShape.circle),
-          ),
-          const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              slice.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.bodySmall,
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(color: slice.color, shape: BoxShape.circle),
             ),
           ),
           const SizedBox(width: 6),
-          Text(
-            MoneyFormat.compact(slice.value),
-            maxLines: 1,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontFeatures: kTabularFigures,
+          // Label and value stack in one Flexible so a long percentage-
+          // annotated value wraps to a second line instead of overflowing
+          // the chip's width, the way it would fighting for space as a
+          // sibling of the label in a single Row.
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  slice.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall,
+                ),
+                Text(
+                  valueLine,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontFeatures: kTabularFigures,
+                  ),
+                ),
+              ],
             ),
           ),
         ],
       ),
     );
+
+    if (onTap == null) return chip;
+    return InkWell(borderRadius: BorderRadius.circular(8), onTap: onTap, child: chip);
   }
 }
 

--- a/lib/features/reports/stats_screen.dart
+++ b/lib/features/reports/stats_screen.dart
@@ -415,7 +415,7 @@ class _CategorySection extends ConsumerWidget {
     final categories = ref.watch(categoryMapProvider);
 
     Widget chartOf(Map<int, Money> rawSpend) {
-      final slices = <({String label, Money value, Color color})>[];
+      final slices = <({String label, Money value, Color color, int? id})>[];
       if (showSubcategories) {
         // Every leaf category gets its own slice — no roll-up. A
         // subcategory is labelled "Parent · Child" so two subcategories
@@ -429,6 +429,7 @@ class _CategorySection extends ConsumerWidget {
             label: parent == null ? cat.name : '${parent.name} · ${cat.name}',
             value: amount,
             color: Color(cat.colorValue),
+            id: id,
           ));
         });
       } else {
@@ -442,10 +443,14 @@ class _CategorySection extends ConsumerWidget {
             label: cat.name,
             value: amount,
             color: Color(cat.colorValue),
+            id: id,
           ));
         });
       }
-      return CategoryPieChart(slices: slices);
+      return CategoryPieChart(
+        slices: slices,
+        onSliceTap: (categoryId) => context.push('/more/budgets/$categoryId'),
+      );
     }
 
     if (showYear) {
@@ -841,13 +846,14 @@ class _CategoryStandings extends ConsumerWidget {
       // Same grouping rule as the pie above: subcategories stand alone
       // (labelled "Parent · Child" to stay distinguishable), or roll up
       // into their parent when the toggle is off.
-      final entries = <({String label, Money value, Color color})>[];
+      final entries = <({int id, String label, Money value, Color color})>[];
       if (showSubcategories) {
         rawSpend.forEach((id, amount) {
           final cat = categories[id];
           if (cat == null) return;
           final parent = cat.parentId == null ? null : categories[cat.parentId];
           entries.add((
+            id: id,
             label: parent == null ? cat.name : '${parent.name} · ${cat.name}',
             value: amount,
             color: Color(cat.colorValue),
@@ -857,7 +863,12 @@ class _CategoryStandings extends ConsumerWidget {
         rollUpToParents(rawSpend, categories).forEach((id, amount) {
           final cat = categories[id];
           if (cat == null) return;
-          entries.add((label: cat.name, value: amount, color: Color(cat.colorValue)));
+          entries.add((
+            id: id,
+            label: cat.name,
+            value: amount,
+            color: Color(cat.colorValue),
+          ));
         });
       }
 
@@ -873,6 +884,7 @@ class _CategoryStandings extends ConsumerWidget {
       final maxValue = positive
           .map((e) => e.value.paise)
           .reduce((a, b) => a > b ? a : b);
+      final total = positive.fold(const Money.zero(), (sum, e) => sum + e.value);
 
       return _StandingsCard(
         children: [
@@ -880,10 +892,14 @@ class _CategoryStandings extends ConsumerWidget {
             _StandingRow(
               rank: i + 1,
               title: e.label,
+              subtitle: total.paise == 0
+                  ? null
+                  : '${(e.value.paise / total.paise * 100).toStringAsFixed(1)}% of total',
               value: MoneyFormat.symbol(e.value),
               dotColor: e.color,
               barFraction: maxValue == 0 ? 0 : e.value.paise / maxValue,
               barColor: e.color,
+              onTap: () => context.push('/more/budgets/${e.id}'),
             ),
         ],
       );

--- a/test/add_transaction_default_account_test.dart
+++ b/test/add_transaction_default_account_test.dart
@@ -1,0 +1,104 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/data/tables.dart';
+import 'package:xpenc/features/add_transaction/add_transaction_screen.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester, {TxType? initialType}) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: AddTransactionScreen(initialType: initialType),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets(
+    'a brand-new transaction pre-selects the most recently used account',
+    (tester) async {
+      final walletId = await db.addAccount(
+        name: 'Wallet',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+      final bankId = await db.addAccount(
+        name: 'Bank',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+
+      // Oldest first, so "Bank" is the most recent by date.
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(500),
+        accountId: walletId,
+        date: DateTime(2026, 1, 1),
+      );
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(700),
+        accountId: bankId,
+        date: DateTime(2026, 1, 2),
+      );
+
+      await pump(tester, initialType: TxType.expense);
+
+      expect(find.text('Bank'), findsOneWidget);
+      expect(find.text('Select account'), findsNothing);
+
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'with no prior transactions, the account picker still asks the user to select one',
+    (tester) async {
+      await db.addAccount(
+        name: 'Wallet',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+
+      await pump(tester, initialType: TxType.expense);
+
+      expect(find.text('Select account'), findsWidgets);
+
+      await unmount(tester);
+    },
+  );
+}

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -350,6 +350,107 @@ void main() {
     await unmount(tester);
   });
 
+  testWidgets(
+    'Stats: category standings show each category\'s share of total spend',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        final seeded = await seed(); // Food: 320 + 1234.56 = 1554.56
+        cash = seeded.cash;
+        final transport = (await db.watchCategories(CategoryKind.expense).first)
+            .firstWhere((c) => c.name == 'Transport')
+            .id;
+        // Total spend: 1554.56 + 500 = 2054.56 -> Transport is ~24.3%.
+        await db.addTransaction(
+          type: TxType.expense,
+          amount: Money.fromRupees(500),
+          accountId: cash,
+          categoryId: transport,
+          date: DateTime.now(),
+        );
+      });
+      // A tall viewport so the whole ListView (charts included) lays out
+      // without needing a scroll — the Stats screen has more than one
+      // Scrollable (the charts included), which makes scrollUntilVisible
+      // unreliable here.
+      tester.view.physicalSize = const Size(1080, 9000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [dbProvider.overrideWithValue(db)],
+          child: const MaterialApp(home: StatsScreen()),
+        ),
+      );
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      // The Standings section defaults to ranking transactions — switch it
+      // to categories to reach the ranking this test targets (GitHub #95).
+      await tester.tap(find.text('Categories'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      expect(find.textContaining('% of total'), findsWidgets);
+      expect(find.textContaining('24.3% of total'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    "Stats: the Spending by category donut's legend shows each slice's "
+    'share of total',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        final seeded = await seed(); // Food: 320 + 1234.56 = 1554.56
+        cash = seeded.cash;
+        final transport = (await db.watchCategories(CategoryKind.expense).first)
+            .firstWhere((c) => c.name == 'Transport')
+            .id;
+        // Total spend: 1554.56 + 500 = 2054.56 -> Transport is ~24%.
+        await db.addTransaction(
+          type: TxType.expense,
+          amount: Money.fromRupees(500),
+          accountId: cash,
+          categoryId: transport,
+          date: DateTime.now(),
+        );
+      });
+      // A tall viewport so the donut's legend lays out without needing a
+      // scroll — see the note on the Standings test above.
+      tester.view.physicalSize = const Size(1080, 9000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [dbProvider.overrideWithValue(db)],
+          child: const MaterialApp(home: StatsScreen()),
+        ),
+      );
+      // spendByCategoryProvider is a drift stream query — give it one more
+      // round trip to emit before asserting on its data.
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      expect(find.textContaining('(24%)'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
   testWidgets('Account Reports renders with a negative credit-card balance', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
User feedback to Yash/the Xpenc team requested two convenience features for daily expense tracking:

1. **Remember last-used account** — a brand-new transaction now pre-selects "Paid via" with whatever account the most recent transaction used (a one-shot query, never overwrites a selection made while it's loading). Still freely changeable before saving.
2. **Category spend percentages + drill-down** — both places Stats shows category totals now show each category's percentage of total spend, and tapping one navigates to its existing Budget Detail screen (which already lists that period's transactions):
   - The "Spending by category" donut chart's legend
   - The Standings section's category ranking (GitHub #95's feature — switch its toggle to "Categories")

`CategoryPieChart` gained an optional per-slice `id` + `onSliceTap` callback to support the drill-down; the accounts-balance chart on Account Reports passes `id: null` and stays non-interactive, unaffected.

Not in scope: weekly/custom date-range filtering (the feedback also asked for this) — Month/Year is a shared filter across the whole Stats screen, not just these sections, so it's a larger change left for a follow-up.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 665 tests pass (3 new: default-account pre-selection x2, category-percentage-in-donut-legend x1; plus percentage assertions added to the existing Standings category test)
- [ ] Manual sanity check on a device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)