### PR TITLE
feat: category templates — save and switch category structures (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Release process: see [docs/RELEASING.md](docs/RELEASING.md).
 
 ## [Unreleased]
 
+### Added
+- **Auto rules: Goals & Loans (G&L)** — a recurring rule's Expense/Income
+  toggle now has a third option, G&L: on schedule, it posts a transfer into
+  a goal or a payment toward a loan instead of a category-tagged
+  income/expense — funding a savings goal or paying down a loan
+  automatically, the same way a bill or subscription already posts itself.
+- **More screen layout** (Settings → More screen layout) — the More hub can
+  render as the original one-column list or as two-per-row cards. Defaults
+  to list, so existing users see no change.
+- **Tag groups** (#92) — a named bundle of tags (e.g. "Work trip" = Travel +
+  Meals + Client), managed from Tags → the new group icon. Picking a group
+  from the tag picker selects every tag in it at once, instead of hunting
+  each one down individually every time the same combination gets used.
+- **Duplicate a transaction** (#92) — long-press a transaction in the list
+  (or tap the new icon on its detail screen) for Duplicate / Edit / Delete
+  quick actions. Duplicate prefills a new transaction from the source —
+  account, category, amount, note, payee, tags — but resets the date to
+  today and never copies its receipt, so it's clearly a new, separate entry
+  rather than a change to the original.
+
 ## [1.5.1] — 2026-09-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Release process: see [docs/RELEASING.md](docs/RELEASING.md).
 ## [Unreleased]
 
 ### Added
+- **Category templates** (#101) — save your current category/sub-category
+  structure as a named template from Categories → the new templates icon,
+  and switch between saved templates any time. Switching never touches a
+  transaction: categories the target template doesn't have are archived
+  (same as a manual archive — their transactions keep them), categories it
+  does have are created or relabelled in place, and switching back later
+  reactivates the same categories rather than duplicating them.
 - **Auto rules: Goals & Loans (G&L)** — a recurring rule's Expense/Income
   toggle now has a third option, G&L: on schedule, it posts a transfer into
   a goal or a payment toward a loan instead of a category-tagged

--- a/docs/superpowers/plans/2026-09-04-multi-currency-01-core-data-engine.md
+++ b/docs/superpowers/plans/2026-09-04-multi-currency-01-core-data-engine.md
@@ -1,0 +1,1601 @@
+# Multi-currency accounts — Plan 1: Core data & conversion engine
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the database a real per-account currency, a manually-maintained
+exchange-rate history, and snapshot-based conversion — with every balance/net
+worth computation correct for a mix of currencies — with zero UI yet.
+
+**Architecture:** Additive Drift schema (one new table, five new nullable
+columns) at migration v60. A new `lib/data/currency_conversion.dart` holds the
+pure integer-scaled conversion math, reused by `AppDatabase` (rate lookup,
+transaction-time snapshotting, `watchNetWorth`) and, later, by UI code. No
+existing table, column, or public method signature is removed — this plan
+only adds.
+
+**Tech Stack:** Dart 3.10, Flutter, Drift (SQLite ORM) with `build_runner`
+codegen, `flutter_test`.
+
+**Relationship to other plans:** This is Plan 1 of the multi-currency-accounts
+feature (see `docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md`).
+It produces a fully tested backend with no screens — Plan 2 (Currency settings
+screen), Plan 3 (account/transaction/transfer UI) and Plan 4 (backups/PDF
+statements) build on top of it. Every task here ends with the app compiling
+and `flutter test` green; this plan is safe to ship on its own even before
+any UI exists to set a non-default currency.
+
+---
+
+### Task 1: Schema — `CurrencyRates` table and new columns
+
+**Files:**
+- Modify: `lib/data/tables.dart`
+- Modify: `lib/data/database.dart:117-152` (table registration), `:463-487` (migration)
+- Generated (do not hand-edit): `lib/data/database.g.dart`
+- Test: `test/migration_version_drift_test.dart`
+
+- [ ] **Step 1: Add the `CurrencyRates` table to `tables.dart`**
+
+Add this after the `MoneyConverter` class (`tables.dart:127`), before the
+`// ─── Tables ───` section's first table, so it sits with the other
+top-level tables:
+
+```dart
+/// A manually-entered exchange rate: how many units of the parent currency
+/// (`Settings.currencyCode`) equal one unit of some other currency, as of a
+/// given date. Never fetched live — see the design spec's "Non-goals".
+///
+/// Rows accumulate as history; adding a new rate is always an insert, never
+/// an update, so a transaction posted under an old rate stays resolvable
+/// (`AppDatabase.latestRate`) even after the rate moves on. This is what
+/// makes converted historical totals stable when the rate changes later.
+@DataClassName('CurrencyRateRow')
+class CurrencyRates extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// The non-parent currency this rate prices, e.g. `USD`. Never the parent
+  /// currency itself, which is always 1:1 with itself.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3)();
+
+  /// Units of the parent currency per 1 unit of [currencyCode], scaled by
+  /// [currencyRateScale] so it's an exact integer — never a `double`, the
+  /// same rule [Money] follows. `83_120_000` means 1 unit = 83.12 parent.
+  IntColumn get rateToBaseMicros => integer()();
+
+  DateTimeColumn get effectiveAt => dateTime()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+```
+
+Then add the five new columns. In `Accounts` (`tables.dart:132-176`), just
+before the closing `}`:
+
+```dart
+  /// Null = this account is in the parent currency (`Settings.currencyCode`)
+  /// — true for every account that existed before this feature, and for
+  /// every account a user never explicitly changes. Locked once the account
+  /// has a transaction (enforced in `AppDatabase.setAccountCurrency`, not
+  /// here — Drift columns can't express that rule). A debit-card/UPI
+  /// instrument (non-null `linkedAccountId`) never gets its own value here —
+  /// it always mirrors its linked account's currency.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
+```
+
+In `Transactions` (`tables.dart:201-266`, right after the existing
+`paymentGroupId` column and before the closing `}` — note this table
+already has an unrelated `foreignCurrencyCode`/`foreignAmount` pair from
+GitHub #85; add these as a second, clearly-distinguished group):
+
+```dart
+  /// This transaction's own ledger currency, snapshotted from its account's
+  /// [Accounts.currencyCode] at post time. Null = parent currency, which
+  /// matches [amount]'s existing meaning exactly (no conversion needed).
+  /// Distinct from the #85 [foreignCurrencyCode]/[foreignAmount] pair above,
+  /// which is a manual informational annotation on a parent-currency
+  /// transaction — this pair instead describes the transaction's *real*
+  /// native currency, inherited from its account.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
+
+  /// Snapshot of `CurrencyRates.rateToBaseMicros` as of [date], for
+  /// [currencyCode]. Null iff [currencyCode] is null.
+  IntColumn get fxRateToBaseMicros => integer().nullable()();
+
+  /// Transfer only, and only when the source and destination accounts don't
+  /// share a currency: the amount credited to [toAccountId], in *its own*
+  /// currency. Null for a same-currency transfer, where crediting [amount]
+  /// unchanged is already correct — see `AppDatabase._applyTxEffect`.
+  IntColumn get toAmount => integer().map(const MoneyConverter()).nullable()();
+
+  /// Transfer only, mirrors [currencyCode]/[fxRateToBaseMicros] for the
+  /// destination leg — the two accounts can each be a different currency
+  /// from the parent (and from each other), so the destination needs its
+  /// own independent snapshot.
+  TextColumn get toCurrencyCode => text().withLength(min: 3, max: 3).nullable()();
+  IntColumn get toFxRateToBaseMicros => integer().nullable()();
+```
+
+- [ ] **Step 2: Register the table and bump the schema version**
+
+In `lib/data/database.dart`, add `CurrencyRates` to the `@DriftDatabase`
+`tables` list (`database.dart:118-151`), anywhere — alphabetically near
+`CreditCardDetails` is fine:
+
+```dart
+    CreditCardDetails,
+    CurrencyRates,
+```
+
+Change the schema version (`database.dart:176`):
+
+```dart
+  int get schemaVersion => 60;
+```
+
+Append a new migration step after the existing `if (from < 59)` block
+(`database.dart:467-487`), inside `onUpgrade`, right before its closing
+`}`:
+
+```dart
+      if (from < 60) {
+        // Multi-currency accounts — see
+        // docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md.
+        await m.createTable(currencyRates);
+        await _addColumnIfMissing(m, accounts, accounts.currencyCode);
+        await _addColumnIfMissing(m, transactions, transactions.currencyCode);
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.fxRateToBaseMicros,
+        );
+        await _addColumnIfMissing(m, transactions, transactions.toAmount);
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.toCurrencyCode,
+        );
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.toFxRateToBaseMicros,
+        );
+      }
+```
+
+- [ ] **Step 3: Regenerate Drift code**
+
+Run: `dart run build_runner build --delete-conflicting-outputs`
+Expected: completes with `Succeeded after ...` and no errors; `git diff
+lib/data/database.g.dart` shows a new `CurrencyRates`/`CurrencyRateRow`
+table class and the new columns on `Accounts`/`AccountRow`/
+`Transactions`/`TransactionRow`.
+
+- [ ] **Step 4: Write the failing migration test**
+
+Add to `test/migration_version_drift_test.dart`, inside `main()` after the
+existing "v46 group tables" test (`migration_version_drift_test.dart:107-129`):
+
+```dart
+  test(
+    'the v60 CurrencyRates table and account/transaction currency columns '
+    'survive a rolled-back re-open',
+    () async {
+      final file = await buildRolledBackDatabase(59);
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      await expectLater(reopened.select(reopened.currencyRates).get(), completes);
+      await expectLater(reopened.select(reopened.accounts).get(), completes);
+      await expectLater(reopened.select(reopened.transactions).get(), completes);
+      await reopened.close();
+    },
+  );
+```
+
+- [ ] **Step 5: Run the test to verify it currently passes**
+
+Run: `flutter test test/migration_version_drift_test.dart`
+Expected: PASS (this test validates the migration you just wrote, so it
+should already pass — if it fails, `_addColumnIfMissing`/`createTable`
+calls in Step 2 are wrong; fix before continuing).
+
+- [ ] **Step 6: Full-suite sanity check, then commit**
+
+Run: `flutter test`
+Expected: PASS (no existing test should be affected by purely-additive
+nullable columns).
+
+```bash
+git add lib/data/tables.dart lib/data/database.dart lib/data/database.g.dart test/migration_version_drift_test.dart
+git commit -m "feat: add CurrencyRates table and per-account/transaction currency columns (v60)"
+```
+
+---
+
+### Task 2: Pure conversion math (`currency_conversion.dart`)
+
+**Files:**
+- Create: `lib/data/currency_conversion.dart`
+- Test: `test/currency_conversion_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/currency_conversion.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  group('convertUsingRate', () {
+    test('1 USD = 83.12 INR converts $10.00 to ₹831.20', () {
+      final converted = convertUsingRate(
+        const Money(1000), // $10.00
+        83120000, // 83.12 scaled by currencyRateScale
+      );
+      expect(converted, const Money(83120)); // ₹831.20
+    });
+
+    test('a 1:1 rate is a no-op', () {
+      final converted = convertUsingRate(const Money(50000), 1000000);
+      expect(converted, const Money(50000));
+    });
+  });
+
+  group('TransactionBaseValue.baseAmount', () {
+    test('a parent-currency transaction (null currencyCode) is unconverted', () {
+      final row = TransactionRow(
+        id: 1,
+        type: TxType.expense,
+        amount: const Money(50000),
+        accountId: 1,
+        date: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+        needsAmountReview: false,
+      );
+      expect(row.baseAmount, const Money(50000));
+    });
+
+    test('a foreign-currency transaction converts using its snapshotted rate', () {
+      final row = TransactionRow(
+        id: 1,
+        type: TxType.expense,
+        amount: const Money(1000), // $10.00
+        accountId: 1,
+        date: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+        needsAmountReview: false,
+        currencyCode: const Value('USD'),
+        fxRateToBaseMicros: const Value(83120000),
+      );
+      expect(row.baseAmount, const Money(83120)); // ₹831.20
+    });
+  });
+}
+```
+
+Note: `TransactionRow` is a generated Drift data class — pass every
+non-nullable field positionally/named as shown (matching whatever
+`database.g.dart` generated for the existing columns), and the two new
+nullable fields via `Value(...)`. If the generated constructor rejects
+`Value(...)` for a plain data-class field (Drift data classes take raw
+values, not `Value<T>` — that wrapper is only for `Companion`s), use the
+raw value directly instead, e.g. `currencyCode: 'USD', fxRateToBaseMicros:
+83120000` — check `database.g.dart`'s `TransactionRow` constructor
+signature and match it exactly.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/currency_conversion_test.dart`
+Expected: FAIL — `currency_conversion.dart` doesn't exist yet (import error).
+
+- [ ] **Step 3: Write the implementation**
+
+```dart
+import '../core/money.dart';
+import 'tables.dart';
+
+/// [CurrencyRates.rateToBaseMicros] and [Transactions.fxRateToBaseMicros]
+/// are both scaled by this so the rate is an exact integer, never a
+/// `double` — the same rule [Money] itself follows.
+const currencyRateScale = 1000000;
+
+/// Converts [amount] (in some other currency) into the parent currency
+/// using [rateToBaseMicros] — units of parent per 1 unit of that currency,
+/// scaled by [currencyRateScale].
+Money convertUsingRate(Money amount, int rateToBaseMicros) =>
+    Money((amount.paise * rateToBaseMicros) ~/ currencyRateScale);
+
+/// A transaction's value in the parent currency — computed, never stored
+/// redundantly. Every Reports/Stats/Budget total that must stay stable
+/// after a rate changes later (the "snapshot" design decision) folds over
+/// this instead of raw [TransactionRow.amount].
+extension TransactionBaseValue on TransactionRow {
+  Money get baseAmount => currencyCode == null
+      ? amount
+      : convertUsingRate(amount, fxRateToBaseMicros!);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/currency_conversion_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/data/currency_conversion.dart test/currency_conversion_test.dart
+git commit -m "feat: add pure currency-conversion math and TransactionRow.baseAmount"
+```
+
+---
+
+### Task 3: `AppDatabase` rate methods
+
+**Files:**
+- Modify: `lib/data/database.dart` (add a new `// ── Currency rates ──` section — put it right after `recalculateBalances` ends, around `database.dart:2100`, before `// ── Queries ──`)
+- Test: `test/currency_rates_db_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  group('addCurrencyRate', () {
+    test('rejects an unknown currency code', () {
+      expect(
+        () => db.addCurrencyRate(
+          currencyCode: 'ZZZ',
+          rateToBaseMicros: 83000000,
+          effectiveAt: DateTime(2026, 1, 1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a non-positive rate', () {
+      expect(
+        () => db.addCurrencyRate(
+          currencyCode: 'USD',
+          rateToBaseMicros: 0,
+          effectiveAt: DateTime(2026, 1, 1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts a valid rate', () async {
+      final id = await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 83000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      expect(id, greaterThan(0));
+    });
+  });
+
+  group('latestRate', () {
+    test('returns null when the currency has no rate yet', () async {
+      final rate = await db.latestRate('USD');
+      expect(rate, isNull);
+    });
+
+    test('resolves the most recent rate at or before "asOf"', () async {
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 80000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 85000000,
+        effectiveAt: DateTime(2026, 6, 1),
+      );
+
+      final beforeBoth = await db.latestRate(
+        'USD',
+        asOf: DateTime(2025, 12, 1),
+      );
+      expect(beforeBoth, isNull);
+
+      final betweenThem = await db.latestRate(
+        'USD',
+        asOf: DateTime(2026, 3, 1),
+      );
+      expect(betweenThem!.rateToBaseMicros, 80000000);
+
+      final afterBoth = await db.latestRate('USD', asOf: DateTime(2026, 12, 1));
+      expect(afterBoth!.rateToBaseMicros, 85000000);
+    });
+  });
+
+  group('watchCurrentRates', () {
+    test('emits one row per currency, the newest rate for each', () async {
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 80000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 85000000,
+        effectiveAt: DateTime(2026, 6, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'EUR',
+        rateToBaseMicros: 90000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+
+      final rows = await db.watchCurrentRates().first;
+      expect(rows, hasLength(2));
+      final usd = rows.firstWhere((r) => r.currencyCode == 'USD');
+      expect(usd.rateToBaseMicros, 85000000);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/currency_rates_db_test.dart`
+Expected: FAIL — `addCurrencyRate`/`latestRate`/`watchCurrentRates` are
+undefined methods on `AppDatabase`.
+
+- [ ] **Step 3: Implement the methods**
+
+In `lib/data/database.dart`, add near the top of the file's imports (check
+it isn't already imported — `_validateForeignCurrency` at `database.dart:866`
+already calls `currencyForCode`, so `core/currency.dart` should already be
+imported; if not, add `import '../core/currency.dart';`) and add
+`import 'currency_conversion.dart';`.
+
+Insert this new section right after `recalculateBalances` closes
+(`database.dart:2099`, before the `// ── Queries ──` comment at `:2101`):
+
+```dart
+  // ── Currency rates ───────────────────────────────────────────────────────
+
+  /// The most recent rate for [currencyCode] at or before [asOf] (defaults
+  /// to now) — `null` if none has been entered yet as of that date. This is
+  /// what a transaction snapshots at post time, and what a live figure
+  /// (Net Worth) resolves with `asOf` left at its default.
+  Future<CurrencyRateRow?> latestRate(
+    String currencyCode, {
+    DateTime? asOf,
+  }) {
+    final cutoff = asOf ?? DateTime.now();
+    return (select(currencyRates)
+          ..where(
+            (r) =>
+                r.currencyCode.equals(currencyCode) &
+                r.effectiveAt.isSmallerOrEqualValue(cutoff),
+          )
+          ..orderBy([
+            (r) => OrderingTerm(expression: r.effectiveAt, mode: OrderingMode.desc),
+          ])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// Records a new rate. Always an insert, never an update — see
+  /// [CurrencyRates]'s doc for why history must never be overwritten.
+  Future<int> addCurrencyRate({
+    required String currencyCode,
+    required int rateToBaseMicros,
+    required DateTime effectiveAt,
+  }) {
+    if (rateToBaseMicros <= 0) {
+      throw ArgumentError('Rate must be positive.');
+    }
+    if (currencyForCode(currencyCode).code != currencyCode) {
+      throw ArgumentError('Unknown currency code: $currencyCode.');
+    }
+    return into(currencyRates).insert(
+      CurrencyRatesCompanion.insert(
+        currencyCode: currencyCode,
+        rateToBaseMicros: rateToBaseMicros,
+        effectiveAt: effectiveAt,
+      ),
+    );
+  }
+
+  /// One row per currency that has ever had a rate entered, each the most
+  /// recent — the list the Currency settings screen renders. Folds in Dart
+  /// rather than SQL, same style as [recalculateBalances]/[watchNetWorth].
+  Stream<List<CurrencyRateRow>> watchCurrentRates() =>
+      select(currencyRates).watch().map((rows) {
+        final latest = <String, CurrencyRateRow>{};
+        for (final r in rows) {
+          final existing = latest[r.currencyCode];
+          if (existing == null || r.effectiveAt.isAfter(existing.effectiveAt)) {
+            latest[r.currencyCode] = r;
+          }
+        }
+        final list = latest.values.toList()
+          ..sort((a, b) => a.currencyCode.compareTo(b.currencyCode));
+        return list;
+      });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/currency_rates_db_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/data/database.dart test/currency_rates_db_test.dart
+git commit -m "feat: add AppDatabase.latestRate/addCurrencyRate/watchCurrentRates"
+```
+
+---
+
+### Task 4: Account currency — creation and the first-transaction lock
+
+**Files:**
+- Modify: `lib/data/database.dart:2348-2386` (`addAccount`), and add `setAccountCurrency` near `renameAccount` (`database.dart:2392-2400`)
+- Test: `test/account_currency_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<int> addBank({String? currencyCode}) => db.addAccount(
+        name: 'Bank',
+        type: AccountType.bank,
+        colorValue: 0xFF000000,
+        iconKey: 'bank',
+        openingBalance: const Money(10000),
+        currencyCode: currencyCode,
+      );
+
+  test('addAccount defaults to null (parent currency)', () async {
+    final id = await addBank();
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    expect(row.currencyCode, isNull);
+  });
+
+  test('addAccount stores an explicit foreign currency', () async {
+    final id = await addBank(currencyCode: 'USD');
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    expect(row.currencyCode, 'USD');
+  });
+
+  test('a debit card never gets its own currency, even if one is passed', () async {
+    final bankId = await addBank(currencyCode: 'USD');
+    final cardId = await db.addAccount(
+      name: 'Debit card',
+      type: AccountType.card,
+      cardKind: CardKind.debit,
+      linkedAccountId: bankId,
+      colorValue: 0xFF000000,
+      iconKey: 'card',
+      openingBalance: const Money.zero(),
+      currencyCode: 'EUR',
+    );
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(cardId))).getSingle();
+    expect(row.currencyCode, isNull);
+  });
+
+  group('setAccountCurrency', () {
+    test('changes the currency of an untouched account', () async {
+      final id = await addBank();
+      await db.setAccountCurrency(id, 'USD');
+      final row = await (db.select(
+        db.accounts,
+      )..where((a) => a.id.equals(id))).getSingle();
+      expect(row.currencyCode, 'USD');
+    });
+
+    test('locks once the account has a transaction', () async {
+      final id = await addBank();
+      await db.addTransaction(
+        type: TxType.income,
+        amount: const Money(5000),
+        accountId: id,
+        date: DateTime(2026, 1, 1),
+      );
+
+      expect(
+        () => db.setAccountCurrency(id, 'USD'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an unknown currency code', () async {
+      final id = await addBank();
+      expect(() => db.setAccountCurrency(id, 'ZZZ'), throwsArgumentError);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/account_currency_test.dart`
+Expected: FAIL — `addAccount` has no `currencyCode` parameter,
+`setAccountCurrency` is undefined.
+
+- [ ] **Step 3: Implement**
+
+Modify `addAccount` (`database.dart:2348-2386`):
+
+```dart
+  Future<int> addAccount({
+    required String name,
+    required AccountType type,
+    CardKind? cardKind,
+    int? linkedAccountId,
+    String? bankName,
+    String? last4,
+    required int colorValue,
+    required String iconKey,
+    required Money openingBalance,
+    String? currencyCode,
+  }) {
+    if (type == AccountType.card && cardKind == null) {
+      throw ArgumentError('A card must be credit or debit.');
+    }
+    if (cardKind == CardKind.debit && linkedAccountId == null) {
+      throw ArgumentError(
+        'A debit card must be linked to the bank account it draws from.',
+      );
+    }
+    // An instrument (debit card) holds no balance, and no currency, of its
+    // own — it always mirrors the account it draws from.
+    final opening = linkedAccountId == null
+        ? openingBalance
+        : const Money.zero();
+    final resolvedCurrencyCode = linkedAccountId == null ? currencyCode : null;
+    if (resolvedCurrencyCode != null &&
+        currencyForCode(resolvedCurrencyCode).code != resolvedCurrencyCode) {
+      throw ArgumentError('Unknown currency code: $resolvedCurrencyCode.');
+    }
+
+    return into(accounts).insert(
+      AccountsCompanion.insert(
+        name: name,
+        type: type,
+        cardKind: Value(cardKind),
+        linkedAccountId: Value(linkedAccountId),
+        bankName: Value(bankName),
+        last4: Value(last4),
+        colorValue: colorValue,
+        iconKey: iconKey,
+        openingBalance: opening,
+        currentBalance: opening,
+        currencyCode: Value(resolvedCurrencyCode),
+      ),
+    );
+  }
+```
+
+Add `setAccountCurrency` right after `renameAccount`
+(`database.dart:2392-2400`):
+
+```dart
+  /// Changes an account's currency. Only ever allowed before it has a
+  /// transaction — once one exists, its native amount is only meaningful
+  /// under the currency it was posted in, so the field locks (see the
+  /// design spec's "an account's currency locks once it has its first
+  /// transaction" decision). A linked card can never set its own currency —
+  /// it always mirrors the account it draws from.
+  Future<void> setAccountCurrency(int id, String? currencyCode) async {
+    if (currencyCode != null &&
+        currencyForCode(currencyCode).code != currencyCode) {
+      throw ArgumentError('Unknown currency code: $currencyCode.');
+    }
+    final account = await (select(
+      accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    if (account.linkedAccountId != null) {
+      throw ArgumentError(
+        "A linked card always uses its bank account's currency.",
+      );
+    }
+    if (await countTransactionsForAccount(id) > 0) {
+      throw ArgumentError(
+        'This account already has transactions — its currency is locked.',
+      );
+    }
+    await (update(accounts)..where((a) => a.id.equals(id))).write(
+      AccountsCompanion(currencyCode: Value(currencyCode)),
+    );
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/account_currency_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite (this touches a widely-used method signature)**
+
+Run: `flutter test`
+Expected: PASS — `addAccount`'s new `currencyCode` parameter is optional, so
+every existing call site (which doesn't pass it) is unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/data/database.dart test/account_currency_test.dart
+git commit -m "feat: add per-account currency, locked after the first transaction"
+```
+
+---
+
+### Task 5: Transaction currency snapshot on `addTransaction`
+
+**Files:**
+- Modify: `lib/data/database.dart:985-1039` (`addTransaction`)
+- Test: `test/transaction_currency_snapshot_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<int> addAccountWithCurrency(String? code) => db.addAccount(
+        name: 'Acct $code',
+        type: AccountType.bank,
+        colorValue: 0xFF000000,
+        iconKey: 'bank',
+        openingBalance: const Money.zero(),
+        currencyCode: code,
+      );
+
+  test('a parent-currency account posts with null currency/rate', () async {
+    final id = await addAccountWithCurrency(null);
+    final txId = await db.addTransaction(
+      type: TxType.expense,
+      amount: const Money(50000),
+      accountId: id,
+      date: DateTime(2026, 1, 1),
+    );
+    final row = await (db.select(
+      db.transactions,
+    )..where((t) => t.id.equals(txId))).getSingle();
+    expect(row.currencyCode, isNull);
+    expect(row.fxRateToBaseMicros, isNull);
+  });
+
+  test('a foreign-currency account with no rate yet throws', () async {
+    final id = await addAccountWithCurrency('USD');
+    expect(
+      () => db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(1000),
+        accountId: id,
+        date: DateTime(2026, 1, 1),
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('a foreign-currency account snapshots the rate as of the tx date', () async {
+    final id = await addAccountWithCurrency('USD');
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 80000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 85000000,
+      effectiveAt: DateTime(2026, 6, 1),
+    );
+
+    final txId = await db.addTransaction(
+      type: TxType.expense,
+      amount: const Money(1000),
+      accountId: id,
+      date: DateTime(2026, 3, 1), // between the two rates
+    );
+    final row = await (db.select(
+      db.transactions,
+    )..where((t) => t.id.equals(txId))).getSingle();
+    expect(row.currencyCode, 'USD');
+    expect(row.fxRateToBaseMicros, 80000000);
+  });
+
+  group('cross-currency transfer', () {
+    test('same-currency transfer leaves toAmount/toCurrencyCode null', () async {
+      final a = await addAccountWithCurrency(null);
+      final b = await addAccountWithCurrency(null);
+      final txId = await db.addTransaction(
+        type: TxType.transfer,
+        amount: const Money(50000),
+        accountId: a,
+        toAccountId: b,
+        date: DateTime(2026, 1, 1),
+      );
+      final row = await (db.select(
+        db.transactions,
+      )..where((t) => t.id.equals(txId))).getSingle();
+      expect(row.toAmount, isNull);
+      expect(row.toCurrencyCode, isNull);
+    });
+
+    test('parent to foreign transfer computes toAmount via the current rate', () async {
+      final inrAcct = await addAccountWithCurrency(null);
+      final usdAcct = await addAccountWithCurrency('USD');
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 83000000, // 1 USD = 83 INR
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+
+      final txId = await db.addTransaction(
+        type: TxType.transfer,
+        amount: const Money(830000), // ₹8300.00
+        accountId: inrAcct,
+        toAccountId: usdAcct,
+        date: DateTime(2026, 2, 1),
+      );
+      final row = await (db.select(
+        db.transactions,
+      )..where((t) => t.id.equals(txId))).getSingle();
+      expect(row.toCurrencyCode, 'USD');
+      // ₹8300.00 / 83 = $100.00
+      expect(row.toAmount, const Money(10000));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/transaction_currency_snapshot_test.dart`
+Expected: FAIL — every new column stays null/unpopulated (`addTransaction`
+doesn't resolve currency yet), so the "throws" and "snapshots the rate"
+assertions fail.
+
+- [ ] **Step 3: Implement**
+
+Add a private helper right before `addTransaction`
+(`database.dart:985`), and rewrite `addTransaction` to use it:
+
+```dart
+  /// Resolves what [accountId] should stamp onto a transaction posted on
+  /// [date]: `(null, null)` for a parent-currency account, or its currency
+  /// code plus the rate snapshot for a foreign-currency one. Throws if the
+  /// account is foreign-currency but no rate has been entered yet as of
+  /// that date — silently falling back to 1:1 would quietly corrupt every
+  /// downstream total, so this fails loudly instead and the UI is
+  /// responsible for steering the user to the Currency settings screen
+  /// first (Plan 2/3).
+  Future<(String?, int?)> _resolveTxCurrency(int accountId, DateTime date) async {
+    final account = await (select(
+      accounts,
+    )..where((a) => a.id.equals(accountId))).getSingle();
+    final code = account.currencyCode;
+    if (code == null) return (null, null);
+    final rate = await latestRate(code, asOf: date);
+    if (rate == null) {
+      throw ArgumentError(
+        'No exchange rate set for $code yet — add one in Settings > '
+        'Currency before posting this transaction.',
+      );
+    }
+    return (code, rate.rateToBaseMicros);
+  }
+```
+
+Replace the body of `addTransaction` (`database.dart:985-1039`):
+
+```dart
+  Future<int> addTransaction({
+    required TxType type,
+    required Money amount,
+    required int accountId,
+    int? toAccountId,
+    int? categoryId,
+    int? personId,
+    required DateTime date,
+    String? note,
+    String? payee,
+    int? recurringRuleId,
+    String? imagePath,
+    bool needsAmountReview = false,
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
+  }) async {
+    await _validateTx(
+      type: type,
+      amount: amount,
+      accountId: accountId,
+      toAccountId: toAccountId,
+      categoryId: categoryId,
+      personId: personId,
+      payee: payee,
+      recurringRuleId: recurringRuleId,
+      foreignCurrencyCode: foreignCurrencyCode,
+      foreignAmount: foreignAmount,
+    );
+
+    final (sourceCode, sourceRate) = await _resolveTxCurrency(accountId, date);
+
+    String? toCode;
+    int? toRate;
+    Money? toAmt;
+    if (type == TxType.transfer && toAccountId != null) {
+      final resolved = await _resolveTxCurrency(toAccountId, date);
+      toCode = resolved.$1;
+      toRate = resolved.$2;
+      if (toCode != sourceCode) {
+        final sourceBase = sourceCode == null
+            ? amount
+            : convertUsingRate(amount, sourceRate!);
+        toAmt = toCode == null
+            ? sourceBase
+            : Money((sourceBase.paise * currencyRateScale) ~/ toRate!);
+      }
+    }
+
+    return transaction(() async {
+      final id = await into(transactions).insert(
+        TransactionsCompanion.insert(
+          type: type,
+          amount: amount,
+          accountId: accountId,
+          toAccountId: Value(toAccountId),
+          categoryId: Value(categoryId),
+          personId: Value(personId),
+          date: date,
+          note: Value(note),
+          payee: Value(payee),
+          recurringRuleId: Value(recurringRuleId),
+          imagePath: Value(imagePath),
+          needsAmountReview: Value(needsAmountReview),
+          foreignCurrencyCode: Value(foreignCurrencyCode),
+          foreignAmount: Value(foreignAmount),
+          currencyCode: Value(sourceCode),
+          fxRateToBaseMicros: Value(sourceRate),
+          toAmount: Value(toAmt),
+          toCurrencyCode: Value(toCode),
+          toFxRateToBaseMicros: Value(toRate),
+        ),
+      );
+      final row = await (select(
+        transactions,
+      )..where((t) => t.id.equals(id))).getSingle();
+      await _applyTxEffect(row, reverse: false);
+      return id;
+    });
+  }
+```
+
+Add the import at the top of `database.dart` (next to the other local
+imports): `import 'currency_conversion.dart';` (skip if Task 3 already
+added it).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/transaction_currency_snapshot_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Full-suite check, then commit**
+
+Run: `flutter test`
+Expected: PASS. (`addHybridPaymentTransaction` and any other transaction-
+writing path that doesn't go through `addTransaction` is untouched by this
+task — cross-currency hybrid payments are explicitly out of scope per the
+spec's Non-goals; leave `addHybridPaymentTransaction` as-is.)
+
+```bash
+git add lib/data/database.dart test/transaction_currency_snapshot_test.dart
+git commit -m "feat: snapshot currency/rate onto a transaction at post time"
+```
+
+---
+
+### Task 6: Fix balance math for cross-currency transfers
+
+**Files:**
+- Modify: `lib/data/database.dart:834-851` (`_applyTxEffect`), `:2061-2099` (`recalculateBalances`)
+- Test: `test/cross_currency_balance_test.dart`
+
+Without this fix, Task 5's `toAmount` is stored but never used — a
+cross-currency transfer would still credit the destination account with the
+*source*-currency `amount`, silently corrupting its balance (e.g. crediting
+"8300" to a USD wallet instead of "100").
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('a cross-currency transfer credits the destination in its own currency',
+      () async {
+    final inrAcct = await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000), // ₹10,000.00
+    );
+    final usdAcct = await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money.zero(),
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000, // 1 USD = 83 INR
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+
+    await db.addTransaction(
+      type: TxType.transfer,
+      amount: const Money(830000), // ₹8300.00 leaves the INR wallet
+      accountId: inrAcct,
+      toAccountId: usdAcct,
+      date: DateTime(2026, 2, 1),
+    );
+
+    final inrRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(inrAcct))).getSingle();
+    final usdRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(usdAcct))).getSingle();
+
+    expect(inrRow.currentBalance, const Money(170000)); // ₹1700.00 left
+    expect(usdRow.currentBalance, const Money(10000)); // $100.00 credited
+  });
+
+  test('recalculateBalances rebuilds a cross-currency transfer identically',
+      () async {
+    final inrAcct = await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000),
+    );
+    final usdAcct = await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money.zero(),
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+    await db.addTransaction(
+      type: TxType.transfer,
+      amount: const Money(830000),
+      accountId: inrAcct,
+      toAccountId: usdAcct,
+      date: DateTime(2026, 2, 1),
+    );
+
+    await db.recalculateBalances();
+
+    final usdRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(usdAcct))).getSingle();
+    expect(usdRow.currentBalance, const Money(10000));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/cross_currency_balance_test.dart`
+Expected: FAIL — `usdRow.currentBalance` comes back as `830000` (wrongly
+credited the raw source amount) instead of `10000`.
+
+- [ ] **Step 3: Fix `_applyTxEffect` and `recalculateBalances`**
+
+In `_applyTxEffect` (`database.dart:834-851`), change the `transfer` case:
+
+```dart
+      case TxType.transfer:
+        await _adjust(t.accountId, -amt);
+        final creditAmt =
+            t.toAmount == null ? amt : Money(t.toAmount!.paise * sign);
+        await _adjust(t.toAccountId!, creditAmt);
+```
+
+In `recalculateBalances` (`database.dart:2061-2099`), change the `transfer`
+case inside the `for (final t in await select(transactions).get())` loop:
+
+```dart
+          case TxType.transfer:
+            bump(t.accountId, -t.amount);
+            bump(t.toAccountId!, t.toAmount ?? t.amount);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/cross_currency_balance_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Full-suite check, then commit**
+
+Run: `flutter test`
+Expected: PASS — every existing same-currency transfer has `toAmount ==
+null`, so `t.toAmount ?? t.amount` and the `creditAmt` fallback both
+degrade to exactly today's behavior.
+
+```bash
+git add lib/data/database.dart test/cross_currency_balance_test.dart
+git commit -m "fix: credit a cross-currency transfer's destination in its own currency"
+```
+
+---
+
+### Task 7: Currency-aware Net Worth
+
+**Files:**
+- Modify: `lib/data/database.dart:2122-2126` (`watchNetWorth`)
+- Test: `test/net_worth_currency_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('sums a mixed-currency set of accounts using the live rate', () async {
+    await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000), // ₹10,000.00
+    );
+    await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(10000), // $100.00
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000, // 1 USD = 83 INR
+      effectiveAt: DateTime(2020, 1, 1),
+    );
+
+    final netWorth = await db.watchNetWorth().first;
+    // ₹10,000.00 + ($100.00 -> ₹8,300.00) = ₹18,300.00
+    expect(netWorth, const Money(1830000));
+  });
+
+  test('a foreign account with no rate yet contributes its raw balance '
+      'unconverted, rather than breaking the stream', () async {
+    await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(10000),
+      currencyCode: 'USD',
+    );
+
+    final netWorth = await db.watchNetWorth().first;
+    expect(netWorth, const Money(10000));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/net_worth_currency_test.dart`
+Expected: FAIL — the first test expects `1830000` but today's plain `+`
+fold produces `1010000` (₹10,000 + a raw `10000` treated as rupees, i.e.
+$100 misread as ₹100).
+
+- [ ] **Step 3: Implement**
+
+Replace `watchNetWorth` (`database.dart:2122-2126`):
+
+```dart
+  /// Total money = Cash + Bank + Credit Card. Instruments never double-count.
+  /// An account with [Accounts.includeInNetWorth] off — opted out from
+  /// Settings > Customize Dashboard — contributes nothing here, though it
+  /// still shows its own balance everywhere else in the app.
+  ///
+  /// A foreign-currency account's balance is converted using **today's**
+  /// rate, not a snapshot — Net Worth is a "right now" figure, unlike a
+  /// transaction's historical [TransactionBaseValue.baseAmount]. If no rate
+  /// has been entered for its currency yet, its raw balance is added
+  /// unconverted rather than dropping it or throwing, so an incomplete
+  /// Currency setup never breaks the dashboard.
+  Stream<Money> watchNetWorth() => watchBalanceHoldingAccounts().asyncMap((
+    rows,
+  ) async {
+    var total = const Money.zero();
+    for (final a in rows) {
+      if (!a.includeInNetWorth) continue;
+      if (a.currencyCode == null) {
+        total += a.currentBalance;
+        continue;
+      }
+      final rate = await latestRate(a.currencyCode!);
+      total += rate == null
+          ? a.currentBalance
+          : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
+    }
+    return total;
+  });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/net_worth_currency_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Full-suite check, then commit**
+
+Run: `flutter test`
+Expected: PASS — every existing account has `currencyCode == null`, so the
+new method takes the unconverted `continue` branch for all of them,
+identical to today's `+` fold.
+
+```bash
+git add lib/data/database.dart test/net_worth_currency_test.dart
+git commit -m "feat: convert foreign-currency balances into Net Worth at the live rate"
+```
+
+---
+
+### Task 8: `MoneyFormat.symbolIn` — format an amount in an explicit currency
+
+**Files:**
+- Modify: `lib/core/money.dart`
+- Test: `test/currency_test.dart` (add to the existing `MoneyFormat.configure` group)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `test/currency_test.dart`, inside the existing `group('MoneyFormat.configure', ...)` block (`currency_test.dart:34-84`):
+
+```dart
+    test('symbolIn formats against an explicit currency, ignoring the '
+        'globally configured one', () {
+      MoneyFormat.configure(
+        currency: currencyForCode('INR'),
+        showSymbol: true,
+      );
+      final out = MoneyFormat.symbolIn(const Money(125050), currencyForCode('USD'));
+      expect(out, contains(r'$'));
+      expect(out, contains('1,250.50'));
+      expect(out, isNot(contains('₹')));
+    });
+
+    test('symbolIn respects a zero-decimal currency', () {
+      final out = MoneyFormat.symbolIn(
+        const Money(125000),
+        currencyForCode('JPY'),
+      );
+      expect(out, contains('¥'));
+      expect(out, isNot(contains('.00')));
+    });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/currency_test.dart`
+Expected: FAIL — `symbolIn` is not a member of `MoneyFormat`.
+
+- [ ] **Step 3: Implement**
+
+In `lib/core/money.dart`, add a new static method to `MoneyFormat` right
+after `symbol` (`money.dart:118-120`):
+
+```dart
+  /// Formats [m] against an explicit [currency], ignoring whatever
+  /// [MoneyFormat] is globally configured to. For rendering one specific
+  /// account's or transaction's own (possibly foreign) amount — every
+  /// aggregate total (Dashboard, Net Worth, Reports, Budgets) stays on
+  /// [symbol] as before, since those are always parent-currency figures.
+  /// Not cached like [_withSymbol] — this path is only ever used per-row,
+  /// not hot enough to need it.
+  static String symbolIn(Money m, Currency currency) {
+    if (!_showSymbol) return _buildBare(currency).format(m.rupees);
+    return _buildWithSymbol(currency).format(m.rupees);
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/currency_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/core/money.dart test/currency_test.dart
+git commit -m "feat: add MoneyFormat.symbolIn to render an explicit currency"
+```
+
+---
+
+### Task 9: `MoneyText`/`BalanceText`/`AnimatedBalanceText` gain an optional `currency`
+
+**Files:**
+- Modify: `lib/core/widgets/money_text.dart:124-219`
+- Test: `test/money_text_currency_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/currency.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/widgets/money_text.dart';
+
+void main() {
+  tearDown(() => MoneyFormat.configure(
+        currency: kDefaultCurrency,
+        showSymbol: true,
+      ));
+
+  testWidgets('an explicit currency overrides the globally configured one',
+      (tester) async {
+    MoneyFormat.configure(currency: currencyForCode('INR'), showSymbol: true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MoneyText(
+            const Money(125050),
+            currency: currencyForCode('USD'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining(r'$'), findsOneWidget);
+    expect(find.textContaining('₹'), findsNothing);
+  });
+
+  testWidgets('omitting currency keeps using the global MoneyFormat, unchanged',
+      (tester) async {
+    MoneyFormat.configure(currency: currencyForCode('INR'), showSymbol: true);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MoneyText(Money(125050))),
+      ),
+    );
+
+    expect(find.textContaining('₹'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/money_text_currency_test.dart`
+Expected: FAIL — `MoneyText` has no `currency` parameter.
+
+- [ ] **Step 3: Implement**
+
+In `lib/core/widgets/money_text.dart`, update `MoneyText`
+(`money_text.dart:124-171`):
+
+```dart
+class MoneyText extends StatelessWidget {
+  const MoneyText(
+    this.amount, {
+    this.style,
+    this.color,
+    this.signed = false,
+    this.compact = false,
+    this.currency,
+    super.key,
+  });
+
+  final Money amount;
+  final TextStyle? style;
+  final Color? color;
+
+  /// Prefix `+`/`-`. Use on ledger rows, not on balances.
+  final bool signed;
+  final bool compact;
+
+  /// Renders against this currency instead of the globally configured one —
+  /// for a specific account's/transaction's own (possibly foreign) amount.
+  /// Null (the default) renders exactly as before, via [MoneyFormat].
+  final Currency? currency;
+
+  /// A fixed-width placeholder — never derived from the real digits, so the
+  /// mask can't leak the amount's order of magnitude (a 3-digit vs 7-digit
+  /// figure would otherwise be visibly distinguishable even hidden).
+  static const _maskGlyph = '••••••';
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuild whenever the currency setting changes — [MoneyFormat] is already
+    // reconfigured by then, so the new symbol/grouping lands immediately.
+    // Irrelevant when [currency] is set explicitly, but depending
+    // unconditionally keeps this widget's rebuild behavior simple.
+    CurrencyScope.depend(context);
+    final hidden = AmountVisibilityScope.of(context);
+    final displayCurrency = currency ?? MoneyFormat.currency;
+    final text = hidden
+        ? (MoneyFormat.showSymbol
+            ? '${displayCurrency.symbol} $_maskGlyph'
+            : _maskGlyph)
+        : compact
+            ? MoneyFormat.compact(amount)
+            : signed
+                ? _signedIn(amount, currency)
+                : currency == null
+                    ? MoneyFormat.symbol(amount)
+                    : MoneyFormat.symbolIn(amount, currency!);
+
+    return Text(
+      text,
+      style: (style ?? Theme.of(context).textTheme.bodyLarge)?.copyWith(
+        color: color,
+        fontFeatures: kTabularFigures,
+      ),
+    );
+  }
+
+  static String _signedIn(Money m, Currency? currency) {
+    if (currency == null) return MoneyFormat.signed(m);
+    final sign = m.isNegative ? '-' : '+';
+    return '$sign${MoneyFormat.symbolIn(m.abs, currency)}';
+  }
+}
+```
+
+Update `BalanceText` and `AnimatedBalanceText` (`money_text.dart:174-219`)
+to accept and forward the same parameter:
+
+```dart
+class BalanceText extends StatelessWidget {
+  const BalanceText(this.amount, {this.style, this.currency, super.key});
+
+  final Money amount;
+  final TextStyle? style;
+  final Currency? currency;
+
+  @override
+  Widget build(BuildContext context) {
+    return MoneyText(
+      amount,
+      style: style,
+      currency: currency,
+      color: amount.isNegative ? AppColors.expense : null,
+    );
+  }
+}
+
+/// A [BalanceText] that counts to its value instead of snapping to it — and
+/// counts *from* the old value whenever the balance changes.
+///
+/// Reserve this for a single hero figure. Numbers that sit in a list or a
+/// column must not move, or the whole screen twitches on every ledger write.
+class AnimatedBalanceText extends StatelessWidget {
+  const AnimatedBalanceText(
+    this.amount, {
+    this.style,
+    this.currency,
+    this.duration = const Duration(milliseconds: 650),
+    super.key,
+  });
+
+  final Money amount;
+  final TextStyle? style;
+  final Currency? currency;
+  final Duration duration;
+
+  @override
+  Widget build(BuildContext context) {
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return BalanceText(amount, style: style, currency: currency);
+    }
+    return TweenAnimationBuilder<int>(
+      tween: IntTween(begin: 0, end: amount.paise),
+      duration: duration,
+      curve: Curves.easeOutCubic,
+      builder: (context, paise, _) =>
+          BalanceText(Money(paise), style: style, currency: currency),
+    );
+  }
+}
+```
+
+`money_text.dart` already imports `../currency.dart` (`money_text.dart:6`),
+so `Currency` is already in scope — no new import needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/money_text_currency_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Full-suite check, then commit**
+
+Run: `flutter test`
+Expected: PASS — `currency` defaults to `null` everywhere it isn't passed,
+so every existing call site (there are dozens across the app) renders
+identically to before.
+
+```bash
+git add lib/core/widgets/money_text.dart test/money_text_currency_test.dart
+git commit -m "feat: let MoneyText/BalanceText/AnimatedBalanceText render an explicit currency"
+```
+
+---
+
+## Self-review notes (for whoever executes this plan)
+
+- **Spec coverage:** This plan implements the "Data model" and "Migration"
+  sections of the design spec in full, plus the `MoneyFormat`/`MoneyText`
+  half of the "Rendering change" section, plus the Net Worth conversion
+  described under "Balances, Net Worth, Reports, Budgets". It deliberately
+  does **not** implement: the Currency settings screen, account/transaction/
+  transfer UI, `watchSpendByCategory`/Reports conversion, or
+  backup/PDF-statement handling — those are Plans 2–4.
+- **`TransactionRow` constructor shape (Task 2):** the exact generated
+  constructor signature for `TransactionRow` may not match this plan's
+  guess field-for-field once `database.g.dart` is regenerated in Task 1 —
+  the step's note says explicitly to check the generated file and adjust.
+  Don't skip that check.
+- **Do not implement Plans 2–4 tasks from this document** — they don't
+  exist here on purpose; see the "Relationship to other plans" note at the
+  top.

--- a/docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md
+++ b/docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md
@@ -1,0 +1,340 @@
+# Multi-currency accounts — design spec
+
+Date: 2026-09-04
+Status: draft, pending approval
+
+## Background
+
+The user wants each wallet/account to be able to hold its own currency
+(e.g. an INR bank account alongside a USD travel wallet), a new **Currency**
+module under Settings where they maintain exchange rates against a parent
+currency, and every total in the app (Net Worth, Reports, transfers, PDF
+statements, backups) to keep working correctly across accounts that don't
+share a currency.
+
+## Why this isn't a small change
+
+The app has exactly **one** currency today, app-wide. `Money`
+(`core/money.dart:13`) is a bare integer number of minor units with no
+currency attached at all. Rendering is done by `MoneyFormat`
+(`core/money.dart:73`), a single static singleton configured once from
+`Settings.currencyCode` (`tables.dart:605`, `providers.dart:666`) and never
+per-row. Every call site — `MoneyText` (`core/widgets/money_text.dart:124`),
+PDF statements, CSV exports, backups — assumes "the" currency, not "this
+account's" currency. `Accounts` and `Transactions` (`tables.dart:132`,
+`tables.dart:201`) have no currency column; `watchNetWorth`
+(`database.dart:2122`) sums every balance-holding account's `currentBalance`
+directly with `+`, which is only correct because today they're guaranteed to
+be the same currency.
+
+So this is a genuine data-model addition (new columns, a new table, a new
+migration) plus updating every place that currently renders or sums money
+assuming a single ambient currency — not a UI-only feature.
+
+## Decisions already made (with the user, before this doc)
+
+- **Rates are snapshotted per transaction, not looked up live.** Each
+  transaction records the exchange rate that was active when it was posted.
+  Editing a rate later never changes what a past transaction's converted
+  value was. This is what makes historical totals ("inflation-aware")
+  stable.
+- **The parent/base currency is the existing global `Settings.currencyCode`**
+  (today's single app-wide currency setting) — not a new, separate choice.
+  Existing users get a base currency for free, with zero new setup.
+- **Cross-currency transfers**: the user enters the amount leaving the
+  source account once; the app auto-converts it into the destination
+  account's currency at the current rate for that pair, showing an editable
+  "≈ received" figure before saving.
+- **Category budgets and Envelope Mode stay parent-currency-only.** A
+  foreign-currency account can freely have income/expenses and counts
+  toward Net Worth, but cannot use Envelope Mode, and its transactions never
+  count toward a category budget. This avoids mixing FX uncertainty into a
+  feature (`categoryBalance`/`readyToAssign`) built around exact
+  rupee-for-rupee assignment.
+- **Full end-to-end in one phase**: the Currency module, per-account
+  currency, snapshotted rates, converted transfers, and every screen that
+  totals money (Dashboard, Net Worth, Reports, Budgets, backup/export, PDF
+  statements) ship together — no intermediate state where some screens
+  silently ignore non-base accounts.
+- **An account's currency locks once it has its first transaction** —
+  editable only while the account is empty. Prevents its existing native
+  amounts from becoming ambiguous.
+
+## Non-goals
+
+- Live/fetched exchange rates (no API integration) — rates are entered
+  manually in the Currency module, exactly as the user described
+  ("comparative prices with parent currency").
+- Multi-currency Envelope Mode / category budgets (see decisions above).
+- Changing an account's currency after it has transactions.
+- A currency-conversion "what-if" calculator or standalone FX tool — rates
+  exist only to power account/transaction conversion.
+- Currency support for `Persons`/`PersonEntries` lending — these stay
+  implicitly parent-currency, same as budgets, since they're not tied to a
+  specific account in the general case (`accountId` is nullable on
+  `PersonEntries`, `tables.dart:367`).
+
+## Data model
+
+### New `CurrencyRates` table
+
+```dart
+@DataClassName('CurrencyRateRow')
+class CurrencyRates extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// The non-parent currency this rate prices, e.g. `USD`. Never the parent
+  /// currency itself — the parent is always rate 1:1 with itself.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3)();
+
+  /// How many units of the PARENT currency equal 1 unit of [currencyCode],
+  /// scaled by 1,000,000 so it's an exact integer — never a `double`, same
+  /// rule as [Money]. `rateToBaseMicros: 83_120_000` means 1 USD = 83.12 INR.
+  IntColumn get rateToBaseMicros => integer()();
+
+  /// When this rate became active. A transaction snapshots the latest row
+  /// with `effectiveAt <= transaction.date`.
+  DateTimeColumn get effectiveAt => dateTime()();
+
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+```
+
+Multiple rows per `currencyCode` accumulate as history — adding a new rate
+is always an insert, never an update, so past snapshots stay resolvable
+even after the "current" rate moves on.
+
+`AppDatabase` gains:
+
+- `latestRate(String currencyCode, {DateTime? asOf})` — the row with the
+  greatest `effectiveAt <= (asOf ?? now)`, or `null` if the currency has no
+  rate yet at that point in time.
+- `watchCurrentRates()` — one row per currency in use, its most recent rate,
+  for the Currency settings screen list.
+- `addCurrencyRate(String currencyCode, int rateToBaseMicros, DateTime effectiveAt)`.
+
+### `Accounts` gains one column
+
+```dart
+/// Null = this account is in the parent currency (`Settings.currencyCode`)
+/// — true for every account created before this feature and for every
+/// account a user never explicitly changes. Locked once the account has a
+/// transaction (enforced in `addAccount`/`updateAccount`, not the schema).
+TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
+```
+
+A debit-card/UPI-style account (`linkedAccountId` non-null,
+`tables.dart:142`) always inherits its linked account's currency and never
+gets its own — it holds no balance of its own, so a separate currency on it
+would be meaningless.
+
+### `Transactions` gains four columns
+
+```dart
+/// This transaction's own currency, snapshotted from its account at post
+/// time. Null = parent currency (matches `amount`'s existing meaning
+/// exactly — no conversion needed). Never changes after the fact, even if
+/// the account's currency setting somehow changed (it can't, once posted —
+/// see the account-lock rule — but a transaction is self-describing anyway).
+TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
+
+/// Snapshot of `CurrencyRates.rateToBaseMicros` as of `date`, for
+/// [currencyCode]. Null iff [currencyCode] is null.
+IntColumn get fxRateToBaseMicros => integer().nullable()();
+
+/// Transfer only, and only when the source and destination accounts don't
+/// share a currency: the amount credited to `toAccountId`, in *its own*
+/// currency. Null for a same-currency transfer, where crediting `amount`
+/// unchanged is already correct.
+IntColumn get toAmount => integer().map(const MoneyConverter()).nullable()();
+
+/// Transfer only, mirrors [currencyCode]/[fxRateToBaseMicros] for the
+/// destination leg — the two accounts can each be a different currency
+/// from the parent (and from each other), so the destination needs its own
+/// independent snapshot.
+TextColumn get toCurrencyCode => text().withLength(min: 3, max: 3).nullable()();
+IntColumn get toFxRateToBaseMicros => integer().nullable()();
+```
+
+`amount` keeps its exact existing meaning: the native amount in the
+transaction's own currency (source leg for a transfer). Nothing about how
+`amount` is written or read changes for a parent-currency transaction —
+every new column is simply null, identical to today's behavior.
+
+A transaction's **base-currency value** is computed, never stored
+redundantly:
+
+```dart
+extension TransactionBaseValue on TransactionRow {
+  Money get baseAmount => currencyCode == null
+      ? amount
+      : Money((amount.paise * fxRateToBaseMicros!) ~/ 1000000);
+}
+```
+
+This mirrors the existing Dart-side-fold style the codebase already uses
+(`recalculateBalances`, `watchNetWorth` — fetch rows, compute in Dart) rather
+than pushing conversion into SQL.
+
+### Migration
+
+Schema v58 → v59, appended to `onUpgrade` after the existing `if (from < 58)`
+block (`database.dart:463`):
+
+```dart
+if (from < 59) {
+  await m.createTable(currencyRates);
+  await _addColumnIfMissing(m, accounts, accounts.currencyCode);
+  await _addColumnIfMissing(m, transactions, transactions.currencyCode);
+  await _addColumnIfMissing(m, transactions, transactions.fxRateToBaseMicros);
+  await _addColumnIfMissing(m, transactions, transactions.toAmount);
+  await _addColumnIfMissing(m, transactions, transactions.toCurrencyCode);
+  await _addColumnIfMissing(m, transactions, transactions.toFxRateToBaseMicros);
+}
+```
+
+Every new column is nullable and additive; every existing row upgrades with
+all-null values, which is defined above to mean exactly today's behavior.
+No backfill needed.
+
+## Rendering change: `MoneyFormat` / `MoneyText`
+
+`MoneyFormat` (`core/money.dart:73`) stays the single global formatter for
+the **parent** currency — Dashboard, Net Worth, Reports, Budgets keep using
+it completely unchanged, since those are always parent-currency totals.
+
+For rendering a specific account's or transaction's own (possibly foreign)
+amount, `MoneyFormat` gains one new method that formats a `Money` against an
+*explicit* `Currency` instead of the configured global one:
+
+```dart
+static String symbolIn(Money m, Currency c) => ...
+```
+
+(built the same way `_buildWithSymbol` already is, just not cached — this
+path is only used per-row, not hot enough to need the cached `NumberFormat`s
+the global path has).
+
+`MoneyText`/`BalanceText`/`AnimatedBalanceText`
+(`core/widgets/money_text.dart:124,174,195`) each gain an optional
+`Currency? currency` parameter. `null` (the default, and the only value
+every existing call site passes) renders exactly as today, via the global
+`MoneyFormat`. Only call sites that render one specific account's/
+transaction's amount — the transaction list tile, account detail balance,
+the add/edit transaction amount field, the transfer sheet's two amount
+fields — are updated to pass that row's `Currency` explicitly. Every
+aggregate-total call site (Dashboard cards, Net Worth, Reports, Budget
+progress, category totals) is left untouched, since those are already,
+correctly, parent-currency figures.
+
+## Balances, Net Worth, Reports, Budgets
+
+- **Per-account screens** (account detail, its own transaction list): always
+  native currency, unchanged mechanics — `currentBalance`/`openingBalance`
+  stay stored in the account's own currency, `recalculateBalances`
+  (`database.dart:2061`) is untouched.
+- **Net Worth / Accounts-screen grand total / Dashboard hero figure**
+  (`watchNetWorth`, `database.dart:2122`): changes from a plain `+` fold to
+  converting each account's `currentBalance` into the parent currency using
+  **today's** rate (`latestRate(account.currencyCode)`, no `asOf`) before
+  summing — a balance is a "right now" figure, so it uses the live rate,
+  not a snapshot.
+- **Reports/Stats aggregate charts, `watchSpendByCategory`**
+  (`database.dart:2209`) and similar category/income/expense totals: fold
+  using each transaction's `baseAmount` (its **snapshotted** rate) instead
+  of raw `amount`. Parent-currency transactions are unaffected (`baseAmount
+  == amount` when `currencyCode == null`).
+- **Category budgets / Envelope Mode**: no change — per the decision above,
+  these already only ever see parent-currency accounts, so `baseAmount ==
+  amount` for every row they touch.
+
+## Screens & UI
+
+### Currency module (Settings → Currency)
+
+New screen, `lib/features/settings/currency_settings_screen.dart`, linked
+from `settings_screen.dart` next to the existing entries. Shows:
+
+- The parent currency (today's `currencyProvider`, `providers.dart:666`,
+  relabelled "Parent currency" in this screen's copy — the underlying
+  setting and `setCurrencyCode` call are unchanged).
+- One row per currency currently used by any account, its latest rate
+  ("1 USD = 83.12 INR"), and when it was last updated. Reuses
+  `CurrencyPickerSheet`'s search list (`currency_picker_sheet.dart:9`) to
+  add a currency not yet in use.
+- Tapping a row opens a small history list (every `CurrencyRates` row for
+  that code, newest first) plus an "Add rate" action: pick an effective
+  date (defaults to today) and enter the new rate. This always inserts,
+  never edits a past row — preserves old snapshots' resolvability.
+
+### Accounts
+
+`add_account_sheet.dart` (fields currently built around
+`_type`/`_colorValue`/`_iconKey`, lines 54–143) gains a currency picker
+(reusing `CurrencyPickerSheet`'s list), defaulting to the parent currency,
+shown for every account type except a debit card / UPI instrument (which
+mirrors its linked account instead — no picker shown). Once the account has
+at least one transaction, the field becomes read-only with a short
+explanation, enforced in `AppDatabase.updateAccount` as well as the UI (not
+just a disabled control).
+
+### Transactions
+
+The add/edit transaction screen (`add_transaction_screen.dart`) resolves the
+selected account's currency and:
+
+- Shows the amount field in that currency's symbol/decimal places.
+- On save, if the account's `currencyCode` is non-null, resolves
+  `latestRate(code, asOf: date)` and writes `currencyCode`/
+  `fxRateToBaseMicros` onto the transaction; throws a clear, catchable error
+  if no rate exists yet as of that date (steers the user to the Currency
+  module first) rather than silently defaulting to 1:1.
+- For a transfer where source and destination currencies differ: after the
+  debit amount is entered, shows a second, editable "≈ you'll receive"
+  field pre-filled by converting through both accounts' current rates
+  (`amount → base → destination`), saved as `toAmount`/`toCurrencyCode`/
+  `toFxRateToBaseMicros` alongside the source leg's own snapshot.
+
+### Backups / PDF statements
+
+- JSON backups: the exporter already walks tables generically and stamps a
+  `schemaVersion` (`database.dart:4805`), so the six new columns ride along
+  automatically. Restoring an old (pre-v59) backup produces all-null new
+  columns — defined above to mean "parent currency" — so old backups restore
+  with identical behavior to today.
+- PDF statements (`statement_pdf.dart`, `report_pdf.dart`): each line shows
+  its transaction's native amount; a statement for a non-parent-currency
+  account gains one subtotal line converted to the parent currency (using
+  each line's own snapshotted rate, i.e. `Σ baseAmount`), so a statement
+  handed to someone using the parent currency still totals correctly.
+
+## Testing
+
+- Migration test (existing `migration_version_drift_test.dart` pattern):
+  v58→v59 upgrade adds `CurrencyRates` and the five new columns with safe
+  (null) defaults; an existing account/transaction round-trips unchanged.
+- `AppDatabase` unit tests: `latestRate` resolves the correct historical row
+  for a given `asOf` date; adding a transaction on a foreign-currency
+  account with no rate yet throws; `watchNetWorth` correctly converts a
+  mixed-currency set of accounts using the live rate; `watchSpendByCategory`
+  sums using each transaction's snapshotted rate, not the live one, after
+  the rate is changed post-hoc; a cross-currency transfer's `toAmount`
+  lands in the destination account's balance correctly;
+  `updateAccount` rejects a currency change once a transaction exists.
+- Widget tests: Currency settings screen lists rates and accepts a new one;
+  account creation offers/hides the currency picker correctly for a
+  debit-card account; the transfer sheet's auto-converted "≈ received"
+  field appears only when currencies differ and remains editable.
+
+## Migration/back-compat summary
+
+Purely additive: one new table, five new nullable columns (`accounts.currencyCode`
+plus four on `transactions`), one new rendering method
+(`MoneyFormat.symbolIn`), one new optional parameter on three widgets, and
+one changed fold (`+` → currency-aware sum) in `watchNetWorth` and
+`watchSpendByCategory`. Every existing account/transaction has `currencyCode
+== null`, meaning "parent currency," which is defined throughout this spec
+to behave identically to today. No existing table, column, route, or screen
+is removed or renamed (the Currency module is new; the existing currency
+picker screen keeps its current job of setting the parent currency and is
+reused, not replaced, inside the new module).

--- a/docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md
+++ b/docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md
@@ -60,6 +60,39 @@ assuming a single ambient currency — not a UI-only feature.
   editable only while the account is empty. Prevents its existing native
   amounts from becoming ambiguous.
 
+## Relationship to the already-shipped per-transaction annotation (GitHub #85)
+
+Since this spec was first drafted, `feat: foreign-currency annotation for
+transactions & auto rules (#85)` landed on `BETA` (schema v58→v59,
+`tables.dart:274-285,608-620`). It lets any transaction/recurring rule
+carry an optional `foreignCurrencyCode`/`foreignAmount` pair — "this ₹830
+charge was really $9.99" — purely as a display annotation; the rate is
+computed live (`amount / foreignAmount`), never stored, and `amount` stays
+the only figure that moves balances, Net Worth, envelopes or budgets. That
+issue's own author said explicitly they didn't need per-account currencies,
+just this — and the repo owner replied a fuller version was still coming
+separately. This spec is that fuller version, and schema v59 means this
+spec's migration starts at **v60**, not v59 (see Migration, below).
+
+The two features are complementary, not overlapping, and require exactly
+one small interaction fix: `foreignCurrencyCode`/`foreignAmount` exist to
+annotate a transaction on a **parent-currency** account. Once an account
+has its own native `currencyCode` (this spec), its transactions are
+already, natively, in that foreign currency — annotating one with a
+*second* foreign currency would be confusing and serves no purpose. So the
+add/edit transaction screen's existing "Foreign currency" toggle
+(`add_transaction_screen.dart`, added by #85) is hidden whenever the
+selected account itself has a non-null `currencyCode`. Nothing about the
+#85 columns, validation, or CSV/PDF export changes — this is a one-line
+UI condition, not a data-model change to that feature.
+
+`CurrencyPickerSheet` also already gained a reusable `pick()` static method
+and `initialCode`/`onSelected` constructor params as part of #85
+(`currency_picker_sheet.dart:32-46`), specifically so a caller can pick an
+arbitrary currency without touching `Settings.currencyCode`. This spec
+reuses that method as-is for both the account currency picker and the
+Currency module's "add a currency" action — no new picker widget needed.
+
 ## Non-goals
 
 - Live/fetched exchange rates (no API integration) — rates are entered
@@ -178,11 +211,11 @@ than pushing conversion into SQL.
 
 ### Migration
 
-Schema v58 → v59, appended to `onUpgrade` after the existing `if (from < 58)`
-block (`database.dart:463`):
+Schema v59 → v60, appended to `onUpgrade` after the #85 `if (from < 59)`
+block (`database.dart:467-487`):
 
 ```dart
-if (from < 59) {
+if (from < 60) {
   await m.createTable(currencyRates);
   await _addColumnIfMissing(m, accounts, accounts.currencyCode);
   await _addColumnIfMissing(m, transactions, transactions.currencyCode);
@@ -259,9 +292,9 @@ from `settings_screen.dart` next to the existing entries. Shows:
   relabelled "Parent currency" in this screen's copy — the underlying
   setting and `setCurrencyCode` call are unchanged).
 - One row per currency currently used by any account, its latest rate
-  ("1 USD = 83.12 INR"), and when it was last updated. Reuses
-  `CurrencyPickerSheet`'s search list (`currency_picker_sheet.dart:9`) to
-  add a currency not yet in use.
+  ("1 USD = 83.12 INR"), and when it was last updated. "Add a currency"
+  calls `CurrencyPickerSheet.pick()` (`currency_picker_sheet.dart:32`,
+  added by #85) to choose a code without touching `Settings.currencyCode`.
 - Tapping a row opens a small history list (every `CurrencyRates` row for
   that code, newest first) plus an "Add rate" action: pick an effective
   date (defaults to today) and enter the new rate. This always inserts,
@@ -271,7 +304,7 @@ from `settings_screen.dart` next to the existing entries. Shows:
 
 `add_account_sheet.dart` (fields currently built around
 `_type`/`_colorValue`/`_iconKey`, lines 54–143) gains a currency picker
-(reusing `CurrencyPickerSheet`'s list), defaulting to the parent currency,
+using `CurrencyPickerSheet.pick()`, defaulting to the parent currency,
 shown for every account type except a debit card / UPI instrument (which
 mirrors its linked account instead — no picker shown). Once the account has
 at least one transaction, the field becomes read-only with a short
@@ -324,7 +357,9 @@ selected account's currency and:
 - Widget tests: Currency settings screen lists rates and accepts a new one;
   account creation offers/hides the currency picker correctly for a
   debit-card account; the transfer sheet's auto-converted "≈ received"
-  field appears only when currencies differ and remains editable.
+  field appears only when currencies differ and remains editable; the
+  add/edit transaction screen's #85 "Foreign currency" toggle is hidden
+  once the selected account has its own non-null `currencyCode`.
 
 ## Migration/back-compat summary
 

--- a/docs/superpowers/specs/2026-09-06-category-templates-design.md
+++ b/docs/superpowers/specs/2026-09-06-category-templates-design.md
@@ -1,0 +1,75 @@
+# Category templates — design spec
+
+Date: 2026-09-06
+Status: implemented
+GitHub: #101
+
+## Background
+
+serrq's ask (#101): save the current category/sub-category structure as a
+reusable template, and switch between templates without losing the history of
+already-categorized transactions. Explicitly orthogonal to Ready to Assign —
+this is about which categories exist, not how money is allocated to them.
+
+## Why the existing archive rule makes this easy
+
+`Categories` already never hard-deletes — `AppDatabase.archiveCategory`'s own
+doc comment says why: "deleting a category orphans every past transaction
+that referenced it." Every transaction stores a `categoryId` pointing at a
+live `Categories` row, archived or not.
+
+That means "switch template" doesn't need to touch a single `Transactions`
+row. It only needs to change which `Categories` rows are archived vs. active:
+
+- A category in the *target* template but not currently active → created (or
+  unarchived + relabelled, if a same-named one already exists).
+- A category currently active but not in the *target* template → archived.
+  Every transaction that used it keeps pointing at the same (now-archived)
+  row, so reports and statements are untouched.
+
+Switching back later re-activates the old set the same way — nothing was
+ever deleted, so it's a free "revert."
+
+## Data model
+
+Two new tables, independent of `Categories`:
+
+- `CategoryTemplates` (id, name, createdAt) — one row per saved template.
+- `CategoryTemplateItems` (id, templateId, name, kind, colorValue, iconKey,
+  sortOrder, parentItemId) — a template's own category tree, exactly two
+  levels deep like `Categories.parentId`, but `parentItemId` resolves against
+  *other rows in the same template*, not live category ids. A template must
+  be applicable on a fresh install that has never seen these categories.
+
+## Matching: how "switch" maps template items onto live categories
+
+Live categories and template items are matched by
+`(kind, name.trim().toLowerCase(), parentName.trim().toLowerCase())` — not by
+id, since a template's ids are meaningless outside the template that made
+them. Two categories are "the same" if they have the same kind, name, and
+parent name.
+
+`applyCategoryTemplate`:
+1. Load the target template's items, parents before children.
+2. For each parent item: if a live top-level category matches, relabel it
+   (name/colour/icon) in place and record the match; otherwise create one.
+3. For each child item: same, nested under the (matched-or-created) live
+   parent from step 2.
+4. Any currently-active category (parent or child) that wasn't matched gets
+   archived — its transactions keep it, just hidden from new entries, same
+   as a manual archive.
+
+Re-nesting a live category that itself still has children (the two-level
+cap in `updateCategory`) can throw; `applyCategoryTemplate` catches that one
+case and keeps the category's existing parent rather than aborting the whole
+switch, so one awkward re-nest never blocks everything else in the template.
+
+## Non-goals (v1)
+
+- No community/shared template gallery — save/switch only, all local.
+- Templates aren't part of `exportAll`/`importAll` in this pass; they are a
+  local convenience over `Categories`, not part of the ledger itself, so a
+  ledger backup doesn't need to carry them for now. Revisit if requested.
+- No automatic re-run of budgets when a template switch archives a budgeted
+  category — `Budgets` already handles an archived category's row the same
+  way manual archiving does today.

--- a/lib/core/app_icons.dart
+++ b/lib/core/app_icons.dart
@@ -38,6 +38,100 @@ class AppIcons {
     'education': Icons.school_outlined,
     'travel': Icons.flight_outlined,
 
+    // food & drink
+    'coffee': Icons.coffee_outlined,
+    'cafe': Icons.local_cafe_outlined,
+    'fastfood': Icons.fastfood_outlined,
+    'breakfast': Icons.breakfast_dining_outlined,
+    'lunch': Icons.lunch_dining_outlined,
+    'dinner': Icons.dinner_dining_outlined,
+    'bakery': Icons.bakery_dining_outlined,
+    'icecream': Icons.icecream_outlined,
+    'pizza': Icons.local_pizza_outlined,
+    'ramen': Icons.ramen_dining_outlined,
+    'bar': Icons.local_bar_outlined,
+    'cake': Icons.cake_outlined,
+    'kitchen': Icons.kitchen_outlined,
+
+    // shopping
+    'mall': Icons.local_mall_outlined,
+    'store': Icons.storefront_outlined,
+    'clothing': Icons.checkroom_outlined,
+    'jewelry': Icons.diamond_outlined,
+
+    // transport
+    'car': Icons.directions_car_outlined,
+    'taxi': Icons.local_taxi_outlined,
+    'fuel': Icons.local_gas_station_outlined,
+    'train': Icons.train_outlined,
+    'subway': Icons.subway_outlined,
+    'bike': Icons.directions_bike_outlined,
+    'scooter': Icons.two_wheeler_outlined,
+    'parking': Icons.local_parking_outlined,
+    'car_repair': Icons.car_repair_outlined,
+
+    // home & utilities
+    'house': Icons.house_outlined,
+    'apartment': Icons.apartment_outlined,
+    'electricity': Icons.bolt_outlined,
+    'water': Icons.water_drop_outlined,
+    'wifi': Icons.wifi_outlined,
+    'gas': Icons.local_fire_department_outlined,
+    'plumbing': Icons.plumbing_outlined,
+    'repair': Icons.build_outlined,
+    'cleaning': Icons.cleaning_services_outlined,
+    'laundry': Icons.local_laundry_service_outlined,
+    'furniture': Icons.chair_outlined,
+
+    // health & fitness
+    'doctor': Icons.medical_services_outlined,
+    'pharmacy': Icons.local_pharmacy_outlined,
+    'vaccine': Icons.vaccines_outlined,
+    'fitness': Icons.fitness_center_outlined,
+    'spa': Icons.spa_outlined,
+    'therapy': Icons.psychology_outlined,
+
+    // entertainment & leisure
+    'gaming': Icons.sports_esports_outlined,
+    'music': Icons.music_note_outlined,
+    'theater': Icons.theater_comedy_outlined,
+    'festival': Icons.festival_outlined,
+    'park': Icons.park_outlined,
+    'beach': Icons.beach_access_outlined,
+    'hiking': Icons.hiking_outlined,
+    'soccer': Icons.sports_soccer_outlined,
+    'basketball': Icons.sports_basketball_outlined,
+    'pool': Icons.pool_outlined,
+    'streaming': Icons.live_tv_outlined,
+    'reading': Icons.menu_book_outlined,
+
+    // work & tech
+    'laptop': Icons.laptop_mac_outlined,
+    'computer': Icons.computer_outlined,
+    'phone': Icons.phone_iphone_outlined,
+    'tv': Icons.tv_outlined,
+    'headphones': Icons.headphones_outlined,
+    'print': Icons.print_outlined,
+    'briefcase': Icons.business_center_outlined,
+
+    // travel
+    'hotel': Icons.hotel_outlined,
+    'luggage': Icons.luggage_outlined,
+    'map': Icons.map_outlined,
+
+    // people & family
+    'baby': Icons.child_care_outlined,
+    'family': Icons.family_restroom_outlined,
+    'pets': Icons.pets_outlined,
+    'elderly': Icons.elderly_outlined,
+    'donation': Icons.volunteer_activism_outlined,
+
+    // finance & misc
+    'invoice': Icons.receipt_long_outlined,
+    'loyalty': Icons.loyalty_outlined,
+    'insurance': Icons.security_outlined,
+    'tax': Icons.request_quote_outlined,
+
     // misc
     'transfer': Icons.swap_horiz_rounded,
     'person': Icons.person_outline_rounded,

--- a/lib/core/branding/app_info.dart
+++ b/lib/core/branding/app_info.dart
@@ -19,8 +19,8 @@ class AppInfo {
       'on this device — nothing is ever uploaded.';
 
   // ── Version ────────────────────────────────────────────────────────────────
-  static const version = '1.5.1';
-  static const buildNumber = 17;
+  static const version = '1.6.0';
+  static const buildNumber = 18;
 
   /// `1.0.0 (build 1)` — the string a bug report should quote.
   static const versionLabel = '$version (build $buildNumber)';

--- a/lib/core/money.dart
+++ b/lib/core/money.dart
@@ -134,6 +134,12 @@ class MoneyFormat {
   /// `₹ ` — for an amount [TextField]'s `prefixText`. Empty when the symbol
   /// is hidden, so the field never shows a stale currency the user turned off.
   static String get inputPrefix => _showSymbol ? '${_currency.symbol} ' : '';
+
+  /// Formats [amount] using [currency]'s own symbol/decimal digits, without
+  /// touching the app-wide [configure]d currency — for displaying a foreign-
+  /// currency annotation (GitHub #85) alongside the home-currency amount.
+  static String forCurrency(Money amount, Currency currency) =>
+      _buildWithSymbol(currency).format(amount.rupees);
 }
 
 /// Amounts must render with tabular figures so columns of numbers line up.

--- a/lib/core/money.dart
+++ b/lib/core/money.dart
@@ -131,6 +131,14 @@ class MoneyFormat {
     return _buildWithSymbol(currency).format(m.rupees);
   }
 
+  /// [bare], but against an explicit [currency] instead of the globally
+  /// configured one — for a PDF statement's account-specific figures, where
+  /// [symbolIn]'s glyph can't be trusted to render (see `statement_pdf.dart`)
+  /// but the decimal-place/grouping rule still needs to match that account's
+  /// own currency, not the parent's.
+  static String bareIn(Money m, Currency currency) =>
+      _buildBare(currency).format(m.rupees);
+
   /// `12,50,000.00` — never carries a symbol, whatever the setting.
   static String bare(Money m) => _bare.format(m.rupees);
 

--- a/lib/core/money.dart
+++ b/lib/core/money.dart
@@ -119,6 +119,18 @@ class MoneyFormat {
   static String symbol(Money m) =>
       _showSymbol ? _withSymbol.format(m.rupees) : _bare.format(m.rupees);
 
+  /// Formats [m] against an explicit [currency], ignoring whatever
+  /// [MoneyFormat] is globally configured to. For rendering one specific
+  /// account's or transaction's own (possibly foreign) amount — every
+  /// aggregate total (Dashboard, Net Worth, Reports, Budgets) stays on
+  /// [symbol] as before, since those are always parent-currency figures.
+  /// Not cached like [_withSymbol] — this path is only ever used per-row,
+  /// not hot enough to need it.
+  static String symbolIn(Money m, Currency currency) {
+    if (!_showSymbol) return _buildBare(currency).format(m.rupees);
+    return _buildWithSymbol(currency).format(m.rupees);
+  }
+
   /// `12,50,000.00` — never carries a symbol, whatever the setting.
   static String bare(Money m) => _bare.format(m.rupees);
 

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -12,6 +12,7 @@ import '../../features/auto/archived_auto_rules_screen.dart';
 import '../../features/auto/auto_screen.dart';
 import '../../features/budgets/budget_detail_screen.dart';
 import '../../features/budgets/budgets_screen.dart';
+import '../../features/budgets/ready_to_assign_screen.dart';
 import '../../features/calendar/calendar_screen.dart';
 import '../../features/categories/categories_screen.dart';
 import '../../features/dashboard/dashboard_screen.dart';
@@ -155,6 +156,11 @@ final appRouter = GoRouter(
                   path: 'calendar',
                   parentNavigatorKey: _rootKey,
                   builder: (_, _) => const CalendarScreen(),
+                ),
+                GoRoute(
+                  path: 'ready-to-assign',
+                  parentNavigatorKey: _rootKey,
+                  builder: (_, _) => const ReadyToAssignScreen(),
                 ),
                 GoRoute(
                   path: 'settings',

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -15,6 +15,7 @@ import '../../features/budgets/budgets_screen.dart';
 import '../../features/budgets/ready_to_assign_screen.dart';
 import '../../features/calendar/calendar_screen.dart';
 import '../../features/categories/categories_screen.dart';
+import '../../features/categories/category_templates_screen.dart';
 import '../../features/dashboard/dashboard_screen.dart';
 import '../../features/data_export/backup_screen.dart';
 import '../../features/data_export/csv_import_screen.dart';
@@ -246,6 +247,13 @@ final appRouter = GoRouter(
                   path: 'categories',
                   parentNavigatorKey: _rootKey,
                   builder: (_, _) => const CategoriesScreen(),
+                  routes: [
+                    GoRoute(
+                      path: 'templates',
+                      parentNavigatorKey: _rootKey,
+                      builder: (_, _) => const CategoryTemplatesScreen(),
+                    ),
+                  ],
                 ),
                 GoRoute(
                   path: 'tags',

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -41,6 +41,7 @@ import '../../features/security/master_phrase_setup_screen.dart';
 import '../../features/security/master_phrase_verify_screen.dart';
 import '../../features/security/set_passcode_screen.dart';
 import '../../features/settings/bottom_nav_settings_screen.dart';
+import '../../features/settings/currency_settings_screen.dart';
 import '../../features/settings/dashboard_settings_screen.dart';
 import '../../features/settings/font_settings_screen.dart';
 import '../../features/settings/settings_screen.dart';
@@ -199,6 +200,11 @@ final appRouter = GoRouter(
                       path: 'dashboard',
                       parentNavigatorKey: _rootKey,
                       builder: (_, _) => const DashboardSettingsScreen(),
+                    ),
+                    GoRoute(
+                      path: 'currency',
+                      parentNavigatorKey: _rootKey,
+                      builder: (_, _) => const CurrencySettingsScreen(),
                     ),
                   ],
                 ),

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -46,6 +46,7 @@ import '../../features/settings/settings_screen.dart';
 import '../../features/settings/widgets_screen.dart';
 import '../../features/shopping/shopping_list_screen.dart';
 import '../../features/shopping/shopping_lists_screen.dart';
+import '../../features/tags/tag_groups_screen.dart';
 import '../../features/tags/tags_screen.dart';
 import '../../features/transactions/transaction_detail_screen.dart';
 import '../../features/transactions/transactions_screen.dart';
@@ -238,6 +239,13 @@ final appRouter = GoRouter(
                   path: 'tags',
                   parentNavigatorKey: _rootKey,
                   builder: (_, _) => const TagsScreen(),
+                  routes: [
+                    GoRoute(
+                      path: 'groups',
+                      parentNavigatorKey: _rootKey,
+                      builder: (_, _) => const TagGroupsScreen(),
+                    ),
+                  ],
                 ),
                 GoRoute(
                   path: 'stats',
@@ -399,12 +407,15 @@ final appRouter = GoRouter(
     ),
 
     // The ➕ button — a route pushed above the shell, not a tab.
-    // With an `id` it edits that transaction instead of creating one.
+    // With an `id` it edits that transaction instead of creating one. With a
+    // `duplicate` id instead, it prefills from that transaction but still
+    // creates a new one on save — see GitHub #92.
     GoRoute(
       path: '/add',
       parentNavigatorKey: _rootKey,
       builder: (_, state) {
         final id = state.uri.queryParameters['id'];
+        final duplicateId = state.uri.queryParameters['duplicate'];
         final type = switch (state.uri.queryParameters['type']) {
           'expense' => TxType.expense,
           'income' => TxType.income,
@@ -412,6 +423,9 @@ final appRouter = GoRouter(
         };
         return AddTransactionScreen(
           transactionId: id == null ? null : int.tryParse(id),
+          duplicateFromId: duplicateId == null
+              ? null
+              : int.tryParse(duplicateId),
           initialType: type,
         );
       },

--- a/lib/core/widgets/icon_picker_sheet.dart
+++ b/lib/core/widgets/icon_picker_sheet.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/providers.dart';
+import '../app_icons.dart';
+
+/// Opens the icon picker and resolves to the chosen key, or `null` if the
+/// sheet was dismissed without a pick. [accentColor] tints the selected tile
+/// and the "Frequently used" row — pass whatever colour the caller's own
+/// entity (category, account, ...) is using, so the preview matches what
+/// saving will actually look like.
+Future<String?> showIconPickerSheet(
+  BuildContext context, {
+  required String? selected,
+  Color? accentColor,
+}) {
+  return showModalBottomSheet<String>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    showDragHandle: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    ),
+    builder: (_) =>
+        _IconPickerSheet(selected: selected, accentColor: accentColor),
+  );
+}
+
+class _IconPickerSheet extends ConsumerStatefulWidget {
+  const _IconPickerSheet({required this.selected, required this.accentColor});
+
+  final String? selected;
+  final Color? accentColor;
+
+  @override
+  ConsumerState<_IconPickerSheet> createState() => _IconPickerSheetState();
+}
+
+class _IconPickerSheetState extends ConsumerState<_IconPickerSheet> {
+  final _controller = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// "car_repair" -> "Car repair" — the keys are already short, descriptive
+  /// slugs, so a plain underscore swap reads fine without a separate label
+  /// table to keep in sync with `AppIcons`.
+  static String _label(String key) {
+    final spaced = key.replaceAll('_', ' ');
+    return spaced[0].toUpperCase() + spaced.substring(1);
+  }
+
+  List<String> _filter(List<String> keys) {
+    final q = _query.trim().toLowerCase();
+    if (q.isEmpty) return keys;
+    return keys.where((k) => _label(k).toLowerCase().contains(q)).toList();
+  }
+
+  void _pick(String key) {
+    ref.read(dbProvider).recordIconUsed(key);
+    Navigator.of(context).pop(key);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = widget.accentColor ?? theme.colorScheme.secondary;
+    // Frequent keys can outlive an icon that's since been removed from
+    // AppIcons — drop anything that no longer resolves rather than showing a
+    // fallback circle for a key that isn't pickable any more.
+    final frequent = _filter(
+      ref
+          .watch(frequentIconKeysProvider)
+          .where(AppIcons.allKeys.contains)
+          .toList(),
+    );
+    final all = _filter(AppIcons.allKeys);
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
+      child: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              child: Text('Icon', style: theme.textTheme.titleLarge),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: TextField(
+                key: const Key('iconPickerSearch'),
+                controller: _controller,
+                autofocus: false,
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.search),
+                  hintText: 'Search icons',
+                  filled: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(14),
+                    borderSide: BorderSide.none,
+                  ),
+                  isDense: true,
+                ),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Flexible(
+              child: all.isEmpty
+                  ? Padding(
+                      padding: const EdgeInsets.all(32),
+                      child: Text(
+                        'No icon matches "$_query".',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    )
+                  : SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (frequent.isNotEmpty) ...[
+                            _sectionLabel(theme, 'Frequently used'),
+                            const SizedBox(height: 10),
+                            Wrap(
+                              spacing: 12,
+                              runSpacing: 12,
+                              children: [
+                                for (final k in frequent)
+                                  _iconTile(theme, k, accent),
+                              ],
+                            ),
+                            const SizedBox(height: 20),
+                          ],
+                          _sectionLabel(
+                            theme,
+                            _query.isEmpty ? 'All icons' : 'Results',
+                          ),
+                          const SizedBox(height: 10),
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: [
+                              for (final k in all) _iconTile(theme, k, accent),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionLabel(ThemeData theme, String text) => Text(
+    text,
+    style: theme.textTheme.labelLarge?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+      fontWeight: FontWeight.w600,
+    ),
+  );
+
+  Widget _iconTile(ThemeData theme, String key, Color accent) {
+    final isSelected = key == widget.selected;
+    return GestureDetector(
+      onTap: () => _pick(key),
+      child: Container(
+        width: 52,
+        height: 52,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: isSelected
+              ? accent.withValues(alpha: 0.15)
+              : theme.colorScheme.surface,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isSelected ? accent : theme.colorScheme.outline,
+            width: isSelected ? 2.5 : 1,
+          ),
+        ),
+        child: Icon(
+          AppIcons.resolve(key),
+          color: isSelected ? accent : theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/money_text.dart
+++ b/lib/core/widgets/money_text.dart
@@ -128,6 +128,7 @@ class MoneyText extends StatelessWidget {
     this.color,
     this.signed = false,
     this.compact = false,
+    this.currency,
     super.key,
   });
 
@@ -139,6 +140,11 @@ class MoneyText extends StatelessWidget {
   final bool signed;
   final bool compact;
 
+  /// Renders against this currency instead of the globally configured one —
+  /// for a specific account's/transaction's own (possibly foreign) amount.
+  /// Null (the default) renders exactly as before, via [MoneyFormat].
+  final Currency? currency;
+
   /// A fixed-width placeholder — never derived from the real digits, so the
   /// mask can't leak the amount's order of magnitude (a 3-digit vs 7-digit
   /// figure would otherwise be visibly distinguishable even hidden).
@@ -148,17 +154,22 @@ class MoneyText extends StatelessWidget {
   Widget build(BuildContext context) {
     // Rebuild whenever the currency setting changes — [MoneyFormat] is already
     // reconfigured by then, so the new symbol/grouping lands immediately.
+    // Irrelevant when [currency] is set explicitly, but depending
+    // unconditionally keeps this widget's rebuild behavior simple.
     CurrencyScope.depend(context);
     final hidden = AmountVisibilityScope.of(context);
+    final displayCurrency = currency ?? MoneyFormat.currency;
     final text = hidden
         ? (MoneyFormat.showSymbol
-            ? '${MoneyFormat.currency.symbol} $_maskGlyph'
+            ? '${displayCurrency.symbol} $_maskGlyph'
             : _maskGlyph)
         : compact
             ? MoneyFormat.compact(amount)
             : signed
-                ? MoneyFormat.signed(amount)
-                : MoneyFormat.symbol(amount);
+                ? _signedIn(amount, currency)
+                : currency == null
+                    ? MoneyFormat.symbol(amount)
+                    : MoneyFormat.symbolIn(amount, currency!);
 
     return Text(
       text,
@@ -168,20 +179,28 @@ class MoneyText extends StatelessWidget {
       ),
     );
   }
+
+  static String _signedIn(Money m, Currency? currency) {
+    if (currency == null) return MoneyFormat.signed(m);
+    final sign = m.isNegative ? '-' : '+';
+    return '$sign${MoneyFormat.symbolIn(m.abs, currency)}';
+  }
 }
 
 /// A balance. Negative renders red because on a credit card it means *owed*.
 class BalanceText extends StatelessWidget {
-  const BalanceText(this.amount, {this.style, super.key});
+  const BalanceText(this.amount, {this.style, this.currency, super.key});
 
   final Money amount;
   final TextStyle? style;
+  final Currency? currency;
 
   @override
   Widget build(BuildContext context) {
     return MoneyText(
       amount,
       style: style,
+      currency: currency,
       color: amount.isNegative ? AppColors.expense : null,
     );
   }
@@ -196,24 +215,27 @@ class AnimatedBalanceText extends StatelessWidget {
   const AnimatedBalanceText(
     this.amount, {
     this.style,
+    this.currency,
     this.duration = const Duration(milliseconds: 650),
     super.key,
   });
 
   final Money amount;
   final TextStyle? style;
+  final Currency? currency;
   final Duration duration;
 
   @override
   Widget build(BuildContext context) {
     if (MediaQuery.disableAnimationsOf(context)) {
-      return BalanceText(amount, style: style);
+      return BalanceText(amount, style: style, currency: currency);
     }
     return TweenAnimationBuilder<int>(
       tween: IntTween(begin: 0, end: amount.paise),
       duration: duration,
       curve: Curves.easeOutCubic,
-      builder: (context, paise, _) => BalanceText(Money(paise), style: style),
+      builder: (context, paise, _) =>
+          BalanceText(Money(paise), style: style, currency: currency),
     );
   }
 }

--- a/lib/data/currency_conversion.dart
+++ b/lib/data/currency_conversion.dart
@@ -1,0 +1,23 @@
+import '../core/money.dart';
+import 'database.dart';
+
+/// [CurrencyRates.rateToBaseMicros] and [Transactions.fxRateToBaseMicros]
+/// are both scaled by this so the rate is an exact integer, never a
+/// `double` — the same rule [Money] itself follows.
+const currencyRateScale = 1000000;
+
+/// Converts [amount] (in some other currency) into the parent currency
+/// using [rateToBaseMicros] — units of parent per 1 unit of that currency,
+/// scaled by [currencyRateScale].
+Money convertUsingRate(Money amount, int rateToBaseMicros) =>
+    Money((amount.paise * rateToBaseMicros) ~/ currencyRateScale);
+
+/// A transaction's value in the parent currency — computed, never stored
+/// redundantly. Every Reports/Stats/Budget total that must stay stable
+/// after a rate changes later (the "snapshot" design decision) folds over
+/// this instead of raw [TransactionRow.amount].
+extension TransactionBaseValue on TransactionRow {
+  Money get baseAmount => currencyCode == null
+      ? amount
+      : convertUsingRate(amount, fxRateToBaseMicros!);
+}

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -2543,21 +2543,29 @@ class AppDatabase extends _$AppDatabase {
       throw ArgumentError('Unknown currency code: $resolvedCurrencyCode.');
     }
 
-    return into(accounts).insert(
-      AccountsCompanion.insert(
-        name: name,
-        type: type,
-        cardKind: Value(cardKind),
-        linkedAccountId: Value(linkedAccountId),
-        bankName: Value(bankName),
-        last4: Value(last4),
-        colorValue: colorValue,
-        currencyCode: Value(resolvedCurrencyCode),
-        iconKey: iconKey,
-        openingBalance: opening,
-        currentBalance: opening,
-      ),
-    );
+    return transaction(() async {
+      // GitHub #100 — while Envelope is the primary budgeting system, every
+      // account joins the shared pool automatically, including a new one;
+      // there's no separate "turn on Envelope Mode" step to remember.
+      final envelopeByDefault =
+          (await getSettings()).budgetingMode == BudgetingMode.envelope;
+      return into(accounts).insert(
+        AccountsCompanion.insert(
+          name: name,
+          type: type,
+          cardKind: Value(cardKind),
+          linkedAccountId: Value(linkedAccountId),
+          bankName: Value(bankName),
+          last4: Value(last4),
+          colorValue: colorValue,
+          currencyCode: Value(resolvedCurrencyCode),
+          iconKey: iconKey,
+          openingBalance: opening,
+          currentBalance: opening,
+          envelopeMode: Value(envelopeByDefault),
+        ),
+      );
+    });
   }
 
   /// GitHub #88 — the only account field ever offered for editing after
@@ -4227,9 +4235,22 @@ class AppDatabase extends _$AppDatabase {
     settings,
   ).write(SettingsCompanion(moreScreenViewMode: Value(mode)));
 
-  Future<void> setBudgetingMode(BudgetingMode mode) => update(
-    settings,
-  ).write(SettingsCompanion(budgetingMode: Value(mode)));
+  /// Switching to [BudgetingMode.envelope] is meant to be the only step —
+  /// GitHub #100 asked that every account join the shared pool at once
+  /// rather than needing its own trip to Account Detail's Envelope Mode
+  /// toggle. Switching back to `budgets` leaves every account's flag as-is
+  /// (nothing here reads it while Budgets is the active mode), so flipping
+  /// back to Envelope later doesn't lose anything.
+  Future<void> setBudgetingMode(BudgetingMode mode) => transaction(() async {
+    await update(
+      settings,
+    ).write(SettingsCompanion(budgetingMode: Value(mode)));
+    if (mode == BudgetingMode.envelope) {
+      await update(
+        accounts,
+      ).write(const AccountsCompanion(envelopeMode: Value(true)));
+    }
+  });
 
   // ── Passcode ──────────────────────────────────────────────────────────────
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -177,7 +177,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 61;
+  int get schemaVersion => 62;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -517,6 +517,20 @@ class AppDatabase extends _$AppDatabase {
         // screen and Envelope Mode's Ready to Assign as the primary
         // budgeting system. Neither system's own data changes.
         await _addColumnIfMissing(m, settings, settings.budgetingMode);
+      }
+      if (from < 62) {
+        // GitHub #100 v2 — Budget (the ceiling system) is now always on for
+        // everyone; the old Budgets-vs-Envelope choice becomes a single
+        // Ready to Assign on/off switch instead. Backfill from the old
+        // enum rather than defaulting everyone to off, so an existing
+        // Envelope-mode user's accounts don't silently fall out of the pool.
+        await _addColumnIfMissing(m, settings, settings.rtaEnabled);
+        final current = await select(settings).getSingleOrNull();
+        if (current != null && current.budgetingMode == BudgetingMode.envelope) {
+          await update(
+            settings,
+          ).write(const SettingsCompanion(rtaEnabled: Value(true)));
+        }
       }
     },
     beforeOpen: (details) async {
@@ -2544,11 +2558,10 @@ class AppDatabase extends _$AppDatabase {
     }
 
     return transaction(() async {
-      // GitHub #100 — while Envelope is the primary budgeting system, every
-      // account joins the shared pool automatically, including a new one;
-      // there's no separate "turn on Envelope Mode" step to remember.
-      final envelopeByDefault =
-          (await getSettings()).budgetingMode == BudgetingMode.envelope;
+      // GitHub #100 v2 — while Ready to Assign is on, every account joins
+      // the shared pool automatically, including a new one; there's no
+      // separate "turn on" step to remember.
+      final envelopeByDefault = (await getSettings()).rtaEnabled;
       return into(accounts).insert(
         AccountsCompanion.insert(
           name: name,
@@ -2644,8 +2657,10 @@ class AppDatabase extends _$AppDatabase {
   /// with transaction history would orphan every row that named it, exactly
   /// like [archiveCategory] above. Removal only ever succeeds on an account
   /// nothing has touched yet — no transaction, no debit card drawing from it,
-  /// no reminder or merchant rule naming it.
-  Future<void> deleteAccount(int id) async {
+  /// no reminder or merchant rule naming it. Returns whether deleting it
+  /// also auto-disabled Ready to Assign (it was the last pool account) — see
+  /// [_maybeAutoDisableRta].
+  Future<bool> deleteAccount(int id) async {
     final linkedCard = await (select(
       accounts,
     )..where((a) => a.linkedAccountId.equals(id))).getSingleOrNull();
@@ -2688,7 +2703,7 @@ class AppDatabase extends _$AppDatabase {
         'that in Settings first.',
       );
     }
-    await transaction(() async {
+    return transaction(() async {
       // A goal account's own target/deadline row has no reason to outlive
       // it — nothing else ever references GoalDetails. Same for a credit
       // card's statement-tracking row.
@@ -2697,6 +2712,7 @@ class AppDatabase extends _$AppDatabase {
         creditCardDetails,
       )..where((c) => c.accountId.equals(id))).go();
       await (delete(accounts)..where((a) => a.id.equals(id))).go();
+      return _maybeAutoDisableRta();
     });
   }
 
@@ -2891,11 +2907,36 @@ class AppDatabase extends _$AppDatabase {
   /// Per-account, not global — every other account keeps working exactly as
   /// it does today. Switching this off never deletes [Allocations] rows (see
   /// [Allocations] doc); they simply stop being read while it's off, and
-  /// reappear if it's switched back on.
-  Future<void> setEnvelopeMode(int accountId, bool enabled) =>
-      (update(accounts)..where((a) => a.id.equals(accountId))).write(
-        AccountsCompanion(envelopeMode: Value(enabled)),
-      );
+  /// reappear if it's switched back on. Returns whether turning it off also
+  /// auto-disabled Ready to Assign (it was the last pool account) — see
+  /// [_maybeAutoDisableRta].
+  Future<bool> setEnvelopeMode(int accountId, bool enabled) =>
+      transaction(() async {
+        await (update(accounts)..where((a) => a.id.equals(accountId))).write(
+          AccountsCompanion(envelopeMode: Value(enabled)),
+        );
+        return enabled ? false : _maybeAutoDisableRta();
+      });
+
+  /// Turns Ready to Assign off, automatically, the moment its pool would
+  /// otherwise go empty — called from inside the same [transaction] as
+  /// whatever just removed the last pool account ([setEnvelopeMode] turning
+  /// one off, or [deleteAccount] removing one). Returns whether it actually
+  /// fired, so the caller can surface a non-blocking notice; never throws
+  /// and never blocks the action that triggered it (GitHub #100 v2 — no
+  /// confirmation prompt on the account-side action, only a heads-up after).
+  Future<bool> _maybeAutoDisableRta() async {
+    final settingsRow = await getSettings();
+    if (!settingsRow.rtaEnabled) return false;
+    final remaining = await (select(
+      accounts,
+    )..where((a) => a.envelopeMode.equals(true))).get();
+    if (remaining.isNotEmpty) return false;
+    await update(
+      settings,
+    ).write(const SettingsCompanion(rtaEnabled: Value(false)));
+    return true;
+  }
 
   /// Every allocation, across every account — the provider layer sums these
   /// per (account, category) rather than this querying once per pair.
@@ -4235,17 +4276,18 @@ class AppDatabase extends _$AppDatabase {
     settings,
   ).write(SettingsCompanion(moreScreenViewMode: Value(mode)));
 
-  /// Switching to [BudgetingMode.envelope] is meant to be the only step —
-  /// GitHub #100 asked that every account join the shared pool at once
-  /// rather than needing its own trip to Account Detail's Envelope Mode
-  /// toggle. Switching back to `budgets` leaves every account's flag as-is
-  /// (nothing here reads it while Budgets is the active mode), so flipping
-  /// back to Envelope later doesn't lose anything.
-  Future<void> setBudgetingMode(BudgetingMode mode) => transaction(() async {
+  /// Turning Ready to Assign on is meant to be the only step — GitHub #100
+  /// asked that every account join the shared pool at once rather than
+  /// needing its own trip to Account Detail's on-budget toggle; users opt
+  /// individual accounts back out from there afterward. Turning it off
+  /// leaves every account's [Accounts.envelopeMode] flag as-is (nothing
+  /// reads it while RTA is off), so turning it back on re-enrolls everyone
+  /// anyway per the branch below — no data is lost either direction.
+  Future<void> setRtaEnabled(bool enabled) => transaction(() async {
     await update(
       settings,
-    ).write(SettingsCompanion(budgetingMode: Value(mode)));
-    if (mode == BudgetingMode.envelope) {
+    ).write(SettingsCompanion(rtaEnabled: Value(enabled)));
+    if (enabled) {
       await update(
         accounts,
       ).write(const AccountsCompanion(envelopeMode: Value(true)));

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -27,9 +27,8 @@ part 'database.g.dart';
 Money accountMovement(TransactionRow tx, Set<int> ownIds) => switch (tx.type) {
   TxType.income || TxType.personIn => tx.amount,
   TxType.expense || TxType.personOut => -tx.amount,
-  TxType.transfer => ownIds.contains(tx.accountId)
-      ? -tx.amount
-      : (tx.toAmount ?? tx.amount),
+  TxType.transfer =>
+    ownIds.contains(tx.accountId) ? -tx.amount : (tx.toAmount ?? tx.amount),
 };
 
 /// The gap between automatic backups for a given schedule. `monthly` is
@@ -152,6 +151,8 @@ typedef CombinedStatementLine = ({
     OcrCorrections,
     CreditCardDetails,
     CurrencyRates,
+    CategoryTemplates,
+    CategoryTemplateItems,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -177,7 +178,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 62;
+  int get schemaVersion => 63;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -374,11 +375,7 @@ class AppDatabase extends _$AppDatabase {
           settings,
           settings.masterPhraseAttemptThreshold,
         );
-        await _addColumnIfMissing(
-          m,
-          settings,
-          settings.failedPasscodeAttempts,
-        );
+        await _addColumnIfMissing(m, settings, settings.failedPasscodeAttempts);
       }
       if (from < 42) {
         await _addColumnIfMissing(m, settings, settings.showBottomNavLabels);
@@ -407,7 +404,11 @@ class AppDatabase extends _$AppDatabase {
         await _addColumnIfMissing(m, recurringRules, recurringRules.note);
       }
       if (from < 48) {
-        await _addColumnIfMissing(m, recurringRules, recurringRules.promoAmount);
+        await _addColumnIfMissing(
+          m,
+          recurringRules,
+          recurringRules.promoAmount,
+        );
         await _addColumnIfMissing(
           m,
           recurringRules,
@@ -501,11 +502,7 @@ class AppDatabase extends _$AppDatabase {
           transactions.fxRateToBaseMicros,
         );
         await _addColumnIfMissing(m, transactions, transactions.toAmount);
-        await _addColumnIfMissing(
-          m,
-          transactions,
-          transactions.toCurrencyCode,
-        );
+        await _addColumnIfMissing(m, transactions, transactions.toCurrencyCode);
         await _addColumnIfMissing(
           m,
           transactions,
@@ -526,11 +523,17 @@ class AppDatabase extends _$AppDatabase {
         // Envelope-mode user's accounts don't silently fall out of the pool.
         await _addColumnIfMissing(m, settings, settings.rtaEnabled);
         final current = await select(settings).getSingleOrNull();
-        if (current != null && current.budgetingMode == BudgetingMode.envelope) {
+        if (current != null &&
+            current.budgetingMode == BudgetingMode.envelope) {
           await update(
             settings,
           ).write(const SettingsCompanion(rtaEnabled: Value(true)));
         }
+      }
+      if (from < 63) {
+        // GitHub #101 — saveable, switchable category templates.
+        await m.createTable(categoryTemplates);
+        await m.createTable(categoryTemplateItems);
       }
     },
     beforeOpen: (details) async {
@@ -894,8 +897,9 @@ class AppDatabase extends _$AppDatabase {
         await _adjust(t.accountId, -amt);
       case TxType.transfer:
         await _adjust(t.accountId, -amt);
-        final creditAmt =
-            t.toAmount == null ? amt : Money(t.toAmount!.paise * sign);
+        final creditAmt = t.toAmount == null
+            ? amt
+            : Money(t.toAmount!.paise * sign);
         await _adjust(t.toAccountId!, creditAmt);
     }
   }
@@ -1040,7 +1044,10 @@ class AppDatabase extends _$AppDatabase {
   /// downstream total, so this fails loudly instead and the UI is
   /// responsible for steering the user to the Currency settings screen
   /// first.
-  Future<(String?, int?)> _resolveTxCurrency(int accountId, DateTime date) async {
+  Future<(String?, int?)> _resolveTxCurrency(
+    int accountId,
+    DateTime date,
+  ) async {
     final account = await (select(
       accounts,
     )..where((a) => a.id.equals(accountId))).getSingle();
@@ -1552,9 +1559,9 @@ class AppDatabase extends _$AppDatabase {
   )..orderBy([(g) => OrderingTerm(expression: g.name)])).watch();
 
   Future<int> addTagGroup({required String name, required int colorValue}) =>
-      into(tagGroups).insert(
-        TagGroupsCompanion.insert(name: name, colorValue: colorValue),
-      );
+      into(
+        tagGroups,
+      ).insert(TagGroupsCompanion.insert(name: name, colorValue: colorValue));
 
   Future<void> updateTagGroup({
     required int id,
@@ -1592,9 +1599,9 @@ class AppDatabase extends _$AppDatabase {
         tagGroupTags,
       )..where((t) => t.groupId.equals(groupId))).go();
       for (final tagId in tagIds) {
-        await into(tagGroupTags).insert(
-          TagGroupTagsCompanion.insert(groupId: groupId, tagId: tagId),
-        );
+        await into(
+          tagGroupTags,
+        ).insert(TagGroupTagsCompanion.insert(groupId: groupId, tagId: tagId));
       }
     });
   }
@@ -1757,15 +1764,13 @@ class AppDatabase extends _$AppDatabase {
 
   // ── Credit card statements (GitHub #91) ─────────────────────────────────
 
-  Future<CreditCardDetailRow?> getCreditCardDetails(int accountId) =>
-      (select(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).getSingleOrNull();
+  Future<CreditCardDetailRow?> getCreditCardDetails(int accountId) => (select(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).getSingleOrNull();
 
-  Stream<CreditCardDetailRow?> watchCreditCardDetails(int accountId) =>
-      (select(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).watchSingleOrNull();
+  Stream<CreditCardDetailRow?> watchCreditCardDetails(int accountId) => (select(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).watchSingleOrNull();
 
   /// Every credit card currently tracking a statement cycle — what
   /// [NotificationService.syncCreditCardReminders] schedules a due-date
@@ -1805,10 +1810,9 @@ class AppDatabase extends _$AppDatabase {
 
   /// Turns tracking back off — the card itself is untouched, only the
   /// cycle it was reporting against.
-  Future<void> deleteCreditCardDetails(int accountId) =>
-      (delete(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).go();
+  Future<void> deleteCreditCardDetails(int accountId) => (delete(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).go();
 
   /// The last real day of [year]/[month] if [day] overshoots it (e.g. the
   /// 31st in a 30-day month) — the same snapping [_nextOccurrence] applies
@@ -2257,10 +2261,7 @@ class AppDatabase extends _$AppDatabase {
   /// to now) — `null` if none has been entered yet as of that date. This is
   /// what a transaction snapshots at post time, and what a live figure
   /// (Net Worth) resolves with `asOf` left at its default.
-  Future<CurrencyRateRow?> latestRate(
-    String currencyCode, {
-    DateTime? asOf,
-  }) {
+  Future<CurrencyRateRow?> latestRate(String currencyCode, {DateTime? asOf}) {
     final cutoff = asOf ?? DateTime.now();
     return (select(currencyRates)
           ..where(
@@ -2269,8 +2270,10 @@ class AppDatabase extends _$AppDatabase {
                 r.effectiveAt.isSmallerOrEqualValue(cutoff),
           )
           ..orderBy([
-            (r) =>
-                OrderingTerm(expression: r.effectiveAt, mode: OrderingMode.desc),
+            (r) => OrderingTerm(
+              expression: r.effectiveAt,
+              mode: OrderingMode.desc,
+            ),
           ])
           ..limit(1))
         .getSingleOrNull();
@@ -2343,23 +2346,22 @@ class AppDatabase extends _$AppDatabase {
   /// has been entered for its currency yet, its raw balance is added
   /// unconverted rather than dropping it or throwing, so an incomplete
   /// Currency setup never breaks the dashboard.
-  Stream<Money> watchNetWorth() => watchBalanceHoldingAccounts().asyncMap((
-    rows,
-  ) async {
-    var total = const Money.zero();
-    for (final a in rows) {
-      if (!a.includeInNetWorth) continue;
-      if (a.currencyCode == null) {
-        total += a.currentBalance;
-        continue;
-      }
-      final rate = await latestRate(a.currencyCode!);
-      total += rate == null
-          ? a.currentBalance
-          : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
-    }
-    return total;
-  });
+  Stream<Money> watchNetWorth() =>
+      watchBalanceHoldingAccounts().asyncMap((rows) async {
+        var total = const Money.zero();
+        for (final a in rows) {
+          if (!a.includeInNetWorth) continue;
+          if (a.currencyCode == null) {
+            total += a.currentBalance;
+            continue;
+          }
+          final rate = await latestRate(a.currencyCode!);
+          total += rate == null
+              ? a.currentBalance
+              : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
+        }
+        return total;
+      });
 
   /// Flips whether [id]'s balance counts toward [watchNetWorth] — the toggle
   /// behind Settings > Customize Dashboard.
@@ -3034,9 +3036,9 @@ class AppDatabase extends _$AppDatabase {
 
   // ── Groups CRUD ───────────────────────────────────────────────────────────
 
-  Future<int> addGroup(String name, {String? note}) => into(groups).insert(
-    GroupsCompanion.insert(name: name, note: Value(note)),
-  );
+  Future<int> addGroup(String name, {String? note}) => into(
+    groups,
+  ).insert(GroupsCompanion.insert(name: name, note: Value(note)));
 
   Future<void> updateGroup({
     required int id,
@@ -3073,7 +3075,9 @@ class AppDatabase extends _$AppDatabase {
   /// history. Anything used must be archived instead.
   Future<void> deleteGroup(int id) async {
     if (await countExpensesForGroup(id) > 0) {
-      throw ArgumentError('This group has expense history — archive it instead.');
+      throw ArgumentError(
+        'This group has expense history — archive it instead.',
+      );
     }
     await transaction(() async {
       await (delete(groupMembers)..where((m) => m.groupId.equals(id))).go();
@@ -3101,11 +3105,12 @@ class AppDatabase extends _$AppDatabase {
   /// [addGroupExpense] distributes a rounding remainder in, so which member
   /// gets an extra paisa is stable, not arbitrary.
   Stream<List<PersonRow>> watchGroupMembers(int groupId) {
-    final query = select(groupMembers).join([
-      innerJoin(persons, persons.id.equalsExp(groupMembers.personId)),
-    ])
-      ..where(groupMembers.groupId.equals(groupId))
-      ..orderBy([OrderingTerm.asc(groupMembers.id)]);
+    final query =
+        select(groupMembers).join([
+            innerJoin(persons, persons.id.equalsExp(groupMembers.personId)),
+          ])
+          ..where(groupMembers.groupId.equals(groupId))
+          ..orderBy([OrderingTerm.asc(groupMembers.id)]);
     return query.watch().map(
       (rows) => rows.map((r) => r.readTable(persons)).toList(),
     );
@@ -3759,14 +3764,15 @@ class AppDatabase extends _$AppDatabase {
               dayOfMonth: rule.dayOfMonth,
             );
           }
-          await (update(recurringRules)..where((r) => r.id.equals(rule.id)))
-              .write(
-                RecurringRulesCompanion(
-                  nextDueDate: Value(next),
-                  promoAmount: Value(promoAmount),
-                  promoOccurrencesLeft: Value(promoLeft),
-                ),
-              );
+          await (update(
+            recurringRules,
+          )..where((r) => r.id.equals(rule.id))).write(
+            RecurringRulesCompanion(
+              nextDueDate: Value(next),
+              promoAmount: Value(promoAmount),
+              promoOccurrencesLeft: Value(promoLeft),
+            ),
+          );
         });
       } catch (_) {
         // One rule that can no longer post (its account stopped being
@@ -4268,9 +4274,8 @@ class AppDatabase extends _$AppDatabase {
   Future<void> setRevolutEnabled(bool value) =>
       update(settings).write(SettingsCompanion(revolutEnabled: Value(value)));
 
-  Future<void> setLockScreenStyle(LockScreenStyle style) => update(
-    settings,
-  ).write(SettingsCompanion(lockScreenStyle: Value(style)));
+  Future<void> setLockScreenStyle(LockScreenStyle style) =>
+      update(settings).write(SettingsCompanion(lockScreenStyle: Value(style)));
 
   Future<void> setMoreScreenViewMode(MoreScreenViewMode mode) => update(
     settings,
@@ -4284,9 +4289,7 @@ class AppDatabase extends _$AppDatabase {
   /// reads it while RTA is off), so turning it back on re-enrolls everyone
   /// anyway per the branch below — no data is lost either direction.
   Future<void> setRtaEnabled(bool enabled) => transaction(() async {
-    await update(
-      settings,
-    ).write(SettingsCompanion(rtaEnabled: Value(enabled)));
+    await update(settings).write(SettingsCompanion(rtaEnabled: Value(enabled)));
     if (enabled) {
       await update(
         accounts,
@@ -4391,9 +4394,9 @@ class AppDatabase extends _$AppDatabase {
   /// fall back to.
   Future<void> setMasterPhraseAttemptThreshold(int attempts) async {
     if ((await getSettings()).masterPhraseHash == null) return;
-    await update(settings).write(
-      SettingsCompanion(masterPhraseAttemptThreshold: Value(attempts)),
-    );
+    await update(
+      settings,
+    ).write(SettingsCompanion(masterPhraseAttemptThreshold: Value(attempts)));
   }
 
   /// Increments the persisted wrong-PIN counter and returns the new count —
@@ -4468,9 +4471,8 @@ class AppDatabase extends _$AppDatabase {
     settings,
   ).write(SettingsCompanion(showBottomNavLabels: Value(value)));
 
-  Future<void> setHoldMenuEnabled(bool value) => update(
-    settings,
-  ).write(SettingsCompanion(holdMenuEnabled: Value(value)));
+  Future<void> setHoldMenuEnabled(bool value) =>
+      update(settings).write(SettingsCompanion(holdMenuEnabled: Value(value)));
 
   Future<void> setHoldMenuSlots(List<String> ids) async {
     if (ids.length != 3 || ids.toSet().length != 3) {
@@ -4487,9 +4489,9 @@ class AppDatabase extends _$AppDatabase {
   /// Clamped to a sane range here, not just in the settings slider — this is
   /// the only path a stray value (a bad restore, a future scripted call)
   /// could take to reach the column.
-  Future<void> setExtraBottomInset(int px) => update(settings).write(
-    SettingsCompanion(extraBottomInset: Value(px.clamp(0, 40))),
-  );
+  Future<void> setExtraBottomInset(int px) => update(
+    settings,
+  ).write(SettingsCompanion(extraBottomInset: Value(px.clamp(0, 40))));
 
   /// Bumps [key] to the front of `Settings.frequentIconKeys` — the icon sheet
   /// calls this whenever an icon is picked. Capped at 12 so the "Frequently
@@ -4804,6 +4806,220 @@ class AppDatabase extends _$AppDatabase {
     )..where((t) => t.categoryId.equals(categoryId))).get();
     return rows.length;
   }
+
+  // ── Category templates (GitHub #101) ────────────────────────────────────
+  //
+  // A template is a named snapshot of a category/sub-category structure.
+  // Switching to one never touches `Transactions` — it only changes which
+  // `Categories` rows are archived vs. active, the same as a manual archive.
+  // See docs/superpowers/specs/2026-09-06-category-templates-design.md.
+
+  /// Matches a live category or template item to "the same" one elsewhere —
+  /// by kind, name and parent *name*, never by id (a template's own ids are
+  /// meaningless once applied on a different device/dataset).
+  String _categoryMatchKey(CategoryKind kind, String name, String? parentName) {
+    final normalizedParent = parentName?.trim().toLowerCase() ?? '';
+    return '${kind.name}|$normalizedParent|${name.trim().toLowerCase()}';
+  }
+
+  Stream<List<CategoryTemplateRow>> watchCategoryTemplates() =>
+      (select(categoryTemplates)..orderBy([
+            (t) =>
+                OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+          ]))
+          .watch();
+
+  Stream<List<CategoryTemplateItemRow>> watchCategoryTemplateItems(
+    int templateId,
+  ) =>
+      (select(categoryTemplateItems)
+            ..where((i) => i.templateId.equals(templateId))
+            ..orderBy([(i) => OrderingTerm(expression: i.sortOrder)]))
+          .watch();
+
+  /// Snapshots every currently-active category (both kinds) into a brand new
+  /// template. A child whose parent isn't itself active (a dangling
+  /// `parentId`, same edge case `_flatten` in the Categories screen guards)
+  /// is skipped rather than saved half-nested.
+  Future<int> saveCategoriesAsTemplate(String name) => transaction(() async {
+    final templateId = await into(
+      categoryTemplates,
+    ).insert(CategoryTemplatesCompanion.insert(name: name));
+
+    final active = await (select(
+      categories,
+    )..where((c) => c.isArchived.equals(false))).get();
+    final parents = active.where((c) => c.parentId == null).toList();
+    final itemIdByCategoryId = <int, int>{};
+
+    for (final p in parents) {
+      final itemId = await into(categoryTemplateItems).insert(
+        CategoryTemplateItemsCompanion.insert(
+          templateId: templateId,
+          name: p.name,
+          kind: p.kind,
+          colorValue: p.colorValue,
+          iconKey: p.iconKey,
+          sortOrder: Value(p.sortOrder),
+        ),
+      );
+      itemIdByCategoryId[p.id] = itemId;
+    }
+    for (final c in active.where((c) => c.parentId != null)) {
+      final parentItemId = itemIdByCategoryId[c.parentId];
+      if (parentItemId == null) continue;
+      await into(categoryTemplateItems).insert(
+        CategoryTemplateItemsCompanion.insert(
+          templateId: templateId,
+          name: c.name,
+          kind: c.kind,
+          colorValue: c.colorValue,
+          iconKey: c.iconKey,
+          sortOrder: Value(c.sortOrder),
+          parentItemId: Value(parentItemId),
+        ),
+      );
+    }
+    return templateId;
+  });
+
+  Future<void> renameCategoryTemplate(int id, String name) =>
+      (update(categoryTemplates)..where((t) => t.id.equals(id))).write(
+        CategoryTemplatesCompanion(name: Value(name)),
+      );
+
+  Future<void> deleteCategoryTemplate(int id) => transaction(() async {
+    await (delete(
+      categoryTemplateItems,
+    )..where((i) => i.templateId.equals(id))).go();
+    await (delete(categoryTemplates)..where((t) => t.id.equals(id))).go();
+  });
+
+  /// Switches the live category set to match [templateId]'s structure,
+  /// without ever touching a transaction:
+  ///
+  /// - A template item that matches an existing category (by
+  ///   [_categoryMatchKey], active **or** archived) relabels that category
+  ///   in place (name, colour, icon) and unarchives it if needed, instead of
+  ///   making a duplicate — this is what makes switching back to a template
+  ///   used before a free "revert" rather than a fresh rebuild.
+  /// - A template item with no match gets created fresh.
+  /// - A live active category that no template item matches gets archived —
+  ///   exactly like a manual archive, so its transactions keep it and only
+  ///   disappear from new-entry pickers.
+  Future<void> applyCategoryTemplate(int templateId) => transaction(() async {
+    final items = await (select(
+      categoryTemplateItems,
+    )..where((i) => i.templateId.equals(templateId))).get();
+    if (items.isEmpty) {
+      throw ArgumentError('This template has no categories to switch to.');
+    }
+    final itemsById = {for (final i in items) i.id: i};
+    String keyOf(CategoryTemplateItemRow i) {
+      final parentName = i.parentItemId == null
+          ? null
+          : itemsById[i.parentItemId]?.name;
+      return _categoryMatchKey(i.kind, i.name, parentName);
+    }
+
+    final all = await select(categories).get();
+    final byId = {for (final c in all) c.id: c};
+    String keyOfCategory(CategoryRow c) {
+      final parentName = c.parentId == null ? null : byId[c.parentId]?.name;
+      return _categoryMatchKey(c.kind, c.name, parentName);
+    }
+
+    // Archived rows first, active rows second — if a key somehow matches
+    // both (a stray duplicate), the map ends up pointing at the active one,
+    // so an already-live category is never displaced by reactivating a
+    // stale archived duplicate of itself.
+    final byKey = <String, CategoryRow>{};
+    for (final c in all.where((c) => c.isArchived)) {
+      byKey[keyOfCategory(c)] = c;
+    }
+    for (final c in all.where((c) => !c.isArchived)) {
+      byKey[keyOfCategory(c)] = c;
+    }
+    final active = all.where((c) => !c.isArchived).toList();
+
+    final matchedIds = <int>{};
+    final liveIdByItemId = <int, int>{};
+
+    Future<void> reuse(
+      CategoryRow existing,
+      CategoryTemplateItemRow item,
+      Value<int?> parentId,
+    ) async {
+      matchedIds.add(existing.id);
+      if (existing.isArchived) {
+        await (update(categories)..where((cc) => cc.id.equals(existing.id)))
+            .write(const CategoriesCompanion(isArchived: Value(false)));
+      }
+      try {
+        await updateCategory(
+          id: existing.id,
+          name: item.name,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+          parentId: parentId,
+        );
+      } on ArgumentError {
+        // Most likely: `existing` still has children of its own, so the
+        // two-level cap in `updateCategory` refuses to nest it under
+        // someone else. Keep its current placement rather than aborting the
+        // whole switch over one awkward re-nest.
+        if (parentId.present && parentId.value != null) {
+          await updateCategory(
+            id: existing.id,
+            name: item.name,
+            colorValue: item.colorValue,
+            iconKey: item.iconKey,
+          );
+        } else {
+          rethrow;
+        }
+      }
+    }
+
+    // Parents first, so children below can resolve their live parent id.
+    for (final item in items.where((i) => i.parentItemId == null)) {
+      final existing = byKey[keyOf(item)];
+      if (existing != null) {
+        liveIdByItemId[item.id] = existing.id;
+        await reuse(existing, item, const Value(null));
+      } else {
+        liveIdByItemId[item.id] = await addCategory(
+          name: item.name,
+          kind: item.kind,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+        );
+      }
+    }
+    for (final item in items.where((i) => i.parentItemId != null)) {
+      final existing = byKey[keyOf(item)];
+      final liveParentId = liveIdByItemId[item.parentItemId];
+      if (existing != null) {
+        await reuse(existing, item, Value(liveParentId));
+      } else if (liveParentId != null) {
+        await addCategory(
+          name: item.name,
+          kind: item.kind,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+          parentId: liveParentId,
+        );
+      }
+    }
+
+    for (final c in active) {
+      if (!matchedIds.contains(c.id)) {
+        await (update(categories)..where((cc) => cc.id.equals(c.id))).write(
+          const CategoriesCompanion(isArchived: Value(true)),
+        );
+      }
+    }
+  });
 
   // ── Per-account history ───────────────────────────────────────────────────
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -1007,6 +1007,30 @@ class AppDatabase extends _$AppDatabase {
     }
   }
 
+  /// Resolves what [accountId] should stamp onto a transaction posted on
+  /// [date]: `(null, null)` for a parent-currency account, or its currency
+  /// code plus the rate snapshot for a foreign-currency one. Throws if the
+  /// account is foreign-currency but no rate has been entered yet as of
+  /// that date — silently falling back to 1:1 would quietly corrupt every
+  /// downstream total, so this fails loudly instead and the UI is
+  /// responsible for steering the user to the Currency settings screen
+  /// first.
+  Future<(String?, int?)> _resolveTxCurrency(int accountId, DateTime date) async {
+    final account = await (select(
+      accounts,
+    )..where((a) => a.id.equals(accountId))).getSingle();
+    final code = account.currencyCode;
+    if (code == null) return (null, null);
+    final rate = await latestRate(code, asOf: date);
+    if (rate == null) {
+      throw ArgumentError(
+        'No exchange rate set for $code yet — add one in Settings > '
+        'Currency before posting this transaction.',
+      );
+    }
+    return (code, rate.rateToBaseMicros);
+  }
+
   Future<int> addTransaction({
     required TxType type,
     required Money amount,
@@ -1036,6 +1060,25 @@ class AppDatabase extends _$AppDatabase {
       foreignAmount: foreignAmount,
     );
 
+    final (sourceCode, sourceRate) = await _resolveTxCurrency(accountId, date);
+
+    String? toCode;
+    int? toRate;
+    Money? toAmt;
+    if (type == TxType.transfer && toAccountId != null) {
+      final resolved = await _resolveTxCurrency(toAccountId, date);
+      toCode = resolved.$1;
+      toRate = resolved.$2;
+      if (toCode != sourceCode) {
+        final sourceBase = sourceCode == null
+            ? amount
+            : convertUsingRate(amount, sourceRate!);
+        toAmt = toCode == null
+            ? sourceBase
+            : Money((sourceBase.paise * currencyRateScale) ~/ toRate!);
+      }
+    }
+
     return transaction(() async {
       final id = await into(transactions).insert(
         TransactionsCompanion.insert(
@@ -1053,6 +1096,11 @@ class AppDatabase extends _$AppDatabase {
           needsAmountReview: Value(needsAmountReview),
           foreignCurrencyCode: Value(foreignCurrencyCode),
           foreignAmount: Value(foreignAmount),
+          currencyCode: Value(sourceCode),
+          fxRateToBaseMicros: Value(sourceRate),
+          toAmount: Value(toAmt),
+          toCurrencyCode: Value(toCode),
+          toFxRateToBaseMicros: Value(toRate),
         ),
       );
       final row = await (select(

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -172,7 +172,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 57;
+  int get schemaVersion => 58;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -459,6 +459,9 @@ class AppDatabase extends _$AppDatabase {
       if (from < 57) {
         await m.createTable(tagGroups);
         await m.createTable(tagGroupTags);
+      }
+      if (from < 58) {
+        await _addColumnIfMissing(m, settings, settings.frequentIconKeys);
       }
     },
     beforeOpen: (details) async {
@@ -4141,6 +4144,21 @@ class AppDatabase extends _$AppDatabase {
   Future<void> setExtraBottomInset(int px) => update(settings).write(
     SettingsCompanion(extraBottomInset: Value(px.clamp(0, 40))),
   );
+
+  /// Bumps [key] to the front of `Settings.frequentIconKeys` — the icon sheet
+  /// calls this whenever an icon is picked. Capped at 12 so the "Frequently
+  /// used" row stays a single scroll, not a second copy of the full grid.
+  Future<void> recordIconUsed(String key) async {
+    final current = await select(settings).getSingle();
+    final keys = current.frequentIconKeys
+        .split(',')
+        .where((k) => k.isNotEmpty && k != key)
+        .toList();
+    keys.insert(0, key);
+    await update(settings).write(
+      SettingsCompanion(frequentIconKeys: Value(keys.take(12).join(','))),
+    );
+  }
 
   // ── Expense reminder ─────────────────────────────────────────────────────
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -2646,6 +2646,12 @@ class AppDatabase extends _$AppDatabase {
   /// separate method for each, the same way [addTransaction] covers
   /// income/expense/transfer with one method rather than three.
   ///
+  /// GitHub #48: category envelope balances and Ready to Assign are pooled
+  /// across every Envelope-Mode account (see `categoryBalanceProvider` /
+  /// `readyToAssignProvider` in `data/providers.dart`), so [accountId] is no
+  /// longer read back for that math — it's kept purely as a historical/audit
+  /// trail of which account a given row was recorded against.
+  ///
   /// Throws [ArgumentError] if [accountId] isn't in Envelope Mode, or if
   /// [amount] is zero.
   Future<int> addAllocation({

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -832,6 +832,7 @@ class AppDatabase extends _$AppDatabase {
     await delete(categories).go();
     await delete(accounts).go();
     await delete(tags).go();
+    await delete(currencyRates).go();
     await _seedDefaultAccountsAndCategories();
   });
 
@@ -5088,6 +5089,7 @@ class AppDatabase extends _$AppDatabase {
       'schemaVersion': schemaVersion,
       'exportedAt': DateTime.now().toIso8601String(),
       'accounts': (await select(accounts).get()).map(m).toList(),
+      'currencyRates': (await select(currencyRates).get()).map(m).toList(),
       'categories': (await select(categories).get()).map(m).toList(),
       'recurringRules': (await select(recurringRules).get()).map(m).toList(),
       'transactions': (await select(transactions).get()).map(m).toList(),
@@ -5209,6 +5211,7 @@ class AppDatabase extends _$AppDatabase {
       await delete(shoppingItems).go();
       await delete(shoppingLists).go();
       await delete(settings).go();
+      await delete(currencyRates).go();
 
       Future<void> load<T extends Table, D>(
         TableInfo<T, D> table,
@@ -5232,6 +5235,10 @@ class AppDatabase extends _$AppDatabase {
       // `persons` before `transactions` (transactions.person_id), and
       // `transactions` before `person_entries` (person_entries.transaction_id).
       await load(accounts, 'accounts');
+      // No foreign key references currencyRates, so it can load anywhere —
+      // grouped with accounts since that's the other half of "an account's
+      // currency resolves to a rate" (AppDatabase.latestRate).
+      await load(currencyRates, 'currencyRates');
       await load(categories, 'categories');
       await load(persons, 'persons');
       await load(tags, 'tags');

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -871,7 +871,9 @@ class AppDatabase extends _$AppDatabase {
         await _adjust(t.accountId, -amt);
       case TxType.transfer:
         await _adjust(t.accountId, -amt);
-        await _adjust(t.toAccountId!, amt);
+        final creditAmt =
+            t.toAmount == null ? amt : Money(t.toAmount!.paise * sign);
+        await _adjust(t.toAccountId!, creditAmt);
     }
   }
 
@@ -2211,7 +2213,7 @@ class AppDatabase extends _$AppDatabase {
             bump(t.accountId, -t.amount);
           case TxType.transfer:
             bump(t.accountId, -t.amount);
-            bump(t.toAccountId!, t.amount);
+            bump(t.toAccountId!, t.toAmount ?? t.amount);
         }
       }
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -135,6 +135,8 @@ typedef CombinedStatementLine = ({
     Tags,
     TransactionTags,
     RecurringRuleTags,
+    TagGroups,
+    TagGroupTags,
     TransactionSplits,
     TransactionLinks,
     GoalDetails,
@@ -170,7 +172,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 54;
+  int get schemaVersion => 57;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -437,6 +439,26 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 54) {
         await m.createTable(creditCardDetails);
+      }
+      if (from < 55) {
+        // Adds RecurringRules.toAccountId and loosens categoryId to
+        // nullable (a G&L rule's transfer carries neither) — SQLite can't
+        // relax a NOT NULL via a plain ALTER TABLE, so this recreates the
+        // table against the current Dart schema, copying existing rows by
+        // column name.
+        await m.alterTable(
+          TableMigration(
+            recurringRules,
+            newColumns: [recurringRules.toAccountId],
+          ),
+        );
+      }
+      if (from < 56) {
+        await _addColumnIfMissing(m, settings, settings.moreScreenViewMode);
+      }
+      if (from < 57) {
+        await m.createTable(tagGroups);
+        await m.createTable(tagGroupTags);
       }
     },
     beforeOpen: (details) async {
@@ -846,8 +868,12 @@ class AppDatabase extends _$AppDatabase {
     if (!type.isIncomeOrExpense && payee != null) {
       throw ArgumentError('Only an income or expense names a payee.');
     }
-    if (!type.isIncomeOrExpense && recurringRuleId != null) {
-      throw ArgumentError('Only income or expense can come from a rule.');
+    if (!type.isIncomeOrExpense &&
+        type != TxType.transfer &&
+        recurringRuleId != null) {
+      throw ArgumentError(
+        'Only income, expense or a transfer can come from a rule.',
+      );
     }
     switch (type) {
       case TxType.transfer:
@@ -1353,6 +1379,65 @@ class AppDatabase extends _$AppDatabase {
             transactionId: transactionId,
             tagId: tagId,
           ),
+        );
+      }
+    });
+  }
+
+  // ── Tag groups ───────────────────────────────────────────────────────────
+  //
+  // A shortcut for [TagPickerSheet]: pick one group and every tag in it gets
+  // selected at once, instead of hunting each one down individually every
+  // time the same combination is used (GitHub #92). A group is never itself
+  // written to a transaction — only the [Tags] it names are.
+
+  Stream<List<TagGroupRow>> watchTagGroups() => (select(
+    tagGroups,
+  )..orderBy([(g) => OrderingTerm(expression: g.name)])).watch();
+
+  Future<int> addTagGroup({required String name, required int colorValue}) =>
+      into(tagGroups).insert(
+        TagGroupsCompanion.insert(name: name, colorValue: colorValue),
+      );
+
+  Future<void> updateTagGroup({
+    required int id,
+    required String name,
+    required int colorValue,
+  }) => (update(tagGroups)..where((g) => g.id.equals(id))).write(
+    TagGroupsCompanion(name: Value(name), colorValue: Value(colorValue)),
+  );
+
+  /// Same hard-delete shape as [deleteTag]: a group is only ever a picker
+  /// shortcut, so dropping it touches no transaction — just its own tag list.
+  Future<void> deleteTagGroup(int id) => transaction(() async {
+    await (delete(tagGroupTags)..where((t) => t.groupId.equals(id))).go();
+    await (delete(tagGroups)..where((g) => g.id.equals(id))).go();
+  });
+
+  /// Every group's tag link, across every group — composed with
+  /// [watchTagGroups] by the provider layer, same shape as
+  /// [watchAllTransactionTags].
+  Stream<List<TagGroupTagRow>> watchAllTagGroupTags() =>
+      select(tagGroupTags).watch();
+
+  Future<List<int>> tagIdsForGroup(int groupId) async {
+    final rows = await (select(
+      tagGroupTags,
+    )..where((t) => t.groupId.equals(groupId))).get();
+    return rows.map((r) => r.tagId).toList();
+  }
+
+  /// Replaces every tag in [groupId] with exactly [tagIds] — same
+  /// whole-set-rewrite shape as [setTransactionTags].
+  Future<void> setTagGroupTags(int groupId, Set<int> tagIds) {
+    return transaction(() async {
+      await (delete(
+        tagGroupTags,
+      )..where((t) => t.groupId.equals(groupId))).go();
+      for (final tagId in tagIds) {
+        await into(tagGroupTags).insert(
+          TagGroupTagsCompanion.insert(groupId: groupId, tagId: tagId),
         );
       }
     });
@@ -2916,7 +3001,7 @@ class AppDatabase extends _$AppDatabase {
   void _validateRecurringRule({
     required Money amount,
     required CategoryKind kind,
-    required CategoryRow category,
+    required CategoryRow? category,
     required RecurringFrequency frequency,
     int? dayOfMonth,
     Money? promoAmount,
@@ -2925,7 +3010,7 @@ class AppDatabase extends _$AppDatabase {
     if (!amount.isPositive) {
       throw ArgumentError('Amount must be positive.');
     }
-    if (category.kind != kind) {
+    if (category != null && category.kind != kind) {
       throw ArgumentError(
         'That category is ${category.kind == CategoryKind.income ? 'an income' : 'an expense'} '
         'category — pick one that matches.',
@@ -2952,12 +3037,42 @@ class AppDatabase extends _$AppDatabase {
     }
   }
 
+  /// A G&L rule's [RecurringRules.toAccountId] must be a real goal/loan
+  /// account, its [RecurringRules.accountId] must be a real non-goal/loan
+  /// (spendable) account, and the two must differ — the same shape
+  /// [_validateTx] enforces for a one-off transfer, checked up front here so
+  /// a bad rule can never be saved.
+  Future<void> _validateGoalOrLoanTarget({
+    required int accountId,
+    required int toAccountId,
+  }) async {
+    if (accountId == toAccountId) {
+      throw ArgumentError('The source and destination must be different.');
+    }
+    final to = await (select(
+      accounts,
+    )..where((a) => a.id.equals(toAccountId))).getSingleOrNull();
+    if (to == null ||
+        (to.type != AccountType.goal && to.type != AccountType.loan)) {
+      throw ArgumentError('Choose a goal or loan to fund.');
+    }
+    final from = await (select(
+      accounts,
+    )..where((a) => a.id.equals(accountId))).getSingleOrNull();
+    if (from == null ||
+        from.type == AccountType.goal ||
+        from.type == AccountType.loan) {
+      throw ArgumentError('Choose a spendable account to fund it from.');
+    }
+  }
+
   Future<int> addRecurringRule({
     required String name,
     required CategoryKind kind,
     required Money amount,
     required int accountId,
-    required int categoryId,
+    int? categoryId,
+    int? toAccountId,
     String? payee,
     String? note,
     required RecurringFrequency frequency,
@@ -2968,9 +3083,20 @@ class AppDatabase extends _$AppDatabase {
     int? promoOccurrences,
     Set<int> tagIds = const {},
   }) async {
-    final category = await categoryById(categoryId);
-    if (category == null) {
-      throw ArgumentError('That category no longer exists.');
+    CategoryRow? category;
+    if (toAccountId != null) {
+      await _validateGoalOrLoanTarget(
+        accountId: accountId,
+        toAccountId: toAccountId,
+      );
+    } else {
+      if (categoryId == null) {
+        throw ArgumentError('Choose a category.');
+      }
+      category = await categoryById(categoryId);
+      if (category == null) {
+        throw ArgumentError('That category no longer exists.');
+      }
     }
     final dayOfMonth = frequency == RecurringFrequency.monthly
         ? startsOn.day
@@ -2992,7 +3118,8 @@ class AppDatabase extends _$AppDatabase {
           kind: kind,
           amount: amount,
           accountId: accountId,
-          categoryId: categoryId,
+          categoryId: Value(categoryId),
+          toAccountId: Value(toAccountId),
           payee: Value(payee),
           note: Value(note),
           frequency: frequency,
@@ -3015,7 +3142,8 @@ class AppDatabase extends _$AppDatabase {
     required CategoryKind kind,
     required Money amount,
     required int accountId,
-    required int categoryId,
+    int? categoryId,
+    int? toAccountId,
     String? payee,
     String? note,
     required RecurringFrequency frequency,
@@ -3026,9 +3154,20 @@ class AppDatabase extends _$AppDatabase {
     int? promoOccurrences,
     Set<int> tagIds = const {},
   }) async {
-    final category = await categoryById(categoryId);
-    if (category == null) {
-      throw ArgumentError('That category no longer exists.');
+    CategoryRow? category;
+    if (toAccountId != null) {
+      await _validateGoalOrLoanTarget(
+        accountId: accountId,
+        toAccountId: toAccountId,
+      );
+    } else {
+      if (categoryId == null) {
+        throw ArgumentError('Choose a category.');
+      }
+      category = await categoryById(categoryId);
+      if (category == null) {
+        throw ArgumentError('That category no longer exists.');
+      }
     }
     final dayOfMonth = frequency == RecurringFrequency.monthly
         ? nextDueDate.day
@@ -3051,6 +3190,7 @@ class AppDatabase extends _$AppDatabase {
         amount: Value(amount),
         accountId: Value(accountId),
         categoryId: Value(categoryId),
+        toAccountId: Value(toAccountId),
         payee: Value(payee),
         note: Value(note),
         frequency: Value(frequency),
@@ -3163,15 +3303,19 @@ class AppDatabase extends _$AppDatabase {
     required Set<int> tagIds,
   }) async {
     final onPromo = promoAmount != null && (promoLeft ?? 0) > 0;
+    final isGoalOrLoan = rule.toAccountId != null;
     final txId = await addTransaction(
-      type: rule.kind == CategoryKind.expense
-          ? TxType.expense
-          : TxType.income,
+      type: isGoalOrLoan
+          ? TxType.transfer
+          : (rule.kind == CategoryKind.expense
+                ? TxType.expense
+                : TxType.income),
       amount: onPromo ? promoAmount : rule.amount,
       accountId: rule.accountId,
+      toAccountId: rule.toAccountId,
       categoryId: rule.categoryId,
       date: date,
-      payee: rule.payee,
+      payee: isGoalOrLoan ? null : rule.payee,
       recurringRuleId: rule.id,
       needsAmountReview: rule.isEstimate,
     );
@@ -3790,6 +3934,10 @@ class AppDatabase extends _$AppDatabase {
   Future<void> setLockScreenStyle(LockScreenStyle style) => update(
     settings,
   ).write(SettingsCompanion(lockScreenStyle: Value(style)));
+
+  Future<void> setMoreScreenViewMode(MoreScreenViewMode mode) => update(
+    settings,
+  ).write(SettingsCompanion(moreScreenViewMode: Value(mode)));
 
   // ── Passcode ──────────────────────────────────────────────────────────────
 
@@ -4647,6 +4795,8 @@ class AppDatabase extends _$AppDatabase {
       'recurringRuleTags': (await select(
         recurringRuleTags,
       ).get()).map(m).toList(),
+      'tagGroups': (await select(tagGroups).get()).map(m).toList(),
+      'tagGroupTags': (await select(tagGroupTags).get()).map(m).toList(),
       'transactionSplits': (await select(
         transactionSplits,
       ).get()).map(m).toList(),
@@ -4744,6 +4894,9 @@ class AppDatabase extends _$AppDatabase {
       await delete(categories).go();
       await delete(accounts).go();
       await delete(senderRules).go();
+      // References tags and tagGroups, so it goes before both deletes.
+      await delete(tagGroupTags).go();
+      await delete(tagGroups).go();
       await delete(tags).go();
       // Items reference lists, so they go first.
       await delete(shoppingItems).go();
@@ -4775,6 +4928,10 @@ class AppDatabase extends _$AppDatabase {
       await load(categories, 'categories');
       await load(persons, 'persons');
       await load(tags, 'tags');
+      // References tags, already loaded above. An older backup simply has no
+      // rows for either, so `rows()` yields nothing.
+      await load(tagGroups, 'tagGroups');
+      await load(tagGroupTags, 'tagGroupTags');
       // A backup taken before v21 has no `goalDetails` key — its (old-shaped)
       // goals live under `savingsGoals` instead. `accounts` is already
       // loaded above, so the linked account's balance is there to snapshot.

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -27,7 +27,9 @@ part 'database.g.dart';
 Money accountMovement(TransactionRow tx, Set<int> ownIds) => switch (tx.type) {
   TxType.income || TxType.personIn => tx.amount,
   TxType.expense || TxType.personOut => -tx.amount,
-  TxType.transfer => ownIds.contains(tx.accountId) ? -tx.amount : tx.amount,
+  TxType.transfer => ownIds.contains(tx.accountId)
+      ? -tx.amount
+      : (tx.toAmount ?? tx.amount),
 };
 
 /// The gap between automatic backups for a given schedule. `monthly` is

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -2444,6 +2444,7 @@ class AppDatabase extends _$AppDatabase {
     required int colorValue,
     required String iconKey,
     required Money openingBalance,
+    String? currencyCode,
   }) {
     if (type == AccountType.card && cardKind == null) {
       throw ArgumentError('A card must be credit or debit.');
@@ -2453,10 +2454,16 @@ class AppDatabase extends _$AppDatabase {
         'A debit card must be linked to the bank account it draws from.',
       );
     }
-    // An instrument (debit card) holds no balance of its own.
+    // An instrument (debit card) holds no balance, and no currency, of its
+    // own — it always mirrors the account it draws from.
     final opening = linkedAccountId == null
         ? openingBalance
         : const Money.zero();
+    final resolvedCurrencyCode = linkedAccountId == null ? currencyCode : null;
+    if (resolvedCurrencyCode != null &&
+        currencyForCode(resolvedCurrencyCode).code != resolvedCurrencyCode) {
+      throw ArgumentError('Unknown currency code: $resolvedCurrencyCode.');
+    }
 
     return into(accounts).insert(
       AccountsCompanion.insert(
@@ -2467,6 +2474,7 @@ class AppDatabase extends _$AppDatabase {
         bankName: Value(bankName),
         last4: Value(last4),
         colorValue: colorValue,
+        currencyCode: Value(resolvedCurrencyCode),
         iconKey: iconKey,
         openingBalance: opening,
         currentBalance: opening,
@@ -2485,6 +2493,35 @@ class AppDatabase extends _$AppDatabase {
     }
     return (update(accounts)..where((a) => a.id.equals(id))).write(
       AccountsCompanion(name: Value(trimmed)),
+    );
+  }
+
+  /// Changes an account's currency. Only ever allowed before it has a
+  /// transaction — once one exists, its native amount is only meaningful
+  /// under the currency it was posted in, so the field locks (see the
+  /// design spec's "an account's currency locks once it has its first
+  /// transaction" decision). A linked card can never set its own currency —
+  /// it always mirrors the account it draws from.
+  Future<void> setAccountCurrency(int id, String? currencyCode) async {
+    if (currencyCode != null &&
+        currencyForCode(currencyCode).code != currencyCode) {
+      throw ArgumentError('Unknown currency code: $currencyCode.');
+    }
+    final account = await (select(
+      accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    if (account.linkedAccountId != null) {
+      throw ArgumentError(
+        "A linked card always uses its bank account's currency.",
+      );
+    }
+    if (await countTransactionsForAccount(id) > 0) {
+      throw ArgumentError(
+        'This account already has transactions — its currency is locked.',
+      );
+    }
+    await (update(accounts)..where((a) => a.id.equals(id))).write(
+      AccountsCompanion(currencyCode: Value(currencyCode)),
     );
   }
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -2313,11 +2313,30 @@ class AppDatabase extends _$AppDatabase {
   /// An account with [Accounts.includeInNetWorth] off — opted out from
   /// Settings > Customize Dashboard — contributes nothing here, though it
   /// still shows its own balance everywhere else in the app.
-  Stream<Money> watchNetWorth() => watchBalanceHoldingAccounts().map(
-    (rows) => rows
-        .where((a) => a.includeInNetWorth)
-        .fold(const Money.zero(), (sum, a) => sum + a.currentBalance),
-  );
+  ///
+  /// A foreign-currency account's balance is converted using **today's**
+  /// rate, not a snapshot — Net Worth is a "right now" figure, unlike a
+  /// transaction's historical [TransactionBaseValue.baseAmount]. If no rate
+  /// has been entered for its currency yet, its raw balance is added
+  /// unconverted rather than dropping it or throwing, so an incomplete
+  /// Currency setup never breaks the dashboard.
+  Stream<Money> watchNetWorth() => watchBalanceHoldingAccounts().asyncMap((
+    rows,
+  ) async {
+    var total = const Money.zero();
+    for (final a in rows) {
+      if (!a.includeInNetWorth) continue;
+      if (a.currencyCode == null) {
+        total += a.currentBalance;
+        continue;
+      }
+      final rate = await latestRate(a.currencyCode!);
+      total += rate == null
+          ? a.currentBalance
+          : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
+    }
+    return total;
+  });
 
   /// Flips whether [id]'s balance counts toward [watchNetWorth] — the toggle
   /// behind Settings > Customize Dashboard.

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -177,7 +177,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 60;
+  int get schemaVersion => 61;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -511,6 +511,12 @@ class AppDatabase extends _$AppDatabase {
           transactions,
           transactions.toFxRateToBaseMicros,
         );
+      }
+      if (from < 61) {
+        // GitHub #100 — a Settings-level switch between the classic Budgets
+        // screen and Envelope Mode's Ready to Assign as the primary
+        // budgeting system. Neither system's own data changes.
+        await _addColumnIfMissing(m, settings, settings.budgetingMode);
       }
     },
     beforeOpen: (details) async {
@@ -4220,6 +4226,10 @@ class AppDatabase extends _$AppDatabase {
   Future<void> setMoreScreenViewMode(MoreScreenViewMode mode) => update(
     settings,
   ).write(SettingsCompanion(moreScreenViewMode: Value(mode)));
+
+  Future<void> setBudgetingMode(BudgetingMode mode) => update(
+    settings,
+  ).write(SettingsCompanion(budgetingMode: Value(mode)));
 
   // ── Passcode ──────────────────────────────────────────────────────────────
 

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -148,6 +148,7 @@ typedef CombinedStatementLine = ({
     Allocations,
     OcrCorrections,
     CreditCardDetails,
+    CurrencyRates,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -173,7 +174,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 59;
+  int get schemaVersion => 60;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -483,6 +484,29 @@ class AppDatabase extends _$AppDatabase {
           m,
           recurringRules,
           recurringRules.foreignAmount,
+        );
+      }
+      if (from < 60) {
+        // Multi-currency accounts — see
+        // docs/superpowers/specs/2026-09-04-multi-currency-accounts-design.md.
+        await m.createTable(currencyRates);
+        await _addColumnIfMissing(m, accounts, accounts.currencyCode);
+        await _addColumnIfMissing(m, transactions, transactions.currencyCode);
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.fxRateToBaseMicros,
+        );
+        await _addColumnIfMissing(m, transactions, transactions.toAmount);
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.toCurrencyCode,
+        );
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.toFxRateToBaseMicros,
         );
       }
     },

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
+import '../core/currency.dart';
 import '../core/group_split_math.dart';
 import '../core/money.dart';
 import '../core/security/passcode.dart';
@@ -172,7 +173,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 58;
+  int get schemaVersion => 59;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -462,6 +463,27 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 58) {
         await _addColumnIfMissing(m, settings, settings.frequentIconKeys);
+      }
+      if (from < 59) {
+        // GitHub #85 — a purely informational "originally paid in another
+        // currency" annotation on transactions and the auto rules that post
+        // them. Both columns on each table are always null together.
+        await _addColumnIfMissing(
+          m,
+          transactions,
+          transactions.foreignCurrencyCode,
+        );
+        await _addColumnIfMissing(m, transactions, transactions.foreignAmount);
+        await _addColumnIfMissing(
+          m,
+          recurringRules,
+          recurringRules.foreignCurrencyCode,
+        );
+        await _addColumnIfMissing(
+          m,
+          recurringRules,
+          recurringRules.foreignAmount,
+        );
       }
     },
     beforeOpen: (details) async {
@@ -828,6 +850,24 @@ class AppDatabase extends _$AppDatabase {
     }
   }
 
+  /// Shared by [_validateTx] and [_validateRecurringRule] — the foreign
+  /// currency annotation (GitHub #85) is optional, but never half-set.
+  void _validateForeignCurrency(String? code, Money? amount) {
+    if (code == null && amount == null) return;
+    if (code == null || amount == null) {
+      throw ArgumentError(
+        'A foreign amount needs a currency, and a foreign currency needs an '
+        'amount.',
+      );
+    }
+    if (!amount.isPositive) {
+      throw ArgumentError('Foreign amount must be positive.');
+    }
+    if (currencyForCode(code).code != code) {
+      throw ArgumentError('Unknown currency code: $code.');
+    }
+  }
+
   Future<void> _validateTx({
     required TxType type,
     required Money amount,
@@ -837,7 +877,10 @@ class AppDatabase extends _$AppDatabase {
     int? personId,
     String? payee,
     int? recurringRuleId,
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) async {
+    _validateForeignCurrency(foreignCurrencyCode, foreignAmount);
     // Zero is a legitimate income/expense (GitHub #87) — a free item, a
     // discount that fully covers the price, a promo month that costs
     // nothing. A transfer or person movement of ₹0 has no real meaning
@@ -952,6 +995,8 @@ class AppDatabase extends _$AppDatabase {
     int? recurringRuleId,
     String? imagePath,
     bool needsAmountReview = false,
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) async {
     await _validateTx(
       type: type,
@@ -962,6 +1007,8 @@ class AppDatabase extends _$AppDatabase {
       personId: personId,
       payee: payee,
       recurringRuleId: recurringRuleId,
+      foreignCurrencyCode: foreignCurrencyCode,
+      foreignAmount: foreignAmount,
     );
 
     return transaction(() async {
@@ -979,6 +1026,8 @@ class AppDatabase extends _$AppDatabase {
           recurringRuleId: Value(recurringRuleId),
           imagePath: Value(imagePath),
           needsAmountReview: Value(needsAmountReview),
+          foreignCurrencyCode: Value(foreignCurrencyCode),
+          foreignAmount: Value(foreignAmount),
         ),
       );
       final row = await (select(
@@ -1267,6 +1316,8 @@ class AppDatabase extends _$AppDatabase {
     String? note,
     String? payee,
     String? imagePath,
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) async {
     await _validateTx(
       type: type,
@@ -1276,6 +1327,8 @@ class AppDatabase extends _$AppDatabase {
       categoryId: categoryId,
       personId: personId,
       payee: payee,
+      foreignCurrencyCode: foreignCurrencyCode,
+      foreignAmount: foreignAmount,
     );
 
     return transaction(() async {
@@ -1306,6 +1359,8 @@ class AppDatabase extends _$AppDatabase {
           // Editing and saving *is* the confirmation — whatever amount is
           // typed here is now the real one, estimate or not.
           needsAmountReview: const Value(false),
+          foreignCurrencyCode: Value(foreignCurrencyCode),
+          foreignAmount: Value(foreignAmount),
         ),
       );
 
@@ -3015,10 +3070,13 @@ class AppDatabase extends _$AppDatabase {
     int? dayOfMonth,
     Money? promoAmount,
     int? promoOccurrences,
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) {
     if (!amount.isPositive) {
       throw ArgumentError('Amount must be positive.');
     }
+    _validateForeignCurrency(foreignCurrencyCode, foreignAmount);
     if (category != null && category.kind != kind) {
       throw ArgumentError(
         'That category is ${category.kind == CategoryKind.income ? 'an income' : 'an expense'} '
@@ -3091,6 +3149,8 @@ class AppDatabase extends _$AppDatabase {
     Money? promoAmount,
     int? promoOccurrences,
     Set<int> tagIds = const {},
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) async {
     CategoryRow? category;
     if (toAccountId != null) {
@@ -3118,6 +3178,8 @@ class AppDatabase extends _$AppDatabase {
       dayOfMonth: dayOfMonth,
       promoAmount: promoAmount,
       promoOccurrences: promoOccurrences,
+      foreignCurrencyCode: foreignCurrencyCode,
+      foreignAmount: foreignAmount,
     );
 
     return transaction(() async {
@@ -3138,6 +3200,8 @@ class AppDatabase extends _$AppDatabase {
           isEstimate: Value(isEstimate),
           promoAmount: Value(promoAmount),
           promoOccurrencesLeft: Value(promoOccurrences),
+          foreignCurrencyCode: Value(foreignCurrencyCode),
+          foreignAmount: Value(foreignAmount),
         ),
       );
       await setRecurringRuleTags(id, tagIds);
@@ -3162,6 +3226,8 @@ class AppDatabase extends _$AppDatabase {
     Money? promoAmount,
     int? promoOccurrences,
     Set<int> tagIds = const {},
+    String? foreignCurrencyCode,
+    Money? foreignAmount,
   }) async {
     CategoryRow? category;
     if (toAccountId != null) {
@@ -3189,6 +3255,8 @@ class AppDatabase extends _$AppDatabase {
       dayOfMonth: dayOfMonth,
       promoAmount: promoAmount,
       promoOccurrences: promoOccurrences,
+      foreignCurrencyCode: foreignCurrencyCode,
+      foreignAmount: foreignAmount,
     );
 
     await setRecurringRuleTags(id, tagIds);
@@ -3211,6 +3279,8 @@ class AppDatabase extends _$AppDatabase {
         isEstimate: Value(isEstimate),
         promoAmount: Value(promoAmount),
         promoOccurrencesLeft: Value(promoOccurrences),
+        foreignCurrencyCode: Value(foreignCurrencyCode),
+        foreignAmount: Value(foreignAmount),
       ),
     );
   }
@@ -3327,6 +3397,11 @@ class AppDatabase extends _$AppDatabase {
       payee: isGoalOrLoan ? null : rule.payee,
       recurringRuleId: rule.id,
       needsAmountReview: rule.isEstimate,
+      // No tracked foreign equivalent for a promo price, so a promo
+      // occurrence posts with no foreign-currency annotation rather than a
+      // misleading one (GitHub #85).
+      foreignCurrencyCode: onPromo ? null : rule.foreignCurrencyCode,
+      foreignAmount: onPromo ? null : rule.foreignAmount,
     );
     if (tagIds.isNotEmpty) {
       await setTransactionTags(txId, tagIds);
@@ -4542,7 +4617,18 @@ class AppDatabase extends _$AppDatabase {
               : categoriesById[t.categoryId];
           final base = category?.name ?? 'Uncategorised';
           final payee = t.payee?.trim();
-          return (payee != null && payee.isNotEmpty) ? '$base - $payee' : base;
+          var desc = (payee != null && payee.isNotEmpty)
+              ? '$base - $payee'
+              : base;
+          // Folded into the description rather than a new PDF column, and
+          // kept plain ASCII (no symbol/rate) — this file's fonts can't
+          // reliably render non-ASCII glyphs (GitHub #85).
+          if (t.foreignCurrencyCode != null && t.foreignAmount != null) {
+            desc +=
+                ' (${(t.foreignAmount!.paise / 100).toStringAsFixed(2)} '
+                '${t.foreignCurrencyCode})';
+          }
+          return desc;
       }
     }
 
@@ -5054,7 +5140,8 @@ class AppDatabase extends _$AppDatabase {
     }
 
     final b = StringBuffer(
-      'Date,Type,Amount,Account,To Account,Category,Person,Note\n',
+      'Date,Type,Amount,Account,To Account,Category,Person,Note,'
+      'Foreign Amount,Foreign Currency\n',
     );
     for (final t in txs) {
       final d = t.date;
@@ -5077,6 +5164,14 @@ class AppDatabase extends _$AppDatabase {
         ..write(esc(t.personId == null ? '' : ppl[t.personId]))
         ..write(',')
         ..write(esc(t.note))
+        ..write(',')
+        ..write(
+          t.foreignAmount == null
+              ? ''
+              : (t.foreignAmount!.paise / 100).toStringAsFixed(2),
+        )
+        ..write(',')
+        ..write(esc(t.foreignCurrencyCode))
         ..write('\n');
     }
     return b.toString();

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -10,6 +10,7 @@ import '../core/money.dart';
 import '../core/security/passcode.dart';
 import '../features/message_capture/parser/bank_message.dart';
 import '../features/message_capture/parser/message_parser.dart';
+import 'currency_conversion.dart';
 import 'tables.dart';
 
 part 'database.g.dart';
@@ -2176,6 +2177,70 @@ class AppDatabase extends _$AppDatabase {
       }
     });
   }
+
+  // ── Currency rates ───────────────────────────────────────────────────────
+
+  /// The most recent rate for [currencyCode] at or before [asOf] (defaults
+  /// to now) — `null` if none has been entered yet as of that date. This is
+  /// what a transaction snapshots at post time, and what a live figure
+  /// (Net Worth) resolves with `asOf` left at its default.
+  Future<CurrencyRateRow?> latestRate(
+    String currencyCode, {
+    DateTime? asOf,
+  }) {
+    final cutoff = asOf ?? DateTime.now();
+    return (select(currencyRates)
+          ..where(
+            (r) =>
+                r.currencyCode.equals(currencyCode) &
+                r.effectiveAt.isSmallerOrEqualValue(cutoff),
+          )
+          ..orderBy([
+            (r) =>
+                OrderingTerm(expression: r.effectiveAt, mode: OrderingMode.desc),
+          ])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// Records a new rate. Always an insert, never an update — see
+  /// [CurrencyRates]'s doc for why history must never be overwritten.
+  Future<int> addCurrencyRate({
+    required String currencyCode,
+    required int rateToBaseMicros,
+    required DateTime effectiveAt,
+  }) {
+    if (rateToBaseMicros <= 0) {
+      throw ArgumentError('Rate must be positive.');
+    }
+    if (currencyForCode(currencyCode).code != currencyCode) {
+      throw ArgumentError('Unknown currency code: $currencyCode.');
+    }
+    return into(currencyRates).insert(
+      CurrencyRatesCompanion.insert(
+        currencyCode: currencyCode,
+        rateToBaseMicros: rateToBaseMicros,
+        effectiveAt: effectiveAt,
+      ),
+    );
+  }
+
+  /// One row per currency that has ever had a rate entered, each the most
+  /// recent — the list the Currency settings screen renders. Folds in Dart
+  /// rather than SQL, same style as [recalculateBalances]/[watchNetWorth].
+  Stream<List<CurrencyRateRow>> watchCurrentRates() =>
+      select(currencyRates).watch().map((rows) {
+        final latest = <String, CurrencyRateRow>{};
+        for (final r in rows) {
+          final existing = latest[r.currencyCode];
+          if (existing == null || r.effectiveAt.isAfter(existing.effectiveAt)) {
+            latest[r.currencyCode] = r;
+          }
+        }
+        final list = latest.values.toList()
+          ..sort((a, b) => a.currencyCode.compareTo(b.currencyCode));
+        return list;
+      });
 
   // ── Queries ───────────────────────────────────────────────────────────────
 

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -204,6 +204,21 @@ class $AccountsTable extends Accounts
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _currencyCodeMeta = const VerificationMeta(
+    'currencyCode',
+  );
+  @override
+  late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
+    'currency_code',
+    aliasedName,
+    true,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 3,
+      maxTextLength: 3,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -222,6 +237,7 @@ class $AccountsTable extends Accounts
     createdAt,
     envelopeMode,
     includeInNetWorth,
+    currencyCode,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -319,6 +335,15 @@ class $AccountsTable extends Accounts
         ),
       );
     }
+    if (data.containsKey('currency_code')) {
+      context.handle(
+        _currencyCodeMeta,
+        currencyCode.isAcceptableOrUnknown(
+          data['currency_code']!,
+          _currencyCodeMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -400,6 +425,10 @@ class $AccountsTable extends Accounts
         DriftSqlType.bool,
         data['${effectivePrefix}include_in_net_worth'],
       )!,
+      currencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}currency_code'],
+      ),
     );
   }
 
@@ -459,6 +488,15 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
   /// savings goal or account off if they don't want it inflating the figure
   /// they treat as their real spendable net worth.
   final bool includeInNetWorth;
+
+  /// Null = this account is in the parent currency (`Settings.currencyCode`)
+  /// — true for every account that existed before this feature, and for
+  /// every account a user never explicitly changes. Locked once the account
+  /// has a transaction (enforced in `AppDatabase.setAccountCurrency`, not
+  /// here — Drift columns can't express that rule). A debit-card/UPI
+  /// instrument (non-null `linkedAccountId`) never gets its own value here —
+  /// it always mirrors its linked account's currency.
+  final String? currencyCode;
   const AccountRow({
     required this.id,
     required this.name,
@@ -476,6 +514,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
     required this.createdAt,
     required this.envelopeMode,
     required this.includeInNetWorth,
+    this.currencyCode,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -516,6 +555,9 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
     map['created_at'] = Variable<DateTime>(createdAt);
     map['envelope_mode'] = Variable<bool>(envelopeMode);
     map['include_in_net_worth'] = Variable<bool>(includeInNetWorth);
+    if (!nullToAbsent || currencyCode != null) {
+      map['currency_code'] = Variable<String>(currencyCode);
+    }
     return map;
   }
 
@@ -545,6 +587,9 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
       createdAt: Value(createdAt),
       envelopeMode: Value(envelopeMode),
       includeInNetWorth: Value(includeInNetWorth),
+      currencyCode: currencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(currencyCode),
     );
   }
 
@@ -574,6 +619,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       envelopeMode: serializer.fromJson<bool>(json['envelopeMode']),
       includeInNetWorth: serializer.fromJson<bool>(json['includeInNetWorth']),
+      currencyCode: serializer.fromJson<String?>(json['currencyCode']),
     );
   }
   @override
@@ -600,6 +646,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'envelopeMode': serializer.toJson<bool>(envelopeMode),
       'includeInNetWorth': serializer.toJson<bool>(includeInNetWorth),
+      'currencyCode': serializer.toJson<String?>(currencyCode),
     };
   }
 
@@ -620,6 +667,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
     DateTime? createdAt,
     bool? envelopeMode,
     bool? includeInNetWorth,
+    Value<String?> currencyCode = const Value.absent(),
   }) => AccountRow(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -639,6 +687,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
     createdAt: createdAt ?? this.createdAt,
     envelopeMode: envelopeMode ?? this.envelopeMode,
     includeInNetWorth: includeInNetWorth ?? this.includeInNetWorth,
+    currencyCode: currencyCode.present ? currencyCode.value : this.currencyCode,
   );
   AccountRow copyWithCompanion(AccountsCompanion data) {
     return AccountRow(
@@ -672,6 +721,9 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
       includeInNetWorth: data.includeInNetWorth.present
           ? data.includeInNetWorth.value
           : this.includeInNetWorth,
+      currencyCode: data.currencyCode.present
+          ? data.currencyCode.value
+          : this.currencyCode,
     );
   }
 
@@ -693,7 +745,8 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
           ..write('sortOrder: $sortOrder, ')
           ..write('createdAt: $createdAt, ')
           ..write('envelopeMode: $envelopeMode, ')
-          ..write('includeInNetWorth: $includeInNetWorth')
+          ..write('includeInNetWorth: $includeInNetWorth, ')
+          ..write('currencyCode: $currencyCode')
           ..write(')'))
         .toString();
   }
@@ -716,6 +769,7 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
     createdAt,
     envelopeMode,
     includeInNetWorth,
+    currencyCode,
   );
   @override
   bool operator ==(Object other) =>
@@ -736,7 +790,8 @@ class AccountRow extends DataClass implements Insertable<AccountRow> {
           other.sortOrder == this.sortOrder &&
           other.createdAt == this.createdAt &&
           other.envelopeMode == this.envelopeMode &&
-          other.includeInNetWorth == this.includeInNetWorth);
+          other.includeInNetWorth == this.includeInNetWorth &&
+          other.currencyCode == this.currencyCode);
 }
 
 class AccountsCompanion extends UpdateCompanion<AccountRow> {
@@ -756,6 +811,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
   final Value<DateTime> createdAt;
   final Value<bool> envelopeMode;
   final Value<bool> includeInNetWorth;
+  final Value<String?> currencyCode;
   const AccountsCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
@@ -773,6 +829,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
     this.createdAt = const Value.absent(),
     this.envelopeMode = const Value.absent(),
     this.includeInNetWorth = const Value.absent(),
+    this.currencyCode = const Value.absent(),
   });
   AccountsCompanion.insert({
     this.id = const Value.absent(),
@@ -791,6 +848,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
     this.createdAt = const Value.absent(),
     this.envelopeMode = const Value.absent(),
     this.includeInNetWorth = const Value.absent(),
+    this.currencyCode = const Value.absent(),
   }) : name = Value(name),
        type = Value(type),
        colorValue = Value(colorValue),
@@ -814,6 +872,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
     Expression<DateTime>? createdAt,
     Expression<bool>? envelopeMode,
     Expression<bool>? includeInNetWorth,
+    Expression<String>? currencyCode,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -832,6 +891,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
       if (createdAt != null) 'created_at': createdAt,
       if (envelopeMode != null) 'envelope_mode': envelopeMode,
       if (includeInNetWorth != null) 'include_in_net_worth': includeInNetWorth,
+      if (currencyCode != null) 'currency_code': currencyCode,
     });
   }
 
@@ -852,6 +912,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
     Value<DateTime>? createdAt,
     Value<bool>? envelopeMode,
     Value<bool>? includeInNetWorth,
+    Value<String?>? currencyCode,
   }) {
     return AccountsCompanion(
       id: id ?? this.id,
@@ -870,6 +931,7 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
       createdAt: createdAt ?? this.createdAt,
       envelopeMode: envelopeMode ?? this.envelopeMode,
       includeInNetWorth: includeInNetWorth ?? this.includeInNetWorth,
+      currencyCode: currencyCode ?? this.currencyCode,
     );
   }
 
@@ -932,6 +994,9 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
     if (includeInNetWorth.present) {
       map['include_in_net_worth'] = Variable<bool>(includeInNetWorth.value);
     }
+    if (currencyCode.present) {
+      map['currency_code'] = Variable<String>(currencyCode.value);
+    }
     return map;
   }
 
@@ -953,7 +1018,8 @@ class AccountsCompanion extends UpdateCompanion<AccountRow> {
           ..write('sortOrder: $sortOrder, ')
           ..write('createdAt: $createdAt, ')
           ..write('envelopeMode: $envelopeMode, ')
-          ..write('includeInNetWorth: $includeInNetWorth')
+          ..write('includeInNetWorth: $includeInNetWorth, ')
+          ..write('currencyCode: $currencyCode')
           ..write(')'))
         .toString();
   }
@@ -3639,6 +3705,65 @@ class $TransactionsTable extends Transactions
         type: DriftSqlType.int,
         requiredDuringInsert: false,
       ).withConverter<Money?>($TransactionsTable.$converterforeignAmountn);
+  static const VerificationMeta _currencyCodeMeta = const VerificationMeta(
+    'currencyCode',
+  );
+  @override
+  late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
+    'currency_code',
+    aliasedName,
+    true,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 3,
+      maxTextLength: 3,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _fxRateToBaseMicrosMeta =
+      const VerificationMeta('fxRateToBaseMicros');
+  @override
+  late final GeneratedColumn<int> fxRateToBaseMicros = GeneratedColumn<int>(
+    'fx_rate_to_base_micros',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<Money?, int> toAmount =
+      GeneratedColumn<int>(
+        'to_amount',
+        aliasedName,
+        true,
+        type: DriftSqlType.int,
+        requiredDuringInsert: false,
+      ).withConverter<Money?>($TransactionsTable.$convertertoAmountn);
+  static const VerificationMeta _toCurrencyCodeMeta = const VerificationMeta(
+    'toCurrencyCode',
+  );
+  @override
+  late final GeneratedColumn<String> toCurrencyCode = GeneratedColumn<String>(
+    'to_currency_code',
+    aliasedName,
+    true,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 3,
+      maxTextLength: 3,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _toFxRateToBaseMicrosMeta =
+      const VerificationMeta('toFxRateToBaseMicros');
+  @override
+  late final GeneratedColumn<int> toFxRateToBaseMicros = GeneratedColumn<int>(
+    'to_fx_rate_to_base_micros',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -3659,6 +3784,11 @@ class $TransactionsTable extends Transactions
     paymentGroupId,
     foreignCurrencyCode,
     foreignAmount,
+    currencyCode,
+    fxRateToBaseMicros,
+    toAmount,
+    toCurrencyCode,
+    toFxRateToBaseMicros,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3778,6 +3908,42 @@ class $TransactionsTable extends Transactions
         ),
       );
     }
+    if (data.containsKey('currency_code')) {
+      context.handle(
+        _currencyCodeMeta,
+        currencyCode.isAcceptableOrUnknown(
+          data['currency_code']!,
+          _currencyCodeMeta,
+        ),
+      );
+    }
+    if (data.containsKey('fx_rate_to_base_micros')) {
+      context.handle(
+        _fxRateToBaseMicrosMeta,
+        fxRateToBaseMicros.isAcceptableOrUnknown(
+          data['fx_rate_to_base_micros']!,
+          _fxRateToBaseMicrosMeta,
+        ),
+      );
+    }
+    if (data.containsKey('to_currency_code')) {
+      context.handle(
+        _toCurrencyCodeMeta,
+        toCurrencyCode.isAcceptableOrUnknown(
+          data['to_currency_code']!,
+          _toCurrencyCodeMeta,
+        ),
+      );
+    }
+    if (data.containsKey('to_fx_rate_to_base_micros')) {
+      context.handle(
+        _toFxRateToBaseMicrosMeta,
+        toFxRateToBaseMicros.isAcceptableOrUnknown(
+          data['to_fx_rate_to_base_micros']!,
+          _toFxRateToBaseMicrosMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -3865,6 +4031,28 @@ class $TransactionsTable extends Transactions
           data['${effectivePrefix}foreign_amount'],
         ),
       ),
+      currencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}currency_code'],
+      ),
+      fxRateToBaseMicros: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}fx_rate_to_base_micros'],
+      ),
+      toAmount: $TransactionsTable.$convertertoAmountn.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.int,
+          data['${effectivePrefix}to_amount'],
+        ),
+      ),
+      toCurrencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}to_currency_code'],
+      ),
+      toFxRateToBaseMicros: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}to_fx_rate_to_base_micros'],
+      ),
     );
   }
 
@@ -3880,6 +4068,9 @@ class $TransactionsTable extends Transactions
       const MoneyConverter();
   static TypeConverter<Money?, int?> $converterforeignAmountn =
       NullAwareTypeConverter.wrap($converterforeignAmount);
+  static TypeConverter<Money, int> $convertertoAmount = const MoneyConverter();
+  static TypeConverter<Money?, int?> $convertertoAmountn =
+      NullAwareTypeConverter.wrap($convertertoAmount);
 }
 
 class TransactionRow extends DataClass implements Insertable<TransactionRow> {
@@ -3951,6 +4142,32 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
   /// `amount / foreignAmount`, recomputed for display rather than stored.
   final String? foreignCurrencyCode;
   final Money? foreignAmount;
+
+  /// This transaction's own ledger currency, snapshotted from its account's
+  /// [Accounts.currencyCode] at post time. Null = parent currency, which
+  /// matches [amount]'s existing meaning exactly (no conversion needed).
+  /// Distinct from the #85 [foreignCurrencyCode]/[foreignAmount] pair above,
+  /// which is a manual informational annotation on a parent-currency
+  /// transaction — this pair instead describes the transaction's *real*
+  /// native currency, inherited from its account.
+  final String? currencyCode;
+
+  /// Snapshot of `CurrencyRates.rateToBaseMicros` as of [date], for
+  /// [currencyCode]. Null iff [currencyCode] is null.
+  final int? fxRateToBaseMicros;
+
+  /// Transfer only, and only when the source and destination accounts don't
+  /// share a currency: the amount credited to [toAccountId], in *its own*
+  /// currency. Null for a same-currency transfer, where crediting [amount]
+  /// unchanged is already correct — see `AppDatabase._applyTxEffect`.
+  final Money? toAmount;
+
+  /// Transfer only, mirrors [currencyCode]/[fxRateToBaseMicros] for the
+  /// destination leg — the two accounts can each be a different currency
+  /// from the parent (and from each other), so the destination needs its
+  /// own independent snapshot.
+  final String? toCurrencyCode;
+  final int? toFxRateToBaseMicros;
   const TransactionRow({
     required this.id,
     required this.type,
@@ -3970,6 +4187,11 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     this.paymentGroupId,
     this.foreignCurrencyCode,
     this.foreignAmount,
+    this.currencyCode,
+    this.fxRateToBaseMicros,
+    this.toAmount,
+    this.toCurrencyCode,
+    this.toFxRateToBaseMicros,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -4022,6 +4244,23 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
         $TransactionsTable.$converterforeignAmountn.toSql(foreignAmount),
       );
     }
+    if (!nullToAbsent || currencyCode != null) {
+      map['currency_code'] = Variable<String>(currencyCode);
+    }
+    if (!nullToAbsent || fxRateToBaseMicros != null) {
+      map['fx_rate_to_base_micros'] = Variable<int>(fxRateToBaseMicros);
+    }
+    if (!nullToAbsent || toAmount != null) {
+      map['to_amount'] = Variable<int>(
+        $TransactionsTable.$convertertoAmountn.toSql(toAmount),
+      );
+    }
+    if (!nullToAbsent || toCurrencyCode != null) {
+      map['to_currency_code'] = Variable<String>(toCurrencyCode);
+    }
+    if (!nullToAbsent || toFxRateToBaseMicros != null) {
+      map['to_fx_rate_to_base_micros'] = Variable<int>(toFxRateToBaseMicros);
+    }
     return map;
   }
 
@@ -4063,6 +4302,21 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       foreignAmount: foreignAmount == null && nullToAbsent
           ? const Value.absent()
           : Value(foreignAmount),
+      currencyCode: currencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(currencyCode),
+      fxRateToBaseMicros: fxRateToBaseMicros == null && nullToAbsent
+          ? const Value.absent()
+          : Value(fxRateToBaseMicros),
+      toAmount: toAmount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(toAmount),
+      toCurrencyCode: toCurrencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(toCurrencyCode),
+      toFxRateToBaseMicros: toFxRateToBaseMicros == null && nullToAbsent
+          ? const Value.absent()
+          : Value(toFxRateToBaseMicros),
     );
   }
 
@@ -4094,6 +4348,13 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
         json['foreignCurrencyCode'],
       ),
       foreignAmount: serializer.fromJson<Money?>(json['foreignAmount']),
+      currencyCode: serializer.fromJson<String?>(json['currencyCode']),
+      fxRateToBaseMicros: serializer.fromJson<int?>(json['fxRateToBaseMicros']),
+      toAmount: serializer.fromJson<Money?>(json['toAmount']),
+      toCurrencyCode: serializer.fromJson<String?>(json['toCurrencyCode']),
+      toFxRateToBaseMicros: serializer.fromJson<int?>(
+        json['toFxRateToBaseMicros'],
+      ),
     );
   }
   @override
@@ -4120,6 +4381,11 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       'paymentGroupId': serializer.toJson<int?>(paymentGroupId),
       'foreignCurrencyCode': serializer.toJson<String?>(foreignCurrencyCode),
       'foreignAmount': serializer.toJson<Money?>(foreignAmount),
+      'currencyCode': serializer.toJson<String?>(currencyCode),
+      'fxRateToBaseMicros': serializer.toJson<int?>(fxRateToBaseMicros),
+      'toAmount': serializer.toJson<Money?>(toAmount),
+      'toCurrencyCode': serializer.toJson<String?>(toCurrencyCode),
+      'toFxRateToBaseMicros': serializer.toJson<int?>(toFxRateToBaseMicros),
     };
   }
 
@@ -4142,6 +4408,11 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     Value<int?> paymentGroupId = const Value.absent(),
     Value<String?> foreignCurrencyCode = const Value.absent(),
     Value<Money?> foreignAmount = const Value.absent(),
+    Value<String?> currencyCode = const Value.absent(),
+    Value<int?> fxRateToBaseMicros = const Value.absent(),
+    Value<Money?> toAmount = const Value.absent(),
+    Value<String?> toCurrencyCode = const Value.absent(),
+    Value<int?> toFxRateToBaseMicros = const Value.absent(),
   }) => TransactionRow(
     id: id ?? this.id,
     type: type ?? this.type,
@@ -4169,6 +4440,17 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     foreignAmount: foreignAmount.present
         ? foreignAmount.value
         : this.foreignAmount,
+    currencyCode: currencyCode.present ? currencyCode.value : this.currencyCode,
+    fxRateToBaseMicros: fxRateToBaseMicros.present
+        ? fxRateToBaseMicros.value
+        : this.fxRateToBaseMicros,
+    toAmount: toAmount.present ? toAmount.value : this.toAmount,
+    toCurrencyCode: toCurrencyCode.present
+        ? toCurrencyCode.value
+        : this.toCurrencyCode,
+    toFxRateToBaseMicros: toFxRateToBaseMicros.present
+        ? toFxRateToBaseMicros.value
+        : this.toFxRateToBaseMicros,
   );
   TransactionRow copyWithCompanion(TransactionsCompanion data) {
     return TransactionRow(
@@ -4204,6 +4486,19 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       foreignAmount: data.foreignAmount.present
           ? data.foreignAmount.value
           : this.foreignAmount,
+      currencyCode: data.currencyCode.present
+          ? data.currencyCode.value
+          : this.currencyCode,
+      fxRateToBaseMicros: data.fxRateToBaseMicros.present
+          ? data.fxRateToBaseMicros.value
+          : this.fxRateToBaseMicros,
+      toAmount: data.toAmount.present ? data.toAmount.value : this.toAmount,
+      toCurrencyCode: data.toCurrencyCode.present
+          ? data.toCurrencyCode.value
+          : this.toCurrencyCode,
+      toFxRateToBaseMicros: data.toFxRateToBaseMicros.present
+          ? data.toFxRateToBaseMicros.value
+          : this.toFxRateToBaseMicros,
     );
   }
 
@@ -4227,13 +4522,18 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
           ..write('needsAmountReview: $needsAmountReview, ')
           ..write('paymentGroupId: $paymentGroupId, ')
           ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
-          ..write('foreignAmount: $foreignAmount')
+          ..write('foreignAmount: $foreignAmount, ')
+          ..write('currencyCode: $currencyCode, ')
+          ..write('fxRateToBaseMicros: $fxRateToBaseMicros, ')
+          ..write('toAmount: $toAmount, ')
+          ..write('toCurrencyCode: $toCurrencyCode, ')
+          ..write('toFxRateToBaseMicros: $toFxRateToBaseMicros')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     type,
     amount,
@@ -4252,7 +4552,12 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     paymentGroupId,
     foreignCurrencyCode,
     foreignAmount,
-  );
+    currencyCode,
+    fxRateToBaseMicros,
+    toAmount,
+    toCurrencyCode,
+    toFxRateToBaseMicros,
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -4274,7 +4579,12 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
           other.needsAmountReview == this.needsAmountReview &&
           other.paymentGroupId == this.paymentGroupId &&
           other.foreignCurrencyCode == this.foreignCurrencyCode &&
-          other.foreignAmount == this.foreignAmount);
+          other.foreignAmount == this.foreignAmount &&
+          other.currencyCode == this.currencyCode &&
+          other.fxRateToBaseMicros == this.fxRateToBaseMicros &&
+          other.toAmount == this.toAmount &&
+          other.toCurrencyCode == this.toCurrencyCode &&
+          other.toFxRateToBaseMicros == this.toFxRateToBaseMicros);
 }
 
 class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
@@ -4296,6 +4606,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
   final Value<int?> paymentGroupId;
   final Value<String?> foreignCurrencyCode;
   final Value<Money?> foreignAmount;
+  final Value<String?> currencyCode;
+  final Value<int?> fxRateToBaseMicros;
+  final Value<Money?> toAmount;
+  final Value<String?> toCurrencyCode;
+  final Value<int?> toFxRateToBaseMicros;
   const TransactionsCompanion({
     this.id = const Value.absent(),
     this.type = const Value.absent(),
@@ -4315,6 +4630,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     this.paymentGroupId = const Value.absent(),
     this.foreignCurrencyCode = const Value.absent(),
     this.foreignAmount = const Value.absent(),
+    this.currencyCode = const Value.absent(),
+    this.fxRateToBaseMicros = const Value.absent(),
+    this.toAmount = const Value.absent(),
+    this.toCurrencyCode = const Value.absent(),
+    this.toFxRateToBaseMicros = const Value.absent(),
   });
   TransactionsCompanion.insert({
     this.id = const Value.absent(),
@@ -4335,6 +4655,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     this.paymentGroupId = const Value.absent(),
     this.foreignCurrencyCode = const Value.absent(),
     this.foreignAmount = const Value.absent(),
+    this.currencyCode = const Value.absent(),
+    this.fxRateToBaseMicros = const Value.absent(),
+    this.toAmount = const Value.absent(),
+    this.toCurrencyCode = const Value.absent(),
+    this.toFxRateToBaseMicros = const Value.absent(),
   }) : type = Value(type),
        amount = Value(amount),
        accountId = Value(accountId),
@@ -4358,6 +4683,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     Expression<int>? paymentGroupId,
     Expression<String>? foreignCurrencyCode,
     Expression<int>? foreignAmount,
+    Expression<String>? currencyCode,
+    Expression<int>? fxRateToBaseMicros,
+    Expression<int>? toAmount,
+    Expression<String>? toCurrencyCode,
+    Expression<int>? toFxRateToBaseMicros,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -4379,6 +4709,13 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
       if (foreignCurrencyCode != null)
         'foreign_currency_code': foreignCurrencyCode,
       if (foreignAmount != null) 'foreign_amount': foreignAmount,
+      if (currencyCode != null) 'currency_code': currencyCode,
+      if (fxRateToBaseMicros != null)
+        'fx_rate_to_base_micros': fxRateToBaseMicros,
+      if (toAmount != null) 'to_amount': toAmount,
+      if (toCurrencyCode != null) 'to_currency_code': toCurrencyCode,
+      if (toFxRateToBaseMicros != null)
+        'to_fx_rate_to_base_micros': toFxRateToBaseMicros,
     });
   }
 
@@ -4401,6 +4738,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     Value<int?>? paymentGroupId,
     Value<String?>? foreignCurrencyCode,
     Value<Money?>? foreignAmount,
+    Value<String?>? currencyCode,
+    Value<int?>? fxRateToBaseMicros,
+    Value<Money?>? toAmount,
+    Value<String?>? toCurrencyCode,
+    Value<int?>? toFxRateToBaseMicros,
   }) {
     return TransactionsCompanion(
       id: id ?? this.id,
@@ -4421,6 +4763,11 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
       paymentGroupId: paymentGroupId ?? this.paymentGroupId,
       foreignCurrencyCode: foreignCurrencyCode ?? this.foreignCurrencyCode,
       foreignAmount: foreignAmount ?? this.foreignAmount,
+      currencyCode: currencyCode ?? this.currencyCode,
+      fxRateToBaseMicros: fxRateToBaseMicros ?? this.fxRateToBaseMicros,
+      toAmount: toAmount ?? this.toAmount,
+      toCurrencyCode: toCurrencyCode ?? this.toCurrencyCode,
+      toFxRateToBaseMicros: toFxRateToBaseMicros ?? this.toFxRateToBaseMicros,
     );
   }
 
@@ -4489,6 +4836,25 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
         $TransactionsTable.$converterforeignAmountn.toSql(foreignAmount.value),
       );
     }
+    if (currencyCode.present) {
+      map['currency_code'] = Variable<String>(currencyCode.value);
+    }
+    if (fxRateToBaseMicros.present) {
+      map['fx_rate_to_base_micros'] = Variable<int>(fxRateToBaseMicros.value);
+    }
+    if (toAmount.present) {
+      map['to_amount'] = Variable<int>(
+        $TransactionsTable.$convertertoAmountn.toSql(toAmount.value),
+      );
+    }
+    if (toCurrencyCode.present) {
+      map['to_currency_code'] = Variable<String>(toCurrencyCode.value);
+    }
+    if (toFxRateToBaseMicros.present) {
+      map['to_fx_rate_to_base_micros'] = Variable<int>(
+        toFxRateToBaseMicros.value,
+      );
+    }
     return map;
   }
 
@@ -4512,7 +4878,12 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
           ..write('needsAmountReview: $needsAmountReview, ')
           ..write('paymentGroupId: $paymentGroupId, ')
           ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
-          ..write('foreignAmount: $foreignAmount')
+          ..write('foreignAmount: $foreignAmount, ')
+          ..write('currencyCode: $currencyCode, ')
+          ..write('fxRateToBaseMicros: $fxRateToBaseMicros, ')
+          ..write('toAmount: $toAmount, ')
+          ..write('toCurrencyCode: $toCurrencyCode, ')
+          ..write('toFxRateToBaseMicros: $toFxRateToBaseMicros')
           ..write(')'))
         .toString();
   }
@@ -19225,6 +19596,383 @@ class CreditCardDetailsCompanion extends UpdateCompanion<CreditCardDetailRow> {
   }
 }
 
+class $CurrencyRatesTable extends CurrencyRates
+    with TableInfo<$CurrencyRatesTable, CurrencyRateRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CurrencyRatesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _currencyCodeMeta = const VerificationMeta(
+    'currencyCode',
+  );
+  @override
+  late final GeneratedColumn<String> currencyCode = GeneratedColumn<String>(
+    'currency_code',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 3,
+      maxTextLength: 3,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _rateToBaseMicrosMeta = const VerificationMeta(
+    'rateToBaseMicros',
+  );
+  @override
+  late final GeneratedColumn<int> rateToBaseMicros = GeneratedColumn<int>(
+    'rate_to_base_micros',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _effectiveAtMeta = const VerificationMeta(
+    'effectiveAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> effectiveAt = GeneratedColumn<DateTime>(
+    'effective_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    currencyCode,
+    rateToBaseMicros,
+    effectiveAt,
+    createdAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'currency_rates';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CurrencyRateRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('currency_code')) {
+      context.handle(
+        _currencyCodeMeta,
+        currencyCode.isAcceptableOrUnknown(
+          data['currency_code']!,
+          _currencyCodeMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_currencyCodeMeta);
+    }
+    if (data.containsKey('rate_to_base_micros')) {
+      context.handle(
+        _rateToBaseMicrosMeta,
+        rateToBaseMicros.isAcceptableOrUnknown(
+          data['rate_to_base_micros']!,
+          _rateToBaseMicrosMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_rateToBaseMicrosMeta);
+    }
+    if (data.containsKey('effective_at')) {
+      context.handle(
+        _effectiveAtMeta,
+        effectiveAt.isAcceptableOrUnknown(
+          data['effective_at']!,
+          _effectiveAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_effectiveAtMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CurrencyRateRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CurrencyRateRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      currencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}currency_code'],
+      )!,
+      rateToBaseMicros: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}rate_to_base_micros'],
+      )!,
+      effectiveAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}effective_at'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $CurrencyRatesTable createAlias(String alias) {
+    return $CurrencyRatesTable(attachedDatabase, alias);
+  }
+}
+
+class CurrencyRateRow extends DataClass implements Insertable<CurrencyRateRow> {
+  final int id;
+
+  /// The non-parent currency this rate prices, e.g. `USD`. Never the parent
+  /// currency itself, which is always 1:1 with itself.
+  final String currencyCode;
+
+  /// Units of the parent currency per 1 unit of [currencyCode], scaled by
+  /// [currencyRateScale] so it's an exact integer — never a `double`, the
+  /// same rule [Money] follows. `83_120_000` means 1 unit = 83.12 parent.
+  final int rateToBaseMicros;
+  final DateTime effectiveAt;
+  final DateTime createdAt;
+  const CurrencyRateRow({
+    required this.id,
+    required this.currencyCode,
+    required this.rateToBaseMicros,
+    required this.effectiveAt,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['currency_code'] = Variable<String>(currencyCode);
+    map['rate_to_base_micros'] = Variable<int>(rateToBaseMicros);
+    map['effective_at'] = Variable<DateTime>(effectiveAt);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  CurrencyRatesCompanion toCompanion(bool nullToAbsent) {
+    return CurrencyRatesCompanion(
+      id: Value(id),
+      currencyCode: Value(currencyCode),
+      rateToBaseMicros: Value(rateToBaseMicros),
+      effectiveAt: Value(effectiveAt),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory CurrencyRateRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CurrencyRateRow(
+      id: serializer.fromJson<int>(json['id']),
+      currencyCode: serializer.fromJson<String>(json['currencyCode']),
+      rateToBaseMicros: serializer.fromJson<int>(json['rateToBaseMicros']),
+      effectiveAt: serializer.fromJson<DateTime>(json['effectiveAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'currencyCode': serializer.toJson<String>(currencyCode),
+      'rateToBaseMicros': serializer.toJson<int>(rateToBaseMicros),
+      'effectiveAt': serializer.toJson<DateTime>(effectiveAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  CurrencyRateRow copyWith({
+    int? id,
+    String? currencyCode,
+    int? rateToBaseMicros,
+    DateTime? effectiveAt,
+    DateTime? createdAt,
+  }) => CurrencyRateRow(
+    id: id ?? this.id,
+    currencyCode: currencyCode ?? this.currencyCode,
+    rateToBaseMicros: rateToBaseMicros ?? this.rateToBaseMicros,
+    effectiveAt: effectiveAt ?? this.effectiveAt,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  CurrencyRateRow copyWithCompanion(CurrencyRatesCompanion data) {
+    return CurrencyRateRow(
+      id: data.id.present ? data.id.value : this.id,
+      currencyCode: data.currencyCode.present
+          ? data.currencyCode.value
+          : this.currencyCode,
+      rateToBaseMicros: data.rateToBaseMicros.present
+          ? data.rateToBaseMicros.value
+          : this.rateToBaseMicros,
+      effectiveAt: data.effectiveAt.present
+          ? data.effectiveAt.value
+          : this.effectiveAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CurrencyRateRow(')
+          ..write('id: $id, ')
+          ..write('currencyCode: $currencyCode, ')
+          ..write('rateToBaseMicros: $rateToBaseMicros, ')
+          ..write('effectiveAt: $effectiveAt, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, currencyCode, rateToBaseMicros, effectiveAt, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CurrencyRateRow &&
+          other.id == this.id &&
+          other.currencyCode == this.currencyCode &&
+          other.rateToBaseMicros == this.rateToBaseMicros &&
+          other.effectiveAt == this.effectiveAt &&
+          other.createdAt == this.createdAt);
+}
+
+class CurrencyRatesCompanion extends UpdateCompanion<CurrencyRateRow> {
+  final Value<int> id;
+  final Value<String> currencyCode;
+  final Value<int> rateToBaseMicros;
+  final Value<DateTime> effectiveAt;
+  final Value<DateTime> createdAt;
+  const CurrencyRatesCompanion({
+    this.id = const Value.absent(),
+    this.currencyCode = const Value.absent(),
+    this.rateToBaseMicros = const Value.absent(),
+    this.effectiveAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  CurrencyRatesCompanion.insert({
+    this.id = const Value.absent(),
+    required String currencyCode,
+    required int rateToBaseMicros,
+    required DateTime effectiveAt,
+    this.createdAt = const Value.absent(),
+  }) : currencyCode = Value(currencyCode),
+       rateToBaseMicros = Value(rateToBaseMicros),
+       effectiveAt = Value(effectiveAt);
+  static Insertable<CurrencyRateRow> custom({
+    Expression<int>? id,
+    Expression<String>? currencyCode,
+    Expression<int>? rateToBaseMicros,
+    Expression<DateTime>? effectiveAt,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (currencyCode != null) 'currency_code': currencyCode,
+      if (rateToBaseMicros != null) 'rate_to_base_micros': rateToBaseMicros,
+      if (effectiveAt != null) 'effective_at': effectiveAt,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  CurrencyRatesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? currencyCode,
+    Value<int>? rateToBaseMicros,
+    Value<DateTime>? effectiveAt,
+    Value<DateTime>? createdAt,
+  }) {
+    return CurrencyRatesCompanion(
+      id: id ?? this.id,
+      currencyCode: currencyCode ?? this.currencyCode,
+      rateToBaseMicros: rateToBaseMicros ?? this.rateToBaseMicros,
+      effectiveAt: effectiveAt ?? this.effectiveAt,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (currencyCode.present) {
+      map['currency_code'] = Variable<String>(currencyCode.value);
+    }
+    if (rateToBaseMicros.present) {
+      map['rate_to_base_micros'] = Variable<int>(rateToBaseMicros.value);
+    }
+    if (effectiveAt.present) {
+      map['effective_at'] = Variable<DateTime>(effectiveAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CurrencyRatesCompanion(')
+          ..write('id: $id, ')
+          ..write('currencyCode: $currencyCode, ')
+          ..write('rateToBaseMicros: $rateToBaseMicros, ')
+          ..write('effectiveAt: $effectiveAt, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -19268,6 +20016,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $OcrCorrectionsTable ocrCorrections = $OcrCorrectionsTable(this);
   late final $CreditCardDetailsTable creditCardDetails =
       $CreditCardDetailsTable(this);
+  late final $CurrencyRatesTable currencyRates = $CurrencyRatesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -19305,6 +20054,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     allocations,
     ocrCorrections,
     creditCardDetails,
+    currencyRates,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -19343,6 +20093,7 @@ typedef $$AccountsTableCreateCompanionBuilder =
       Value<DateTime> createdAt,
       Value<bool> envelopeMode,
       Value<bool> includeInNetWorth,
+      Value<String?> currencyCode,
     });
 typedef $$AccountsTableUpdateCompanionBuilder =
     AccountsCompanion Function({
@@ -19362,6 +20113,7 @@ typedef $$AccountsTableUpdateCompanionBuilder =
       Value<DateTime> createdAt,
       Value<bool> envelopeMode,
       Value<bool> includeInNetWorth,
+      Value<String?> currencyCode,
     });
 
 final class $$AccountsTableReferences
@@ -19665,6 +20417,11 @@ class $$AccountsTableFilterComposer
 
   ColumnFilters<bool> get includeInNetWorth => $composableBuilder(
     column: $table.includeInNetWorth,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -20026,6 +20783,11 @@ class $$AccountsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$AccountsTableOrderingComposer get linkedAccountId {
     final $$AccountsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -20115,6 +20877,11 @@ class $$AccountsTableAnnotationComposer
 
   GeneratedColumn<bool> get includeInNetWorth => $composableBuilder(
     column: $table.includeInNetWorth,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
     builder: (column) => column,
   );
 
@@ -20449,6 +21216,7 @@ class $$AccountsTableTableManager
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<bool> envelopeMode = const Value.absent(),
                 Value<bool> includeInNetWorth = const Value.absent(),
+                Value<String?> currencyCode = const Value.absent(),
               }) => AccountsCompanion(
                 id: id,
                 name: name,
@@ -20466,6 +21234,7 @@ class $$AccountsTableTableManager
                 createdAt: createdAt,
                 envelopeMode: envelopeMode,
                 includeInNetWorth: includeInNetWorth,
+                currencyCode: currencyCode,
               ),
           createCompanionCallback:
               ({
@@ -20485,6 +21254,7 @@ class $$AccountsTableTableManager
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<bool> envelopeMode = const Value.absent(),
                 Value<bool> includeInNetWorth = const Value.absent(),
+                Value<String?> currencyCode = const Value.absent(),
               }) => AccountsCompanion.insert(
                 id: id,
                 name: name,
@@ -20502,6 +21272,7 @@ class $$AccountsTableTableManager
                 createdAt: createdAt,
                 envelopeMode: envelopeMode,
                 includeInNetWorth: includeInNetWorth,
+                currencyCode: currencyCode,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -24200,6 +24971,11 @@ typedef $$TransactionsTableCreateCompanionBuilder =
       Value<int?> paymentGroupId,
       Value<String?> foreignCurrencyCode,
       Value<Money?> foreignAmount,
+      Value<String?> currencyCode,
+      Value<int?> fxRateToBaseMicros,
+      Value<Money?> toAmount,
+      Value<String?> toCurrencyCode,
+      Value<int?> toFxRateToBaseMicros,
     });
 typedef $$TransactionsTableUpdateCompanionBuilder =
     TransactionsCompanion Function({
@@ -24221,6 +24997,11 @@ typedef $$TransactionsTableUpdateCompanionBuilder =
       Value<int?> paymentGroupId,
       Value<String?> foreignCurrencyCode,
       Value<Money?> foreignAmount,
+      Value<String?> currencyCode,
+      Value<int?> fxRateToBaseMicros,
+      Value<Money?> toAmount,
+      Value<String?> toCurrencyCode,
+      Value<int?> toFxRateToBaseMicros,
     });
 
 final class $$TransactionsTableReferences
@@ -24556,6 +25337,32 @@ class $$TransactionsTableFilterComposer
         column: $table.foreignAmount,
         builder: (column) => ColumnWithTypeConverterFilters(column),
       );
+
+  ColumnFilters<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fxRateToBaseMicros => $composableBuilder(
+    column: $table.fxRateToBaseMicros,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<Money?, Money, int> get toAmount =>
+      $composableBuilder(
+        column: $table.toAmount,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
+
+  ColumnFilters<String> get toCurrencyCode => $composableBuilder(
+    column: $table.toCurrencyCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get toFxRateToBaseMicros => $composableBuilder(
+    column: $table.toFxRateToBaseMicros,
+    builder: (column) => ColumnFilters(column),
+  );
 
   $$AccountsTableFilterComposer get accountId {
     final $$AccountsTableFilterComposer composer = $composerBuilder(
@@ -24915,6 +25722,31 @@ class $$TransactionsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fxRateToBaseMicros => $composableBuilder(
+    column: $table.fxRateToBaseMicros,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get toAmount => $composableBuilder(
+    column: $table.toAmount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get toCurrencyCode => $composableBuilder(
+    column: $table.toCurrencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get toFxRateToBaseMicros => $composableBuilder(
+    column: $table.toFxRateToBaseMicros,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$AccountsTableOrderingComposer get accountId {
     final $$AccountsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -25105,6 +25937,29 @@ class $$TransactionsTableAnnotationComposer
         column: $table.foreignAmount,
         builder: (column) => column,
       );
+
+  GeneratedColumn<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get fxRateToBaseMicros => $composableBuilder(
+    column: $table.fxRateToBaseMicros,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<Money?, int> get toAmount =>
+      $composableBuilder(column: $table.toAmount, builder: (column) => column);
+
+  GeneratedColumn<String> get toCurrencyCode => $composableBuilder(
+    column: $table.toCurrencyCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get toFxRateToBaseMicros => $composableBuilder(
+    column: $table.toFxRateToBaseMicros,
+    builder: (column) => column,
+  );
 
   $$AccountsTableAnnotationComposer get accountId {
     final $$AccountsTableAnnotationComposer composer = $composerBuilder(
@@ -25456,6 +26311,11 @@ class $$TransactionsTableTableManager
                 Value<int?> paymentGroupId = const Value.absent(),
                 Value<String?> foreignCurrencyCode = const Value.absent(),
                 Value<Money?> foreignAmount = const Value.absent(),
+                Value<String?> currencyCode = const Value.absent(),
+                Value<int?> fxRateToBaseMicros = const Value.absent(),
+                Value<Money?> toAmount = const Value.absent(),
+                Value<String?> toCurrencyCode = const Value.absent(),
+                Value<int?> toFxRateToBaseMicros = const Value.absent(),
               }) => TransactionsCompanion(
                 id: id,
                 type: type,
@@ -25475,6 +26335,11 @@ class $$TransactionsTableTableManager
                 paymentGroupId: paymentGroupId,
                 foreignCurrencyCode: foreignCurrencyCode,
                 foreignAmount: foreignAmount,
+                currencyCode: currencyCode,
+                fxRateToBaseMicros: fxRateToBaseMicros,
+                toAmount: toAmount,
+                toCurrencyCode: toCurrencyCode,
+                toFxRateToBaseMicros: toFxRateToBaseMicros,
               ),
           createCompanionCallback:
               ({
@@ -25496,6 +26361,11 @@ class $$TransactionsTableTableManager
                 Value<int?> paymentGroupId = const Value.absent(),
                 Value<String?> foreignCurrencyCode = const Value.absent(),
                 Value<Money?> foreignAmount = const Value.absent(),
+                Value<String?> currencyCode = const Value.absent(),
+                Value<int?> fxRateToBaseMicros = const Value.absent(),
+                Value<Money?> toAmount = const Value.absent(),
+                Value<String?> toCurrencyCode = const Value.absent(),
+                Value<int?> toFxRateToBaseMicros = const Value.absent(),
               }) => TransactionsCompanion.insert(
                 id: id,
                 type: type,
@@ -25515,6 +26385,11 @@ class $$TransactionsTableTableManager
                 paymentGroupId: paymentGroupId,
                 foreignCurrencyCode: foreignCurrencyCode,
                 foreignAmount: foreignAmount,
+                currencyCode: currencyCode,
+                fxRateToBaseMicros: fxRateToBaseMicros,
+                toAmount: toAmount,
+                toCurrencyCode: toCurrencyCode,
+                toFxRateToBaseMicros: toFxRateToBaseMicros,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -38422,6 +39297,206 @@ typedef $$CreditCardDetailsTableProcessedTableManager =
       CreditCardDetailRow,
       PrefetchHooks Function({bool accountId})
     >;
+typedef $$CurrencyRatesTableCreateCompanionBuilder =
+    CurrencyRatesCompanion Function({
+      Value<int> id,
+      required String currencyCode,
+      required int rateToBaseMicros,
+      required DateTime effectiveAt,
+      Value<DateTime> createdAt,
+    });
+typedef $$CurrencyRatesTableUpdateCompanionBuilder =
+    CurrencyRatesCompanion Function({
+      Value<int> id,
+      Value<String> currencyCode,
+      Value<int> rateToBaseMicros,
+      Value<DateTime> effectiveAt,
+      Value<DateTime> createdAt,
+    });
+
+class $$CurrencyRatesTableFilterComposer
+    extends Composer<_$AppDatabase, $CurrencyRatesTable> {
+  $$CurrencyRatesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get rateToBaseMicros => $composableBuilder(
+    column: $table.rateToBaseMicros,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get effectiveAt => $composableBuilder(
+    column: $table.effectiveAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$CurrencyRatesTableOrderingComposer
+    extends Composer<_$AppDatabase, $CurrencyRatesTable> {
+  $$CurrencyRatesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get rateToBaseMicros => $composableBuilder(
+    column: $table.rateToBaseMicros,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get effectiveAt => $composableBuilder(
+    column: $table.effectiveAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$CurrencyRatesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $CurrencyRatesTable> {
+  $$CurrencyRatesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get currencyCode => $composableBuilder(
+    column: $table.currencyCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get rateToBaseMicros => $composableBuilder(
+    column: $table.rateToBaseMicros,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get effectiveAt => $composableBuilder(
+    column: $table.effectiveAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+}
+
+class $$CurrencyRatesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $CurrencyRatesTable,
+          CurrencyRateRow,
+          $$CurrencyRatesTableFilterComposer,
+          $$CurrencyRatesTableOrderingComposer,
+          $$CurrencyRatesTableAnnotationComposer,
+          $$CurrencyRatesTableCreateCompanionBuilder,
+          $$CurrencyRatesTableUpdateCompanionBuilder,
+          (
+            CurrencyRateRow,
+            BaseReferences<_$AppDatabase, $CurrencyRatesTable, CurrencyRateRow>,
+          ),
+          CurrencyRateRow,
+          PrefetchHooks Function()
+        > {
+  $$CurrencyRatesTableTableManager(_$AppDatabase db, $CurrencyRatesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$CurrencyRatesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$CurrencyRatesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$CurrencyRatesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> currencyCode = const Value.absent(),
+                Value<int> rateToBaseMicros = const Value.absent(),
+                Value<DateTime> effectiveAt = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => CurrencyRatesCompanion(
+                id: id,
+                currencyCode: currencyCode,
+                rateToBaseMicros: rateToBaseMicros,
+                effectiveAt: effectiveAt,
+                createdAt: createdAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String currencyCode,
+                required int rateToBaseMicros,
+                required DateTime effectiveAt,
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => CurrencyRatesCompanion.insert(
+                id: id,
+                currencyCode: currencyCode,
+                rateToBaseMicros: rateToBaseMicros,
+                effectiveAt: effectiveAt,
+                createdAt: createdAt,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$CurrencyRatesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $CurrencyRatesTable,
+      CurrencyRateRow,
+      $$CurrencyRatesTableFilterComposer,
+      $$CurrencyRatesTableOrderingComposer,
+      $$CurrencyRatesTableAnnotationComposer,
+      $$CurrencyRatesTableCreateCompanionBuilder,
+      $$CurrencyRatesTableUpdateCompanionBuilder,
+      (
+        CurrencyRateRow,
+        BaseReferences<_$AppDatabase, $CurrencyRatesTable, CurrencyRateRow>,
+      ),
+      CurrencyRateRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -38489,4 +39564,6 @@ class $AppDatabaseManager {
       $$OcrCorrectionsTableTableManager(_db, _db.ocrCorrections);
   $$CreditCardDetailsTableTableManager get creditCardDetails =>
       $$CreditCardDetailsTableTableManager(_db, _db.creditCardDetails);
+  $$CurrencyRatesTableTableManager get currencyRates =>
+      $$CurrencyRatesTableTableManager(_db, _db.currencyRates);
 }

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -2416,6 +2416,26 @@ class $RecurringRulesTable extends RecurringRules
     requiredDuringInsert: false,
     defaultValue: currentDateAndTime,
   );
+  static const VerificationMeta _foreignCurrencyCodeMeta =
+      const VerificationMeta('foreignCurrencyCode');
+  @override
+  late final GeneratedColumn<String> foreignCurrencyCode =
+      GeneratedColumn<String>(
+        'foreign_currency_code',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  @override
+  late final GeneratedColumnWithTypeConverter<Money?, int> foreignAmount =
+      GeneratedColumn<int>(
+        'foreign_amount',
+        aliasedName,
+        true,
+        type: DriftSqlType.int,
+        requiredDuringInsert: false,
+      ).withConverter<Money?>($RecurringRulesTable.$converterforeignAmountn);
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -2436,6 +2456,8 @@ class $RecurringRulesTable extends RecurringRules
     promoAmount,
     promoOccurrencesLeft,
     createdAt,
+    foreignCurrencyCode,
+    foreignAmount,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -2551,6 +2573,15 @@ class $RecurringRulesTable extends RecurringRules
         createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
       );
     }
+    if (data.containsKey('foreign_currency_code')) {
+      context.handle(
+        _foreignCurrencyCodeMeta,
+        foreignCurrencyCode.isAcceptableOrUnknown(
+          data['foreign_currency_code']!,
+          _foreignCurrencyCodeMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -2640,6 +2671,16 @@ class $RecurringRulesTable extends RecurringRules
         DriftSqlType.dateTime,
         data['${effectivePrefix}created_at'],
       )!,
+      foreignCurrencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}foreign_currency_code'],
+      ),
+      foreignAmount: $RecurringRulesTable.$converterforeignAmountn.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.int,
+          data['${effectivePrefix}foreign_amount'],
+        ),
+      ),
     );
   }
 
@@ -2659,6 +2700,10 @@ class $RecurringRulesTable extends RecurringRules
       const MoneyConverter();
   static TypeConverter<Money?, int?> $converterpromoAmountn =
       NullAwareTypeConverter.wrap($converterpromoAmount);
+  static TypeConverter<Money, int> $converterforeignAmount =
+      const MoneyConverter();
+  static TypeConverter<Money?, int?> $converterforeignAmountn =
+      NullAwareTypeConverter.wrap($converterforeignAmount);
 }
 
 class RecurringRuleRow extends DataClass
@@ -2730,6 +2775,16 @@ class RecurringRuleRow extends DataClass
   /// the promotion is set up.
   final int? promoOccurrencesLeft;
   final DateTime createdAt;
+
+  /// Same annotation as [Transactions.foreignCurrencyCode]/
+  /// [Transactions.foreignAmount] (GitHub #85), carried on the rule so every
+  /// occurrence it posts keeps showing its original foreign-currency price
+  /// (e.g. a $9.99 subscription). Copied onto each posted transaction by
+  /// [AppDatabase.runDueRecurringRules] — except while a promo price is
+  /// active, since there is no tracked foreign equivalent for [promoAmount].
+  /// Always null exactly when [foreignAmount] is null.
+  final String? foreignCurrencyCode;
+  final Money? foreignAmount;
   const RecurringRuleRow({
     required this.id,
     required this.name,
@@ -2749,6 +2804,8 @@ class RecurringRuleRow extends DataClass
     this.promoAmount,
     this.promoOccurrencesLeft,
     required this.createdAt,
+    this.foreignCurrencyCode,
+    this.foreignAmount,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -2799,6 +2856,14 @@ class RecurringRuleRow extends DataClass
       map['promo_occurrences_left'] = Variable<int>(promoOccurrencesLeft);
     }
     map['created_at'] = Variable<DateTime>(createdAt);
+    if (!nullToAbsent || foreignCurrencyCode != null) {
+      map['foreign_currency_code'] = Variable<String>(foreignCurrencyCode);
+    }
+    if (!nullToAbsent || foreignAmount != null) {
+      map['foreign_amount'] = Variable<int>(
+        $RecurringRulesTable.$converterforeignAmountn.toSql(foreignAmount),
+      );
+    }
     return map;
   }
 
@@ -2834,6 +2899,12 @@ class RecurringRuleRow extends DataClass
           ? const Value.absent()
           : Value(promoOccurrencesLeft),
       createdAt: Value(createdAt),
+      foreignCurrencyCode: foreignCurrencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(foreignCurrencyCode),
+      foreignAmount: foreignAmount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(foreignAmount),
     );
   }
 
@@ -2867,6 +2938,10 @@ class RecurringRuleRow extends DataClass
         json['promoOccurrencesLeft'],
       ),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      foreignCurrencyCode: serializer.fromJson<String?>(
+        json['foreignCurrencyCode'],
+      ),
+      foreignAmount: serializer.fromJson<Money?>(json['foreignAmount']),
     );
   }
   @override
@@ -2895,6 +2970,8 @@ class RecurringRuleRow extends DataClass
       'promoAmount': serializer.toJson<Money?>(promoAmount),
       'promoOccurrencesLeft': serializer.toJson<int?>(promoOccurrencesLeft),
       'createdAt': serializer.toJson<DateTime>(createdAt),
+      'foreignCurrencyCode': serializer.toJson<String?>(foreignCurrencyCode),
+      'foreignAmount': serializer.toJson<Money?>(foreignAmount),
     };
   }
 
@@ -2917,6 +2994,8 @@ class RecurringRuleRow extends DataClass
     Value<Money?> promoAmount = const Value.absent(),
     Value<int?> promoOccurrencesLeft = const Value.absent(),
     DateTime? createdAt,
+    Value<String?> foreignCurrencyCode = const Value.absent(),
+    Value<Money?> foreignAmount = const Value.absent(),
   }) => RecurringRuleRow(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -2938,6 +3017,12 @@ class RecurringRuleRow extends DataClass
         ? promoOccurrencesLeft.value
         : this.promoOccurrencesLeft,
     createdAt: createdAt ?? this.createdAt,
+    foreignCurrencyCode: foreignCurrencyCode.present
+        ? foreignCurrencyCode.value
+        : this.foreignCurrencyCode,
+    foreignAmount: foreignAmount.present
+        ? foreignAmount.value
+        : this.foreignAmount,
   );
   RecurringRuleRow copyWithCompanion(RecurringRulesCompanion data) {
     return RecurringRuleRow(
@@ -2975,6 +3060,12 @@ class RecurringRuleRow extends DataClass
           ? data.promoOccurrencesLeft.value
           : this.promoOccurrencesLeft,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      foreignCurrencyCode: data.foreignCurrencyCode.present
+          ? data.foreignCurrencyCode.value
+          : this.foreignCurrencyCode,
+      foreignAmount: data.foreignAmount.present
+          ? data.foreignAmount.value
+          : this.foreignAmount,
     );
   }
 
@@ -2998,7 +3089,9 @@ class RecurringRuleRow extends DataClass
           ..write('isEstimate: $isEstimate, ')
           ..write('promoAmount: $promoAmount, ')
           ..write('promoOccurrencesLeft: $promoOccurrencesLeft, ')
-          ..write('createdAt: $createdAt')
+          ..write('createdAt: $createdAt, ')
+          ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
+          ..write('foreignAmount: $foreignAmount')
           ..write(')'))
         .toString();
   }
@@ -3023,6 +3116,8 @@ class RecurringRuleRow extends DataClass
     promoAmount,
     promoOccurrencesLeft,
     createdAt,
+    foreignCurrencyCode,
+    foreignAmount,
   );
   @override
   bool operator ==(Object other) =>
@@ -3045,7 +3140,9 @@ class RecurringRuleRow extends DataClass
           other.isEstimate == this.isEstimate &&
           other.promoAmount == this.promoAmount &&
           other.promoOccurrencesLeft == this.promoOccurrencesLeft &&
-          other.createdAt == this.createdAt);
+          other.createdAt == this.createdAt &&
+          other.foreignCurrencyCode == this.foreignCurrencyCode &&
+          other.foreignAmount == this.foreignAmount);
 }
 
 class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
@@ -3067,6 +3164,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
   final Value<Money?> promoAmount;
   final Value<int?> promoOccurrencesLeft;
   final Value<DateTime> createdAt;
+  final Value<String?> foreignCurrencyCode;
+  final Value<Money?> foreignAmount;
   const RecurringRulesCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
@@ -3086,6 +3185,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     this.promoAmount = const Value.absent(),
     this.promoOccurrencesLeft = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.foreignCurrencyCode = const Value.absent(),
+    this.foreignAmount = const Value.absent(),
   });
   RecurringRulesCompanion.insert({
     this.id = const Value.absent(),
@@ -3106,6 +3207,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     this.promoAmount = const Value.absent(),
     this.promoOccurrencesLeft = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.foreignCurrencyCode = const Value.absent(),
+    this.foreignAmount = const Value.absent(),
   }) : name = Value(name),
        kind = Value(kind),
        amount = Value(amount),
@@ -3131,6 +3234,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     Expression<int>? promoAmount,
     Expression<int>? promoOccurrencesLeft,
     Expression<DateTime>? createdAt,
+    Expression<String>? foreignCurrencyCode,
+    Expression<int>? foreignAmount,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -3152,6 +3257,9 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
       if (promoOccurrencesLeft != null)
         'promo_occurrences_left': promoOccurrencesLeft,
       if (createdAt != null) 'created_at': createdAt,
+      if (foreignCurrencyCode != null)
+        'foreign_currency_code': foreignCurrencyCode,
+      if (foreignAmount != null) 'foreign_amount': foreignAmount,
     });
   }
 
@@ -3174,6 +3282,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     Value<Money?>? promoAmount,
     Value<int?>? promoOccurrencesLeft,
     Value<DateTime>? createdAt,
+    Value<String?>? foreignCurrencyCode,
+    Value<Money?>? foreignAmount,
   }) {
     return RecurringRulesCompanion(
       id: id ?? this.id,
@@ -3194,6 +3304,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
       promoAmount: promoAmount ?? this.promoAmount,
       promoOccurrencesLeft: promoOccurrencesLeft ?? this.promoOccurrencesLeft,
       createdAt: createdAt ?? this.createdAt,
+      foreignCurrencyCode: foreignCurrencyCode ?? this.foreignCurrencyCode,
+      foreignAmount: foreignAmount ?? this.foreignAmount,
     );
   }
 
@@ -3262,6 +3374,18 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     if (createdAt.present) {
       map['created_at'] = Variable<DateTime>(createdAt.value);
     }
+    if (foreignCurrencyCode.present) {
+      map['foreign_currency_code'] = Variable<String>(
+        foreignCurrencyCode.value,
+      );
+    }
+    if (foreignAmount.present) {
+      map['foreign_amount'] = Variable<int>(
+        $RecurringRulesTable.$converterforeignAmountn.toSql(
+          foreignAmount.value,
+        ),
+      );
+    }
     return map;
   }
 
@@ -3285,7 +3409,9 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
           ..write('isEstimate: $isEstimate, ')
           ..write('promoAmount: $promoAmount, ')
           ..write('promoOccurrencesLeft: $promoOccurrencesLeft, ')
-          ..write('createdAt: $createdAt')
+          ..write('createdAt: $createdAt, ')
+          ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
+          ..write('foreignAmount: $foreignAmount')
           ..write(')'))
         .toString();
   }
@@ -3493,6 +3619,26 @@ class $TransactionsTable extends Transactions
       'REFERENCES transactions (id)',
     ),
   );
+  static const VerificationMeta _foreignCurrencyCodeMeta =
+      const VerificationMeta('foreignCurrencyCode');
+  @override
+  late final GeneratedColumn<String> foreignCurrencyCode =
+      GeneratedColumn<String>(
+        'foreign_currency_code',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  @override
+  late final GeneratedColumnWithTypeConverter<Money?, int> foreignAmount =
+      GeneratedColumn<int>(
+        'foreign_amount',
+        aliasedName,
+        true,
+        type: DriftSqlType.int,
+        requiredDuringInsert: false,
+      ).withConverter<Money?>($TransactionsTable.$converterforeignAmountn);
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -3511,6 +3657,8 @@ class $TransactionsTable extends Transactions
     updatedAt,
     needsAmountReview,
     paymentGroupId,
+    foreignCurrencyCode,
+    foreignAmount,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -3621,6 +3769,15 @@ class $TransactionsTable extends Transactions
         ),
       );
     }
+    if (data.containsKey('foreign_currency_code')) {
+      context.handle(
+        _foreignCurrencyCodeMeta,
+        foreignCurrencyCode.isAcceptableOrUnknown(
+          data['foreign_currency_code']!,
+          _foreignCurrencyCodeMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -3698,6 +3855,16 @@ class $TransactionsTable extends Transactions
         DriftSqlType.int,
         data['${effectivePrefix}payment_group_id'],
       ),
+      foreignCurrencyCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}foreign_currency_code'],
+      ),
+      foreignAmount: $TransactionsTable.$converterforeignAmountn.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.int,
+          data['${effectivePrefix}foreign_amount'],
+        ),
+      ),
     );
   }
 
@@ -3709,6 +3876,10 @@ class $TransactionsTable extends Transactions
   static JsonTypeConverter2<TxType, String, String> $convertertype =
       const EnumNameConverter<TxType>(TxType.values);
   static TypeConverter<Money, int> $converteramount = const MoneyConverter();
+  static TypeConverter<Money, int> $converterforeignAmount =
+      const MoneyConverter();
+  static TypeConverter<Money?, int?> $converterforeignAmountn =
+      NullAwareTypeConverter.wrap($converterforeignAmount);
 }
 
 class TransactionRow extends DataClass implements Insertable<TransactionRow> {
@@ -3769,6 +3940,17 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
   /// mutually exclusive in the UI, to avoid the 2-D matrix of splitting
   /// both at once.
   final int? paymentGroupId;
+
+  /// What this cost in another currency, manually entered — e.g. "$9.99" for
+  /// a subscription actually charged as [amount] home-currency rupees
+  /// (GitHub #85). [amount] stays authoritative for every balance/net-worth/
+  /// envelope computation; this is a purely informational annotation. Always
+  /// null exactly when [foreignAmount] is null — never one without the
+  /// other, same pairing as [RecurringRules.promoAmount]/
+  /// [RecurringRules.promoOccurrencesLeft]. The implied conversion rate is
+  /// `amount / foreignAmount`, recomputed for display rather than stored.
+  final String? foreignCurrencyCode;
+  final Money? foreignAmount;
   const TransactionRow({
     required this.id,
     required this.type,
@@ -3786,6 +3968,8 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     required this.updatedAt,
     required this.needsAmountReview,
     this.paymentGroupId,
+    this.foreignCurrencyCode,
+    this.foreignAmount,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -3830,6 +4014,14 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     if (!nullToAbsent || paymentGroupId != null) {
       map['payment_group_id'] = Variable<int>(paymentGroupId);
     }
+    if (!nullToAbsent || foreignCurrencyCode != null) {
+      map['foreign_currency_code'] = Variable<String>(foreignCurrencyCode);
+    }
+    if (!nullToAbsent || foreignAmount != null) {
+      map['foreign_amount'] = Variable<int>(
+        $TransactionsTable.$converterforeignAmountn.toSql(foreignAmount),
+      );
+    }
     return map;
   }
 
@@ -3865,6 +4057,12 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       paymentGroupId: paymentGroupId == null && nullToAbsent
           ? const Value.absent()
           : Value(paymentGroupId),
+      foreignCurrencyCode: foreignCurrencyCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(foreignCurrencyCode),
+      foreignAmount: foreignAmount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(foreignAmount),
     );
   }
 
@@ -3892,6 +4090,10 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
       needsAmountReview: serializer.fromJson<bool>(json['needsAmountReview']),
       paymentGroupId: serializer.fromJson<int?>(json['paymentGroupId']),
+      foreignCurrencyCode: serializer.fromJson<String?>(
+        json['foreignCurrencyCode'],
+      ),
+      foreignAmount: serializer.fromJson<Money?>(json['foreignAmount']),
     );
   }
   @override
@@ -3916,6 +4118,8 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
       'needsAmountReview': serializer.toJson<bool>(needsAmountReview),
       'paymentGroupId': serializer.toJson<int?>(paymentGroupId),
+      'foreignCurrencyCode': serializer.toJson<String?>(foreignCurrencyCode),
+      'foreignAmount': serializer.toJson<Money?>(foreignAmount),
     };
   }
 
@@ -3936,6 +4140,8 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     DateTime? updatedAt,
     bool? needsAmountReview,
     Value<int?> paymentGroupId = const Value.absent(),
+    Value<String?> foreignCurrencyCode = const Value.absent(),
+    Value<Money?> foreignAmount = const Value.absent(),
   }) => TransactionRow(
     id: id ?? this.id,
     type: type ?? this.type,
@@ -3957,6 +4163,12 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     paymentGroupId: paymentGroupId.present
         ? paymentGroupId.value
         : this.paymentGroupId,
+    foreignCurrencyCode: foreignCurrencyCode.present
+        ? foreignCurrencyCode.value
+        : this.foreignCurrencyCode,
+    foreignAmount: foreignAmount.present
+        ? foreignAmount.value
+        : this.foreignAmount,
   );
   TransactionRow copyWithCompanion(TransactionsCompanion data) {
     return TransactionRow(
@@ -3986,6 +4198,12 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
       paymentGroupId: data.paymentGroupId.present
           ? data.paymentGroupId.value
           : this.paymentGroupId,
+      foreignCurrencyCode: data.foreignCurrencyCode.present
+          ? data.foreignCurrencyCode.value
+          : this.foreignCurrencyCode,
+      foreignAmount: data.foreignAmount.present
+          ? data.foreignAmount.value
+          : this.foreignAmount,
     );
   }
 
@@ -4007,7 +4225,9 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('needsAmountReview: $needsAmountReview, ')
-          ..write('paymentGroupId: $paymentGroupId')
+          ..write('paymentGroupId: $paymentGroupId, ')
+          ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
+          ..write('foreignAmount: $foreignAmount')
           ..write(')'))
         .toString();
   }
@@ -4030,6 +4250,8 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
     updatedAt,
     needsAmountReview,
     paymentGroupId,
+    foreignCurrencyCode,
+    foreignAmount,
   );
   @override
   bool operator ==(Object other) =>
@@ -4050,7 +4272,9 @@ class TransactionRow extends DataClass implements Insertable<TransactionRow> {
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt &&
           other.needsAmountReview == this.needsAmountReview &&
-          other.paymentGroupId == this.paymentGroupId);
+          other.paymentGroupId == this.paymentGroupId &&
+          other.foreignCurrencyCode == this.foreignCurrencyCode &&
+          other.foreignAmount == this.foreignAmount);
 }
 
 class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
@@ -4070,6 +4294,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
   final Value<DateTime> updatedAt;
   final Value<bool> needsAmountReview;
   final Value<int?> paymentGroupId;
+  final Value<String?> foreignCurrencyCode;
+  final Value<Money?> foreignAmount;
   const TransactionsCompanion({
     this.id = const Value.absent(),
     this.type = const Value.absent(),
@@ -4087,6 +4313,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     this.updatedAt = const Value.absent(),
     this.needsAmountReview = const Value.absent(),
     this.paymentGroupId = const Value.absent(),
+    this.foreignCurrencyCode = const Value.absent(),
+    this.foreignAmount = const Value.absent(),
   });
   TransactionsCompanion.insert({
     this.id = const Value.absent(),
@@ -4105,6 +4333,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     this.updatedAt = const Value.absent(),
     this.needsAmountReview = const Value.absent(),
     this.paymentGroupId = const Value.absent(),
+    this.foreignCurrencyCode = const Value.absent(),
+    this.foreignAmount = const Value.absent(),
   }) : type = Value(type),
        amount = Value(amount),
        accountId = Value(accountId),
@@ -4126,6 +4356,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     Expression<DateTime>? updatedAt,
     Expression<bool>? needsAmountReview,
     Expression<int>? paymentGroupId,
+    Expression<String>? foreignCurrencyCode,
+    Expression<int>? foreignAmount,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -4144,6 +4376,9 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
       if (updatedAt != null) 'updated_at': updatedAt,
       if (needsAmountReview != null) 'needs_amount_review': needsAmountReview,
       if (paymentGroupId != null) 'payment_group_id': paymentGroupId,
+      if (foreignCurrencyCode != null)
+        'foreign_currency_code': foreignCurrencyCode,
+      if (foreignAmount != null) 'foreign_amount': foreignAmount,
     });
   }
 
@@ -4164,6 +4399,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     Value<DateTime>? updatedAt,
     Value<bool>? needsAmountReview,
     Value<int?>? paymentGroupId,
+    Value<String?>? foreignCurrencyCode,
+    Value<Money?>? foreignAmount,
   }) {
     return TransactionsCompanion(
       id: id ?? this.id,
@@ -4182,6 +4419,8 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
       updatedAt: updatedAt ?? this.updatedAt,
       needsAmountReview: needsAmountReview ?? this.needsAmountReview,
       paymentGroupId: paymentGroupId ?? this.paymentGroupId,
+      foreignCurrencyCode: foreignCurrencyCode ?? this.foreignCurrencyCode,
+      foreignAmount: foreignAmount ?? this.foreignAmount,
     );
   }
 
@@ -4240,6 +4479,16 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
     if (paymentGroupId.present) {
       map['payment_group_id'] = Variable<int>(paymentGroupId.value);
     }
+    if (foreignCurrencyCode.present) {
+      map['foreign_currency_code'] = Variable<String>(
+        foreignCurrencyCode.value,
+      );
+    }
+    if (foreignAmount.present) {
+      map['foreign_amount'] = Variable<int>(
+        $TransactionsTable.$converterforeignAmountn.toSql(foreignAmount.value),
+      );
+    }
     return map;
   }
 
@@ -4261,7 +4510,9 @@ class TransactionsCompanion extends UpdateCompanion<TransactionRow> {
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('needsAmountReview: $needsAmountReview, ')
-          ..write('paymentGroupId: $paymentGroupId')
+          ..write('paymentGroupId: $paymentGroupId, ')
+          ..write('foreignCurrencyCode: $foreignCurrencyCode, ')
+          ..write('foreignAmount: $foreignAmount')
           ..write(')'))
         .toString();
   }
@@ -22928,6 +23179,8 @@ typedef $$RecurringRulesTableCreateCompanionBuilder =
       Value<Money?> promoAmount,
       Value<int?> promoOccurrencesLeft,
       Value<DateTime> createdAt,
+      Value<String?> foreignCurrencyCode,
+      Value<Money?> foreignAmount,
     });
 typedef $$RecurringRulesTableUpdateCompanionBuilder =
     RecurringRulesCompanion Function({
@@ -22949,6 +23202,8 @@ typedef $$RecurringRulesTableUpdateCompanionBuilder =
       Value<Money?> promoAmount,
       Value<int?> promoOccurrencesLeft,
       Value<DateTime> createdAt,
+      Value<String?> foreignCurrencyCode,
+      Value<Money?> foreignAmount,
     });
 
 final class $$RecurringRulesTableReferences
@@ -23150,6 +23405,17 @@ class $$RecurringRulesTableFilterComposer
     column: $table.createdAt,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<Money?, Money, int> get foreignAmount =>
+      $composableBuilder(
+        column: $table.foreignAmount,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
 
   $$AccountsTableFilterComposer get accountId {
     final $$AccountsTableFilterComposer composer = $composerBuilder(
@@ -23355,6 +23621,16 @@ class $$RecurringRulesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get foreignAmount => $composableBuilder(
+    column: $table.foreignAmount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$AccountsTableOrderingComposer get accountId {
     final $$AccountsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -23491,6 +23767,17 @@ class $$RecurringRulesTableAnnotationComposer
 
   GeneratedColumn<DateTime> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<Money?, int> get foreignAmount =>
+      $composableBuilder(
+        column: $table.foreignAmount,
+        builder: (column) => column,
+      );
 
   $$AccountsTableAnnotationComposer get accountId {
     final $$AccountsTableAnnotationComposer composer = $composerBuilder(
@@ -23667,6 +23954,8 @@ class $$RecurringRulesTableTableManager
                 Value<Money?> promoAmount = const Value.absent(),
                 Value<int?> promoOccurrencesLeft = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> foreignCurrencyCode = const Value.absent(),
+                Value<Money?> foreignAmount = const Value.absent(),
               }) => RecurringRulesCompanion(
                 id: id,
                 name: name,
@@ -23686,6 +23975,8 @@ class $$RecurringRulesTableTableManager
                 promoAmount: promoAmount,
                 promoOccurrencesLeft: promoOccurrencesLeft,
                 createdAt: createdAt,
+                foreignCurrencyCode: foreignCurrencyCode,
+                foreignAmount: foreignAmount,
               ),
           createCompanionCallback:
               ({
@@ -23707,6 +23998,8 @@ class $$RecurringRulesTableTableManager
                 Value<Money?> promoAmount = const Value.absent(),
                 Value<int?> promoOccurrencesLeft = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
+                Value<String?> foreignCurrencyCode = const Value.absent(),
+                Value<Money?> foreignAmount = const Value.absent(),
               }) => RecurringRulesCompanion.insert(
                 id: id,
                 name: name,
@@ -23726,6 +24019,8 @@ class $$RecurringRulesTableTableManager
                 promoAmount: promoAmount,
                 promoOccurrencesLeft: promoOccurrencesLeft,
                 createdAt: createdAt,
+                foreignCurrencyCode: foreignCurrencyCode,
+                foreignAmount: foreignAmount,
               ),
           withReferenceMapper: (p0) => p0
               .map(
@@ -23903,6 +24198,8 @@ typedef $$TransactionsTableCreateCompanionBuilder =
       Value<DateTime> updatedAt,
       Value<bool> needsAmountReview,
       Value<int?> paymentGroupId,
+      Value<String?> foreignCurrencyCode,
+      Value<Money?> foreignAmount,
     });
 typedef $$TransactionsTableUpdateCompanionBuilder =
     TransactionsCompanion Function({
@@ -23922,6 +24219,8 @@ typedef $$TransactionsTableUpdateCompanionBuilder =
       Value<DateTime> updatedAt,
       Value<bool> needsAmountReview,
       Value<int?> paymentGroupId,
+      Value<String?> foreignCurrencyCode,
+      Value<Money?> foreignAmount,
     });
 
 final class $$TransactionsTableReferences
@@ -24246,6 +24545,17 @@ class $$TransactionsTableFilterComposer
     column: $table.needsAmountReview,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<Money?, Money, int> get foreignAmount =>
+      $composableBuilder(
+        column: $table.foreignAmount,
+        builder: (column) => ColumnWithTypeConverterFilters(column),
+      );
 
   $$AccountsTableFilterComposer get accountId {
     final $$AccountsTableFilterComposer composer = $composerBuilder(
@@ -24595,6 +24905,16 @@ class $$TransactionsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get foreignAmount => $composableBuilder(
+    column: $table.foreignAmount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$AccountsTableOrderingComposer get accountId {
     final $$AccountsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -24774,6 +25094,17 @@ class $$TransactionsTableAnnotationComposer
     column: $table.needsAmountReview,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get foreignCurrencyCode => $composableBuilder(
+    column: $table.foreignCurrencyCode,
+    builder: (column) => column,
+  );
+
+  GeneratedColumnWithTypeConverter<Money?, int> get foreignAmount =>
+      $composableBuilder(
+        column: $table.foreignAmount,
+        builder: (column) => column,
+      );
 
   $$AccountsTableAnnotationComposer get accountId {
     final $$AccountsTableAnnotationComposer composer = $composerBuilder(
@@ -25123,6 +25454,8 @@ class $$TransactionsTableTableManager
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<bool> needsAmountReview = const Value.absent(),
                 Value<int?> paymentGroupId = const Value.absent(),
+                Value<String?> foreignCurrencyCode = const Value.absent(),
+                Value<Money?> foreignAmount = const Value.absent(),
               }) => TransactionsCompanion(
                 id: id,
                 type: type,
@@ -25140,6 +25473,8 @@ class $$TransactionsTableTableManager
                 updatedAt: updatedAt,
                 needsAmountReview: needsAmountReview,
                 paymentGroupId: paymentGroupId,
+                foreignCurrencyCode: foreignCurrencyCode,
+                foreignAmount: foreignAmount,
               ),
           createCompanionCallback:
               ({
@@ -25159,6 +25494,8 @@ class $$TransactionsTableTableManager
                 Value<DateTime> updatedAt = const Value.absent(),
                 Value<bool> needsAmountReview = const Value.absent(),
                 Value<int?> paymentGroupId = const Value.absent(),
+                Value<String?> foreignCurrencyCode = const Value.absent(),
+                Value<Money?> foreignAmount = const Value.absent(),
               }) => TransactionsCompanion.insert(
                 id: id,
                 type: type,
@@ -25176,6 +25513,8 @@ class $$TransactionsTableTableManager
                 updatedAt: updatedAt,
                 needsAmountReview: needsAmountReview,
                 paymentGroupId: paymentGroupId,
+                foreignCurrencyCode: foreignCurrencyCode,
+                foreignAmount: foreignAmount,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -2269,11 +2269,25 @@ class $RecurringRulesTable extends RecurringRules
   late final GeneratedColumn<int> categoryId = GeneratedColumn<int>(
     'category_id',
     aliasedName,
-    false,
+    true,
     type: DriftSqlType.int,
-    requiredDuringInsert: true,
+    requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways(
       'REFERENCES categories (id)',
+    ),
+  );
+  static const VerificationMeta _toAccountIdMeta = const VerificationMeta(
+    'toAccountId',
+  );
+  @override
+  late final GeneratedColumn<int> toAccountId = GeneratedColumn<int>(
+    'to_account_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES accounts (id)',
     ),
   );
   static const VerificationMeta _payeeMeta = const VerificationMeta('payee');
@@ -2410,6 +2424,7 @@ class $RecurringRulesTable extends RecurringRules
     amount,
     accountId,
     categoryId,
+    toAccountId,
     payee,
     note,
     frequency,
@@ -2458,8 +2473,15 @@ class $RecurringRulesTable extends RecurringRules
         _categoryIdMeta,
         categoryId.isAcceptableOrUnknown(data['category_id']!, _categoryIdMeta),
       );
-    } else if (isInserting) {
-      context.missing(_categoryIdMeta);
+    }
+    if (data.containsKey('to_account_id')) {
+      context.handle(
+        _toAccountIdMeta,
+        toAccountId.isAcceptableOrUnknown(
+          data['to_account_id']!,
+          _toAccountIdMeta,
+        ),
+      );
     }
     if (data.containsKey('payee')) {
       context.handle(
@@ -2565,7 +2587,11 @@ class $RecurringRulesTable extends RecurringRules
       categoryId: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}category_id'],
-      )!,
+      ),
+      toAccountId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}to_account_id'],
+      ),
       payee: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}payee'],
@@ -2641,11 +2667,25 @@ class RecurringRuleRow extends DataClass
   final String name;
 
   /// Reuses [CategoryKind] rather than a bespoke enum — a rule is exactly as
-  /// income-or-expense as the category it posts under.
+  /// income-or-expense as the category it posts under. For a G&L rule (see
+  /// [toAccountId]) this is always [CategoryKind.expense] — money leaves
+  /// [accountId] the same direction as an expense — but it's otherwise
+  /// unread: every code path branches on [toAccountId] first.
   final CategoryKind kind;
   final Money amount;
   final int accountId;
-  final int categoryId;
+
+  /// Null for a G&L rule (see [toAccountId]) — a transfer into a goal or
+  /// loan is only ever optionally tagged, exactly like
+  /// [GoalDetails.categoryId]/[LoanDetails.categoryId]. Required for an
+  /// expense/income rule.
+  final int? categoryId;
+
+  /// Non-null makes this a "G&L" rule: it posts a [TxType.transfer] from
+  /// [accountId] to this goal or loan account instead of an
+  /// income/expense transaction. Null (the common case) means the rule
+  /// posts an ordinary expense/income per [kind].
+  final int? toAccountId;
 
   /// Same free-text field as [Transactions.payee] — who the rule pays (an
   /// expense) or who it's paid by (income, e.g. an employer for a salary
@@ -2696,7 +2736,8 @@ class RecurringRuleRow extends DataClass
     required this.kind,
     required this.amount,
     required this.accountId,
-    required this.categoryId,
+    this.categoryId,
+    this.toAccountId,
     this.payee,
     this.note,
     required this.frequency,
@@ -2725,7 +2766,12 @@ class RecurringRuleRow extends DataClass
       );
     }
     map['account_id'] = Variable<int>(accountId);
-    map['category_id'] = Variable<int>(categoryId);
+    if (!nullToAbsent || categoryId != null) {
+      map['category_id'] = Variable<int>(categoryId);
+    }
+    if (!nullToAbsent || toAccountId != null) {
+      map['to_account_id'] = Variable<int>(toAccountId);
+    }
     if (!nullToAbsent || payee != null) {
       map['payee'] = Variable<String>(payee);
     }
@@ -2763,7 +2809,12 @@ class RecurringRuleRow extends DataClass
       kind: Value(kind),
       amount: Value(amount),
       accountId: Value(accountId),
-      categoryId: Value(categoryId),
+      categoryId: categoryId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(categoryId),
+      toAccountId: toAccountId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(toAccountId),
       payee: payee == null && nullToAbsent
           ? const Value.absent()
           : Value(payee),
@@ -2799,7 +2850,8 @@ class RecurringRuleRow extends DataClass
       ),
       amount: serializer.fromJson<Money>(json['amount']),
       accountId: serializer.fromJson<int>(json['accountId']),
-      categoryId: serializer.fromJson<int>(json['categoryId']),
+      categoryId: serializer.fromJson<int?>(json['categoryId']),
+      toAccountId: serializer.fromJson<int?>(json['toAccountId']),
       payee: serializer.fromJson<String?>(json['payee']),
       note: serializer.fromJson<String?>(json['note']),
       frequency: $RecurringRulesTable.$converterfrequency.fromJson(
@@ -2828,7 +2880,8 @@ class RecurringRuleRow extends DataClass
       ),
       'amount': serializer.toJson<Money>(amount),
       'accountId': serializer.toJson<int>(accountId),
-      'categoryId': serializer.toJson<int>(categoryId),
+      'categoryId': serializer.toJson<int?>(categoryId),
+      'toAccountId': serializer.toJson<int?>(toAccountId),
       'payee': serializer.toJson<String?>(payee),
       'note': serializer.toJson<String?>(note),
       'frequency': serializer.toJson<String>(
@@ -2851,7 +2904,8 @@ class RecurringRuleRow extends DataClass
     CategoryKind? kind,
     Money? amount,
     int? accountId,
-    int? categoryId,
+    Value<int?> categoryId = const Value.absent(),
+    Value<int?> toAccountId = const Value.absent(),
     Value<String?> payee = const Value.absent(),
     Value<String?> note = const Value.absent(),
     RecurringFrequency? frequency,
@@ -2869,7 +2923,8 @@ class RecurringRuleRow extends DataClass
     kind: kind ?? this.kind,
     amount: amount ?? this.amount,
     accountId: accountId ?? this.accountId,
-    categoryId: categoryId ?? this.categoryId,
+    categoryId: categoryId.present ? categoryId.value : this.categoryId,
+    toAccountId: toAccountId.present ? toAccountId.value : this.toAccountId,
     payee: payee.present ? payee.value : this.payee,
     note: note.present ? note.value : this.note,
     frequency: frequency ?? this.frequency,
@@ -2894,6 +2949,9 @@ class RecurringRuleRow extends DataClass
       categoryId: data.categoryId.present
           ? data.categoryId.value
           : this.categoryId,
+      toAccountId: data.toAccountId.present
+          ? data.toAccountId.value
+          : this.toAccountId,
       payee: data.payee.present ? data.payee.value : this.payee,
       note: data.note.present ? data.note.value : this.note,
       frequency: data.frequency.present ? data.frequency.value : this.frequency,
@@ -2929,6 +2987,7 @@ class RecurringRuleRow extends DataClass
           ..write('amount: $amount, ')
           ..write('accountId: $accountId, ')
           ..write('categoryId: $categoryId, ')
+          ..write('toAccountId: $toAccountId, ')
           ..write('payee: $payee, ')
           ..write('note: $note, ')
           ..write('frequency: $frequency, ')
@@ -2952,6 +3011,7 @@ class RecurringRuleRow extends DataClass
     amount,
     accountId,
     categoryId,
+    toAccountId,
     payee,
     note,
     frequency,
@@ -2974,6 +3034,7 @@ class RecurringRuleRow extends DataClass
           other.amount == this.amount &&
           other.accountId == this.accountId &&
           other.categoryId == this.categoryId &&
+          other.toAccountId == this.toAccountId &&
           other.payee == this.payee &&
           other.note == this.note &&
           other.frequency == this.frequency &&
@@ -2993,7 +3054,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
   final Value<CategoryKind> kind;
   final Value<Money> amount;
   final Value<int> accountId;
-  final Value<int> categoryId;
+  final Value<int?> categoryId;
+  final Value<int?> toAccountId;
   final Value<String?> payee;
   final Value<String?> note;
   final Value<RecurringFrequency> frequency;
@@ -3012,6 +3074,7 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     this.amount = const Value.absent(),
     this.accountId = const Value.absent(),
     this.categoryId = const Value.absent(),
+    this.toAccountId = const Value.absent(),
     this.payee = const Value.absent(),
     this.note = const Value.absent(),
     this.frequency = const Value.absent(),
@@ -3030,7 +3093,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     required CategoryKind kind,
     required Money amount,
     required int accountId,
-    required int categoryId,
+    this.categoryId = const Value.absent(),
+    this.toAccountId = const Value.absent(),
     this.payee = const Value.absent(),
     this.note = const Value.absent(),
     required RecurringFrequency frequency,
@@ -3046,7 +3110,6 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
        kind = Value(kind),
        amount = Value(amount),
        accountId = Value(accountId),
-       categoryId = Value(categoryId),
        frequency = Value(frequency),
        nextDueDate = Value(nextDueDate);
   static Insertable<RecurringRuleRow> custom({
@@ -3056,6 +3119,7 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     Expression<int>? amount,
     Expression<int>? accountId,
     Expression<int>? categoryId,
+    Expression<int>? toAccountId,
     Expression<String>? payee,
     Expression<String>? note,
     Expression<String>? frequency,
@@ -3075,6 +3139,7 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
       if (amount != null) 'amount': amount,
       if (accountId != null) 'account_id': accountId,
       if (categoryId != null) 'category_id': categoryId,
+      if (toAccountId != null) 'to_account_id': toAccountId,
       if (payee != null) 'payee': payee,
       if (note != null) 'note': note,
       if (frequency != null) 'frequency': frequency,
@@ -3096,7 +3161,8 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     Value<CategoryKind>? kind,
     Value<Money>? amount,
     Value<int>? accountId,
-    Value<int>? categoryId,
+    Value<int?>? categoryId,
+    Value<int?>? toAccountId,
     Value<String?>? payee,
     Value<String?>? note,
     Value<RecurringFrequency>? frequency,
@@ -3116,6 +3182,7 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
       amount: amount ?? this.amount,
       accountId: accountId ?? this.accountId,
       categoryId: categoryId ?? this.categoryId,
+      toAccountId: toAccountId ?? this.toAccountId,
       payee: payee ?? this.payee,
       note: note ?? this.note,
       frequency: frequency ?? this.frequency,
@@ -3154,6 +3221,9 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
     }
     if (categoryId.present) {
       map['category_id'] = Variable<int>(categoryId.value);
+    }
+    if (toAccountId.present) {
+      map['to_account_id'] = Variable<int>(toAccountId.value);
     }
     if (payee.present) {
       map['payee'] = Variable<String>(payee.value);
@@ -3204,6 +3274,7 @@ class RecurringRulesCompanion extends UpdateCompanion<RecurringRuleRow> {
           ..write('amount: $amount, ')
           ..write('accountId: $accountId, ')
           ..write('categoryId: $categoryId, ')
+          ..write('toAccountId: $toAccountId, ')
           ..write('payee: $payee, ')
           ..write('note: $note, ')
           ..write('frequency: $frequency, ')
@@ -8333,6 +8404,19 @@ class $SettingsTable extends Settings
     requiredDuringInsert: false,
     defaultValue: const Constant('classic'),
   ).withConverter<LockScreenStyle>($SettingsTable.$converterlockScreenStyle);
+  @override
+  late final GeneratedColumnWithTypeConverter<MoreScreenViewMode, String>
+  moreScreenViewMode =
+      GeneratedColumn<String>(
+        'more_screen_view_mode',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('list'),
+      ).withConverter<MoreScreenViewMode>(
+        $SettingsTable.$convertermoreScreenViewMode,
+      );
   static const VerificationMeta _pinTimeoutMinutesMeta = const VerificationMeta(
     'pinTimeoutMinutes',
   );
@@ -8717,6 +8801,7 @@ class $SettingsTable extends Settings
     passcodeLength,
     biometricEnabled,
     lockScreenStyle,
+    moreScreenViewMode,
     pinTimeoutMinutes,
     masterPhraseHash,
     masterPhraseSalt,
@@ -9318,6 +9403,12 @@ class $SettingsTable extends Settings
           data['${effectivePrefix}lock_screen_style'],
         )!,
       ),
+      moreScreenViewMode: $SettingsTable.$convertermoreScreenViewMode.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}more_screen_view_mode'],
+        )!,
+      ),
       pinTimeoutMinutes: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}pin_timeout_minutes'],
@@ -9444,6 +9535,10 @@ class $SettingsTable extends Settings
   $converterlockScreenStyle = const EnumNameConverter<LockScreenStyle>(
     LockScreenStyle.values,
   );
+  static JsonTypeConverter2<MoreScreenViewMode, String, String>
+  $convertermoreScreenViewMode = const EnumNameConverter<MoreScreenViewMode>(
+    MoreScreenViewMode.values,
+  );
   static JsonTypeConverter2<AutoBackupFrequency, String, String>
   $converterautoBackupFrequency = const EnumNameConverter<AutoBackupFrequency>(
     AutoBackupFrequency.values,
@@ -9540,6 +9635,10 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
   /// Which numpad style the lock screen draws — see [LockScreenStyle].
   /// Defaults to `classic` so existing users see no change.
   final LockScreenStyle lockScreenStyle;
+
+  /// How the More hub lays out its items — see [MoreScreenViewMode].
+  /// Defaults to `list` so existing users see no change.
+  final MoreScreenViewMode moreScreenViewMode;
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the
@@ -9712,6 +9811,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     this.passcodeLength,
     required this.biometricEnabled,
     required this.lockScreenStyle,
+    required this.moreScreenViewMode,
     required this.pinTimeoutMinutes,
     this.masterPhraseHash,
     this.masterPhraseSalt,
@@ -9793,6 +9893,11 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     {
       map['lock_screen_style'] = Variable<String>(
         $SettingsTable.$converterlockScreenStyle.toSql(lockScreenStyle),
+      );
+    }
+    {
+      map['more_screen_view_mode'] = Variable<String>(
+        $SettingsTable.$convertermoreScreenViewMode.toSql(moreScreenViewMode),
       );
     }
     map['pin_timeout_minutes'] = Variable<int>(pinTimeoutMinutes);
@@ -9895,6 +10000,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           : Value(passcodeLength),
       biometricEnabled: Value(biometricEnabled),
       lockScreenStyle: Value(lockScreenStyle),
+      moreScreenViewMode: Value(moreScreenViewMode),
       pinTimeoutMinutes: Value(pinTimeoutMinutes),
       masterPhraseHash: masterPhraseHash == null && nullToAbsent
           ? const Value.absent()
@@ -9978,6 +10084,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       biometricEnabled: serializer.fromJson<bool>(json['biometricEnabled']),
       lockScreenStyle: $SettingsTable.$converterlockScreenStyle.fromJson(
         serializer.fromJson<String>(json['lockScreenStyle']),
+      ),
+      moreScreenViewMode: $SettingsTable.$convertermoreScreenViewMode.fromJson(
+        serializer.fromJson<String>(json['moreScreenViewMode']),
       ),
       pinTimeoutMinutes: serializer.fromJson<int>(json['pinTimeoutMinutes']),
       masterPhraseHash: serializer.fromJson<String?>(json['masterPhraseHash']),
@@ -10071,6 +10180,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       'lockScreenStyle': serializer.toJson<String>(
         $SettingsTable.$converterlockScreenStyle.toJson(lockScreenStyle),
       ),
+      'moreScreenViewMode': serializer.toJson<String>(
+        $SettingsTable.$convertermoreScreenViewMode.toJson(moreScreenViewMode),
+      ),
       'pinTimeoutMinutes': serializer.toJson<int>(pinTimeoutMinutes),
       'masterPhraseHash': serializer.toJson<String?>(masterPhraseHash),
       'masterPhraseSalt': serializer.toJson<String?>(masterPhraseSalt),
@@ -10140,6 +10252,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     Value<int?> passcodeLength = const Value.absent(),
     bool? biometricEnabled,
     LockScreenStyle? lockScreenStyle,
+    MoreScreenViewMode? moreScreenViewMode,
     int? pinTimeoutMinutes,
     Value<String?> masterPhraseHash = const Value.absent(),
     Value<String?> masterPhraseSalt = const Value.absent(),
@@ -10201,6 +10314,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
         : this.passcodeLength,
     biometricEnabled: biometricEnabled ?? this.biometricEnabled,
     lockScreenStyle: lockScreenStyle ?? this.lockScreenStyle,
+    moreScreenViewMode: moreScreenViewMode ?? this.moreScreenViewMode,
     pinTimeoutMinutes: pinTimeoutMinutes ?? this.pinTimeoutMinutes,
     masterPhraseHash: masterPhraseHash.present
         ? masterPhraseHash.value
@@ -10308,6 +10422,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       lockScreenStyle: data.lockScreenStyle.present
           ? data.lockScreenStyle.value
           : this.lockScreenStyle,
+      moreScreenViewMode: data.moreScreenViewMode.present
+          ? data.moreScreenViewMode.value
+          : this.moreScreenViewMode,
       pinTimeoutMinutes: data.pinTimeoutMinutes.present
           ? data.pinTimeoutMinutes.value
           : this.pinTimeoutMinutes,
@@ -10425,6 +10542,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ..write('passcodeLength: $passcodeLength, ')
           ..write('biometricEnabled: $biometricEnabled, ')
           ..write('lockScreenStyle: $lockScreenStyle, ')
+          ..write('moreScreenViewMode: $moreScreenViewMode, ')
           ..write('pinTimeoutMinutes: $pinTimeoutMinutes, ')
           ..write('masterPhraseHash: $masterPhraseHash, ')
           ..write('masterPhraseSalt: $masterPhraseSalt, ')
@@ -10488,6 +10606,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     passcodeLength,
     biometricEnabled,
     lockScreenStyle,
+    moreScreenViewMode,
     pinTimeoutMinutes,
     masterPhraseHash,
     masterPhraseSalt,
@@ -10548,6 +10667,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           other.passcodeLength == this.passcodeLength &&
           other.biometricEnabled == this.biometricEnabled &&
           other.lockScreenStyle == this.lockScreenStyle &&
+          other.moreScreenViewMode == this.moreScreenViewMode &&
           other.pinTimeoutMinutes == this.pinTimeoutMinutes &&
           other.masterPhraseHash == this.masterPhraseHash &&
           other.masterPhraseSalt == this.masterPhraseSalt &&
@@ -10608,6 +10728,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
   final Value<int?> passcodeLength;
   final Value<bool> biometricEnabled;
   final Value<LockScreenStyle> lockScreenStyle;
+  final Value<MoreScreenViewMode> moreScreenViewMode;
   final Value<int> pinTimeoutMinutes;
   final Value<String?> masterPhraseHash;
   final Value<String?> masterPhraseSalt;
@@ -10664,6 +10785,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.passcodeLength = const Value.absent(),
     this.biometricEnabled = const Value.absent(),
     this.lockScreenStyle = const Value.absent(),
+    this.moreScreenViewMode = const Value.absent(),
     this.pinTimeoutMinutes = const Value.absent(),
     this.masterPhraseHash = const Value.absent(),
     this.masterPhraseSalt = const Value.absent(),
@@ -10721,6 +10843,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.passcodeLength = const Value.absent(),
     this.biometricEnabled = const Value.absent(),
     this.lockScreenStyle = const Value.absent(),
+    this.moreScreenViewMode = const Value.absent(),
     this.pinTimeoutMinutes = const Value.absent(),
     this.masterPhraseHash = const Value.absent(),
     this.masterPhraseSalt = const Value.absent(),
@@ -10778,6 +10901,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Expression<int>? passcodeLength,
     Expression<bool>? biometricEnabled,
     Expression<String>? lockScreenStyle,
+    Expression<String>? moreScreenViewMode,
     Expression<int>? pinTimeoutMinutes,
     Expression<String>? masterPhraseHash,
     Expression<String>? masterPhraseSalt,
@@ -10839,6 +10963,8 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       if (passcodeLength != null) 'passcode_length': passcodeLength,
       if (biometricEnabled != null) 'biometric_enabled': biometricEnabled,
       if (lockScreenStyle != null) 'lock_screen_style': lockScreenStyle,
+      if (moreScreenViewMode != null)
+        'more_screen_view_mode': moreScreenViewMode,
       if (pinTimeoutMinutes != null) 'pin_timeout_minutes': pinTimeoutMinutes,
       if (masterPhraseHash != null) 'master_phrase_hash': masterPhraseHash,
       if (masterPhraseSalt != null) 'master_phrase_salt': masterPhraseSalt,
@@ -10911,6 +11037,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Value<int?>? passcodeLength,
     Value<bool>? biometricEnabled,
     Value<LockScreenStyle>? lockScreenStyle,
+    Value<MoreScreenViewMode>? moreScreenViewMode,
     Value<int>? pinTimeoutMinutes,
     Value<String?>? masterPhraseHash,
     Value<String?>? masterPhraseSalt,
@@ -10970,6 +11097,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       passcodeLength: passcodeLength ?? this.passcodeLength,
       biometricEnabled: biometricEnabled ?? this.biometricEnabled,
       lockScreenStyle: lockScreenStyle ?? this.lockScreenStyle,
+      moreScreenViewMode: moreScreenViewMode ?? this.moreScreenViewMode,
       pinTimeoutMinutes: pinTimeoutMinutes ?? this.pinTimeoutMinutes,
       masterPhraseHash: masterPhraseHash ?? this.masterPhraseHash,
       masterPhraseSalt: masterPhraseSalt ?? this.masterPhraseSalt,
@@ -11097,6 +11225,13 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     if (lockScreenStyle.present) {
       map['lock_screen_style'] = Variable<String>(
         $SettingsTable.$converterlockScreenStyle.toSql(lockScreenStyle.value),
+      );
+    }
+    if (moreScreenViewMode.present) {
+      map['more_screen_view_mode'] = Variable<String>(
+        $SettingsTable.$convertermoreScreenViewMode.toSql(
+          moreScreenViewMode.value,
+        ),
       );
     }
     if (pinTimeoutMinutes.present) {
@@ -11238,6 +11373,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
           ..write('passcodeLength: $passcodeLength, ')
           ..write('biometricEnabled: $biometricEnabled, ')
           ..write('lockScreenStyle: $lockScreenStyle, ')
+          ..write('moreScreenViewMode: $moreScreenViewMode, ')
           ..write('pinTimeoutMinutes: $pinTimeoutMinutes, ')
           ..write('masterPhraseHash: $masterPhraseHash, ')
           ..write('masterPhraseSalt: $masterPhraseSalt, ')
@@ -14220,6 +14356,530 @@ class RecurringRuleTagsCompanion extends UpdateCompanion<RecurringRuleTagRow> {
   String toString() {
     return (StringBuffer('RecurringRuleTagsCompanion(')
           ..write('ruleId: $ruleId, ')
+          ..write('tagId: $tagId, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $TagGroupsTable extends TagGroups
+    with TableInfo<$TagGroupsTable, TagGroupRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TagGroupsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 30,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _colorValueMeta = const VerificationMeta(
+    'colorValue',
+  );
+  @override
+  late final GeneratedColumn<int> colorValue = GeneratedColumn<int>(
+    'color_value',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, name, colorValue, createdAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'tag_groups';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<TagGroupRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('color_value')) {
+      context.handle(
+        _colorValueMeta,
+        colorValue.isAcceptableOrUnknown(data['color_value']!, _colorValueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_colorValueMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+    {name},
+  ];
+  @override
+  TagGroupRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TagGroupRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      colorValue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}color_value'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $TagGroupsTable createAlias(String alias) {
+    return $TagGroupsTable(attachedDatabase, alias);
+  }
+}
+
+class TagGroupRow extends DataClass implements Insertable<TagGroupRow> {
+  final int id;
+  final String name;
+  final int colorValue;
+  final DateTime createdAt;
+  const TagGroupRow({
+    required this.id,
+    required this.name,
+    required this.colorValue,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    map['color_value'] = Variable<int>(colorValue);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  TagGroupsCompanion toCompanion(bool nullToAbsent) {
+    return TagGroupsCompanion(
+      id: Value(id),
+      name: Value(name),
+      colorValue: Value(colorValue),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory TagGroupRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return TagGroupRow(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      colorValue: serializer.fromJson<int>(json['colorValue']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'colorValue': serializer.toJson<int>(colorValue),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  TagGroupRow copyWith({
+    int? id,
+    String? name,
+    int? colorValue,
+    DateTime? createdAt,
+  }) => TagGroupRow(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    colorValue: colorValue ?? this.colorValue,
+    createdAt: createdAt ?? this.createdAt,
+  );
+  TagGroupRow copyWithCompanion(TagGroupsCompanion data) {
+    return TagGroupRow(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      colorValue: data.colorValue.present
+          ? data.colorValue.value
+          : this.colorValue,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TagGroupRow(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, colorValue, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TagGroupRow &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.colorValue == this.colorValue &&
+          other.createdAt == this.createdAt);
+}
+
+class TagGroupsCompanion extends UpdateCompanion<TagGroupRow> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<int> colorValue;
+  final Value<DateTime> createdAt;
+  const TagGroupsCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.colorValue = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  TagGroupsCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    required int colorValue,
+    this.createdAt = const Value.absent(),
+  }) : name = Value(name),
+       colorValue = Value(colorValue);
+  static Insertable<TagGroupRow> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<int>? colorValue,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (colorValue != null) 'color_value': colorValue,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  TagGroupsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<int>? colorValue,
+    Value<DateTime>? createdAt,
+  }) {
+    return TagGroupsCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      colorValue: colorValue ?? this.colorValue,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (colorValue.present) {
+      map['color_value'] = Variable<int>(colorValue.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TagGroupsCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $TagGroupTagsTable extends TagGroupTags
+    with TableInfo<$TagGroupTagsTable, TagGroupTagRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TagGroupTagsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _groupIdMeta = const VerificationMeta(
+    'groupId',
+  );
+  @override
+  late final GeneratedColumn<int> groupId = GeneratedColumn<int>(
+    'group_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES tag_groups (id)',
+    ),
+  );
+  static const VerificationMeta _tagIdMeta = const VerificationMeta('tagId');
+  @override
+  late final GeneratedColumn<int> tagId = GeneratedColumn<int>(
+    'tag_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES tags (id)',
+    ),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [groupId, tagId];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'tag_group_tags';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<TagGroupTagRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('group_id')) {
+      context.handle(
+        _groupIdMeta,
+        groupId.isAcceptableOrUnknown(data['group_id']!, _groupIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_groupIdMeta);
+    }
+    if (data.containsKey('tag_id')) {
+      context.handle(
+        _tagIdMeta,
+        tagId.isAcceptableOrUnknown(data['tag_id']!, _tagIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_tagIdMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {groupId, tagId};
+  @override
+  TagGroupTagRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TagGroupTagRow(
+      groupId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}group_id'],
+      )!,
+      tagId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}tag_id'],
+      )!,
+    );
+  }
+
+  @override
+  $TagGroupTagsTable createAlias(String alias) {
+    return $TagGroupTagsTable(attachedDatabase, alias);
+  }
+}
+
+class TagGroupTagRow extends DataClass implements Insertable<TagGroupTagRow> {
+  final int groupId;
+  final int tagId;
+  const TagGroupTagRow({required this.groupId, required this.tagId});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['group_id'] = Variable<int>(groupId);
+    map['tag_id'] = Variable<int>(tagId);
+    return map;
+  }
+
+  TagGroupTagsCompanion toCompanion(bool nullToAbsent) {
+    return TagGroupTagsCompanion(groupId: Value(groupId), tagId: Value(tagId));
+  }
+
+  factory TagGroupTagRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return TagGroupTagRow(
+      groupId: serializer.fromJson<int>(json['groupId']),
+      tagId: serializer.fromJson<int>(json['tagId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'groupId': serializer.toJson<int>(groupId),
+      'tagId': serializer.toJson<int>(tagId),
+    };
+  }
+
+  TagGroupTagRow copyWith({int? groupId, int? tagId}) => TagGroupTagRow(
+    groupId: groupId ?? this.groupId,
+    tagId: tagId ?? this.tagId,
+  );
+  TagGroupTagRow copyWithCompanion(TagGroupTagsCompanion data) {
+    return TagGroupTagRow(
+      groupId: data.groupId.present ? data.groupId.value : this.groupId,
+      tagId: data.tagId.present ? data.tagId.value : this.tagId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TagGroupTagRow(')
+          ..write('groupId: $groupId, ')
+          ..write('tagId: $tagId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(groupId, tagId);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TagGroupTagRow &&
+          other.groupId == this.groupId &&
+          other.tagId == this.tagId);
+}
+
+class TagGroupTagsCompanion extends UpdateCompanion<TagGroupTagRow> {
+  final Value<int> groupId;
+  final Value<int> tagId;
+  final Value<int> rowid;
+  const TagGroupTagsCompanion({
+    this.groupId = const Value.absent(),
+    this.tagId = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  TagGroupTagsCompanion.insert({
+    required int groupId,
+    required int tagId,
+    this.rowid = const Value.absent(),
+  }) : groupId = Value(groupId),
+       tagId = Value(tagId);
+  static Insertable<TagGroupTagRow> custom({
+    Expression<int>? groupId,
+    Expression<int>? tagId,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (groupId != null) 'group_id': groupId,
+      if (tagId != null) 'tag_id': tagId,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  TagGroupTagsCompanion copyWith({
+    Value<int>? groupId,
+    Value<int>? tagId,
+    Value<int>? rowid,
+  }) {
+    return TagGroupTagsCompanion(
+      groupId: groupId ?? this.groupId,
+      tagId: tagId ?? this.tagId,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (groupId.present) {
+      map['group_id'] = Variable<int>(groupId.value);
+    }
+    if (tagId.present) {
+      map['tag_id'] = Variable<int>(tagId.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TagGroupTagsCompanion(')
+          ..write('groupId: $groupId, ')
           ..write('tagId: $tagId, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -18285,6 +18945,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   );
   late final $RecurringRuleTagsTable recurringRuleTags =
       $RecurringRuleTagsTable(this);
+  late final $TagGroupsTable tagGroups = $TagGroupsTable(this);
+  late final $TagGroupTagsTable tagGroupTags = $TagGroupTagsTable(this);
   late final $TransactionSplitsTable transactionSplits =
       $TransactionSplitsTable(this);
   late final $TransactionLinksTable transactionLinks = $TransactionLinksTable(
@@ -18324,6 +18986,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     tags,
     transactionTags,
     recurringRuleTags,
+    tagGroups,
+    tagGroupTags,
     transactionSplits,
     transactionLinks,
     goalDetails,
@@ -18413,27 +19077,6 @@ final class $$AccountsTableReferences
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
-    );
-  }
-
-  static MultiTypedResultKey<$RecurringRulesTable, List<RecurringRuleRow>>
-  _recurringRulesRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
-    db.recurringRules,
-    aliasName: $_aliasNameGenerator(
-      db.accounts.id,
-      db.recurringRules.accountId,
-    ),
-  );
-
-  $$RecurringRulesTableProcessedTableManager get recurringRulesRefs {
-    final manager = $$RecurringRulesTableTableManager(
-      $_db,
-      $_db.recurringRules,
-    ).filter((f) => f.accountId.id.sqlEquals($_itemColumn<int>('id')!));
-
-    final cache = $_typedResult.readTableOrNull(_recurringRulesRefsTable($_db));
-    return ProcessedTableManager(
-      manager.$state.copyWith(prefetchedData: cache),
     );
   }
 
@@ -18739,31 +19382,6 @@ class $$AccountsTableFilterComposer
           ),
     );
     return composer;
-  }
-
-  Expression<bool> recurringRulesRefs(
-    Expression<bool> Function($$RecurringRulesTableFilterComposer f) f,
-  ) {
-    final $$RecurringRulesTableFilterComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.recurringRules,
-      getReferencedColumn: (t) => t.accountId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$RecurringRulesTableFilterComposer(
-            $db: $db,
-            $table: $db.recurringRules,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
   }
 
   Expression<bool> personEntriesRefs(
@@ -19216,31 +19834,6 @@ class $$AccountsTableAnnotationComposer
     return composer;
   }
 
-  Expression<T> recurringRulesRefs<T extends Object>(
-    Expression<T> Function($$RecurringRulesTableAnnotationComposer a) f,
-  ) {
-    final $$RecurringRulesTableAnnotationComposer composer = $composerBuilder(
-      composer: this,
-      getCurrentColumn: (t) => t.id,
-      referencedTable: $db.recurringRules,
-      getReferencedColumn: (t) => t.accountId,
-      builder:
-          (
-            joinBuilder, {
-            $addJoinBuilderToRootComposer,
-            $removeJoinBuilderFromRootComposer,
-          }) => $$RecurringRulesTableAnnotationComposer(
-            $db: $db,
-            $table: $db.recurringRules,
-            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
-            joinBuilder: joinBuilder,
-            $removeJoinBuilderFromRootComposer:
-                $removeJoinBuilderFromRootComposer,
-          ),
-    );
-    return f(composer);
-  }
-
   Expression<T> personEntriesRefs<T extends Object>(
     Expression<T> Function($$PersonEntriesTableAnnotationComposer a) f,
   ) {
@@ -19508,7 +20101,6 @@ class $$AccountsTableTableManager
           AccountRow,
           PrefetchHooks Function({
             bool linkedAccountId,
-            bool recurringRulesRefs,
             bool personEntriesRefs,
             bool groupExpensesRefs,
             bool remindersRefs,
@@ -19615,7 +20207,6 @@ class $$AccountsTableTableManager
           prefetchHooksCallback:
               ({
                 linkedAccountId = false,
-                recurringRulesRefs = false,
                 personEntriesRefs = false,
                 groupExpensesRefs = false,
                 remindersRefs = false,
@@ -19630,7 +20221,6 @@ class $$AccountsTableTableManager
                 return PrefetchHooks(
                   db: db,
                   explicitlyWatchedTables: [
-                    if (recurringRulesRefs) db.recurringRules,
                     if (personEntriesRefs) db.personEntries,
                     if (groupExpensesRefs) db.groupExpenses,
                     if (remindersRefs) db.reminders,
@@ -19676,27 +20266,6 @@ class $$AccountsTableTableManager
                       },
                   getPrefetchedDataCallback: (items) async {
                     return [
-                      if (recurringRulesRefs)
-                        await $_getPrefetchedData<
-                          AccountRow,
-                          $AccountsTable,
-                          RecurringRuleRow
-                        >(
-                          currentTable: table,
-                          referencedTable: $$AccountsTableReferences
-                              ._recurringRulesRefsTable(db),
-                          managerFromTypedResult: (p0) =>
-                              $$AccountsTableReferences(
-                                db,
-                                table,
-                                p0,
-                              ).recurringRulesRefs,
-                          referencedItemsForCurrentItem:
-                              (item, referencedItems) => referencedItems.where(
-                                (e) => e.accountId == item.id,
-                              ),
-                          typedResults: items,
-                        ),
                       if (personEntriesRefs)
                         await $_getPrefetchedData<
                           AccountRow,
@@ -19929,7 +20498,6 @@ typedef $$AccountsTableProcessedTableManager =
       AccountRow,
       PrefetchHooks Function({
         bool linkedAccountId,
-        bool recurringRulesRefs,
         bool personEntriesRefs,
         bool groupExpensesRefs,
         bool remindersRefs,
@@ -22291,7 +22859,8 @@ typedef $$RecurringRulesTableCreateCompanionBuilder =
       required CategoryKind kind,
       required Money amount,
       required int accountId,
-      required int categoryId,
+      Value<int?> categoryId,
+      Value<int?> toAccountId,
       Value<String?> payee,
       Value<String?> note,
       required RecurringFrequency frequency,
@@ -22311,7 +22880,8 @@ typedef $$RecurringRulesTableUpdateCompanionBuilder =
       Value<CategoryKind> kind,
       Value<Money> amount,
       Value<int> accountId,
-      Value<int> categoryId,
+      Value<int?> categoryId,
+      Value<int?> toAccountId,
       Value<String?> payee,
       Value<String?> note,
       Value<RecurringFrequency> frequency,
@@ -22358,14 +22928,33 @@ final class $$RecurringRulesTableReferences
         $_aliasNameGenerator(db.recurringRules.categoryId, db.categories.id),
       );
 
-  $$CategoriesTableProcessedTableManager get categoryId {
-    final $_column = $_itemColumn<int>('category_id')!;
-
+  $$CategoriesTableProcessedTableManager? get categoryId {
+    final $_column = $_itemColumn<int>('category_id');
+    if ($_column == null) return null;
     final manager = $$CategoriesTableTableManager(
       $_db,
       $_db.categories,
     ).filter((f) => f.id.sqlEquals($_column));
     final item = $_typedResult.readTableOrNull(_categoryIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $AccountsTable _toAccountIdTable(_$AppDatabase db) =>
+      db.accounts.createAlias(
+        $_aliasNameGenerator(db.recurringRules.toAccountId, db.accounts.id),
+      );
+
+  $$AccountsTableProcessedTableManager? get toAccountId {
+    final $_column = $_itemColumn<int>('to_account_id');
+    if ($_column == null) return null;
+    final manager = $$AccountsTableTableManager(
+      $_db,
+      $_db.accounts,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_toAccountIdTable($_db));
     if (item == null) return manager;
     return ProcessedTableManager(
       manager.$state.copyWith(prefetchedData: [item]),
@@ -22543,6 +23132,29 @@ class $$RecurringRulesTableFilterComposer
           }) => $$CategoriesTableFilterComposer(
             $db: $db,
             $table: $db.categories,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$AccountsTableFilterComposer get toAccountId {
+    final $$AccountsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.toAccountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableFilterComposer(
+            $db: $db,
+            $table: $db.accounts,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -22732,6 +23344,29 @@ class $$RecurringRulesTableOrderingComposer
     );
     return composer;
   }
+
+  $$AccountsTableOrderingComposer get toAccountId {
+    final $$AccountsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.toAccountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableOrderingComposer(
+            $db: $db,
+            $table: $db.accounts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
 }
 
 class $$RecurringRulesTableAnnotationComposer
@@ -22847,6 +23482,29 @@ class $$RecurringRulesTableAnnotationComposer
     return composer;
   }
 
+  $$AccountsTableAnnotationComposer get toAccountId {
+    final $$AccountsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.toAccountId,
+      referencedTable: $db.accounts,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AccountsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.accounts,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
   Expression<T> transactionsRefs<T extends Object>(
     Expression<T> Function($$TransactionsTableAnnotationComposer a) f,
   ) {
@@ -22915,6 +23573,7 @@ class $$RecurringRulesTableTableManager
           PrefetchHooks Function({
             bool accountId,
             bool categoryId,
+            bool toAccountId,
             bool transactionsRefs,
             bool recurringRuleTagsRefs,
           })
@@ -22939,7 +23598,8 @@ class $$RecurringRulesTableTableManager
                 Value<CategoryKind> kind = const Value.absent(),
                 Value<Money> amount = const Value.absent(),
                 Value<int> accountId = const Value.absent(),
-                Value<int> categoryId = const Value.absent(),
+                Value<int?> categoryId = const Value.absent(),
+                Value<int?> toAccountId = const Value.absent(),
                 Value<String?> payee = const Value.absent(),
                 Value<String?> note = const Value.absent(),
                 Value<RecurringFrequency> frequency = const Value.absent(),
@@ -22958,6 +23618,7 @@ class $$RecurringRulesTableTableManager
                 amount: amount,
                 accountId: accountId,
                 categoryId: categoryId,
+                toAccountId: toAccountId,
                 payee: payee,
                 note: note,
                 frequency: frequency,
@@ -22977,7 +23638,8 @@ class $$RecurringRulesTableTableManager
                 required CategoryKind kind,
                 required Money amount,
                 required int accountId,
-                required int categoryId,
+                Value<int?> categoryId = const Value.absent(),
+                Value<int?> toAccountId = const Value.absent(),
                 Value<String?> payee = const Value.absent(),
                 Value<String?> note = const Value.absent(),
                 required RecurringFrequency frequency,
@@ -22996,6 +23658,7 @@ class $$RecurringRulesTableTableManager
                 amount: amount,
                 accountId: accountId,
                 categoryId: categoryId,
+                toAccountId: toAccountId,
                 payee: payee,
                 note: note,
                 frequency: frequency,
@@ -23020,6 +23683,7 @@ class $$RecurringRulesTableTableManager
               ({
                 accountId = false,
                 categoryId = false,
+                toAccountId = false,
                 transactionsRefs = false,
                 recurringRuleTagsRefs = false,
               }) {
@@ -23071,6 +23735,21 @@ class $$RecurringRulesTableTableManager
                                     referencedColumn:
                                         $$RecurringRulesTableReferences
                                             ._categoryIdTable(db)
+                                            .id,
+                                  )
+                                  as T;
+                        }
+                        if (toAccountId) {
+                          state =
+                              state.withJoin(
+                                    currentTable: table,
+                                    currentColumn: table.toAccountId,
+                                    referencedTable:
+                                        $$RecurringRulesTableReferences
+                                            ._toAccountIdTable(db),
+                                    referencedColumn:
+                                        $$RecurringRulesTableReferences
+                                            ._toAccountIdTable(db)
                                             .id,
                                   )
                                   as T;
@@ -23145,6 +23824,7 @@ typedef $$RecurringRulesTableProcessedTableManager =
       PrefetchHooks Function({
         bool accountId,
         bool categoryId,
+        bool toAccountId,
         bool transactionsRefs,
         bool recurringRuleTagsRefs,
       })
@@ -28976,6 +29656,7 @@ typedef $$SettingsTableCreateCompanionBuilder =
       Value<int?> passcodeLength,
       Value<bool> biometricEnabled,
       Value<LockScreenStyle> lockScreenStyle,
+      Value<MoreScreenViewMode> moreScreenViewMode,
       Value<int> pinTimeoutMinutes,
       Value<String?> masterPhraseHash,
       Value<String?> masterPhraseSalt,
@@ -29034,6 +29715,7 @@ typedef $$SettingsTableUpdateCompanionBuilder =
       Value<int?> passcodeLength,
       Value<bool> biometricEnabled,
       Value<LockScreenStyle> lockScreenStyle,
+      Value<MoreScreenViewMode> moreScreenViewMode,
       Value<int> pinTimeoutMinutes,
       Value<String?> masterPhraseHash,
       Value<String?> masterPhraseSalt,
@@ -29230,6 +29912,12 @@ class $$SettingsTableFilterComposer
   ColumnWithTypeConverterFilters<LockScreenStyle, LockScreenStyle, String>
   get lockScreenStyle => $composableBuilder(
     column: $table.lockScreenStyle,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<MoreScreenViewMode, MoreScreenViewMode, String>
+  get moreScreenViewMode => $composableBuilder(
+    column: $table.moreScreenViewMode,
     builder: (column) => ColumnWithTypeConverterFilters(column),
   );
 
@@ -29541,6 +30229,11 @@ class $$SettingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get moreScreenViewMode => $composableBuilder(
+    column: $table.moreScreenViewMode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get pinTimeoutMinutes => $composableBuilder(
     column: $table.pinTimeoutMinutes,
     builder: (column) => ColumnOrderings(column),
@@ -29827,6 +30520,12 @@ class $$SettingsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumnWithTypeConverter<MoreScreenViewMode, String>
+  get moreScreenViewMode => $composableBuilder(
+    column: $table.moreScreenViewMode,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<int> get pinTimeoutMinutes => $composableBuilder(
     column: $table.pinTimeoutMinutes,
     builder: (column) => column,
@@ -30042,6 +30741,8 @@ class $$SettingsTableTableManager
                 Value<int?> passcodeLength = const Value.absent(),
                 Value<bool> biometricEnabled = const Value.absent(),
                 Value<LockScreenStyle> lockScreenStyle = const Value.absent(),
+                Value<MoreScreenViewMode> moreScreenViewMode =
+                    const Value.absent(),
                 Value<int> pinTimeoutMinutes = const Value.absent(),
                 Value<String?> masterPhraseHash = const Value.absent(),
                 Value<String?> masterPhraseSalt = const Value.absent(),
@@ -30099,6 +30800,7 @@ class $$SettingsTableTableManager
                 passcodeLength: passcodeLength,
                 biometricEnabled: biometricEnabled,
                 lockScreenStyle: lockScreenStyle,
+                moreScreenViewMode: moreScreenViewMode,
                 pinTimeoutMinutes: pinTimeoutMinutes,
                 masterPhraseHash: masterPhraseHash,
                 masterPhraseSalt: masterPhraseSalt,
@@ -30157,6 +30859,8 @@ class $$SettingsTableTableManager
                 Value<int?> passcodeLength = const Value.absent(),
                 Value<bool> biometricEnabled = const Value.absent(),
                 Value<LockScreenStyle> lockScreenStyle = const Value.absent(),
+                Value<MoreScreenViewMode> moreScreenViewMode =
+                    const Value.absent(),
                 Value<int> pinTimeoutMinutes = const Value.absent(),
                 Value<String?> masterPhraseHash = const Value.absent(),
                 Value<String?> masterPhraseSalt = const Value.absent(),
@@ -30214,6 +30918,7 @@ class $$SettingsTableTableManager
                 passcodeLength: passcodeLength,
                 biometricEnabled: biometricEnabled,
                 lockScreenStyle: lockScreenStyle,
+                moreScreenViewMode: moreScreenViewMode,
                 pinTimeoutMinutes: pinTimeoutMinutes,
                 masterPhraseHash: masterPhraseHash,
                 masterPhraseSalt: masterPhraseSalt,
@@ -31993,6 +32698,24 @@ final class $$TagsTableReferences
       manager.$state.copyWith(prefetchedData: cache),
     );
   }
+
+  static MultiTypedResultKey<$TagGroupTagsTable, List<TagGroupTagRow>>
+  _tagGroupTagsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.tagGroupTags,
+    aliasName: $_aliasNameGenerator(db.tags.id, db.tagGroupTags.tagId),
+  );
+
+  $$TagGroupTagsTableProcessedTableManager get tagGroupTagsRefs {
+    final manager = $$TagGroupTagsTableTableManager(
+      $_db,
+      $_db.tagGroupTags,
+    ).filter((f) => f.tagId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_tagGroupTagsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 }
 
 class $$TagsTableFilterComposer extends Composer<_$AppDatabase, $TagsTable> {
@@ -32059,6 +32782,31 @@ class $$TagsTableFilterComposer extends Composer<_$AppDatabase, $TagsTable> {
           }) => $$RecurringRuleTagsTableFilterComposer(
             $db: $db,
             $table: $db.recurringRuleTags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+
+  Expression<bool> tagGroupTagsRefs(
+    Expression<bool> Function($$TagGroupTagsTableFilterComposer f) f,
+  ) {
+    final $$TagGroupTagsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.tagGroupTags,
+      getReferencedColumn: (t) => t.tagId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupTagsTableFilterComposer(
+            $db: $db,
+            $table: $db.tagGroupTags,
             $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
             joinBuilder: joinBuilder,
             $removeJoinBuilderFromRootComposer:
@@ -32163,6 +32911,31 @@ class $$TagsTableAnnotationComposer
         );
     return f(composer);
   }
+
+  Expression<T> tagGroupTagsRefs<T extends Object>(
+    Expression<T> Function($$TagGroupTagsTableAnnotationComposer a) f,
+  ) {
+    final $$TagGroupTagsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.tagGroupTags,
+      getReferencedColumn: (t) => t.tagId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupTagsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.tagGroupTags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$TagsTableTableManager
@@ -32181,6 +32954,7 @@ class $$TagsTableTableManager
           PrefetchHooks Function({
             bool transactionTagsRefs,
             bool recurringRuleTagsRefs,
+            bool tagGroupTagsRefs,
           })
         > {
   $$TagsTableTableManager(_$AppDatabase db, $TagsTable table)
@@ -32217,12 +32991,17 @@ class $$TagsTableTableManager
               )
               .toList(),
           prefetchHooksCallback:
-              ({transactionTagsRefs = false, recurringRuleTagsRefs = false}) {
+              ({
+                transactionTagsRefs = false,
+                recurringRuleTagsRefs = false,
+                tagGroupTagsRefs = false,
+              }) {
                 return PrefetchHooks(
                   db: db,
                   explicitlyWatchedTables: [
                     if (transactionTagsRefs) db.transactionTags,
                     if (recurringRuleTagsRefs) db.recurringRuleTags,
+                    if (tagGroupTagsRefs) db.tagGroupTags,
                   ],
                   addJoins: null,
                   getPrefetchedDataCallback: (items) async {
@@ -32267,6 +33046,26 @@ class $$TagsTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (tagGroupTagsRefs)
+                        await $_getPrefetchedData<
+                          TagRow,
+                          $TagsTable,
+                          TagGroupTagRow
+                        >(
+                          currentTable: table,
+                          referencedTable: $$TagsTableReferences
+                              ._tagGroupTagsRefsTable(db),
+                          managerFromTypedResult: (p0) => $$TagsTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).tagGroupTagsRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.tagId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                     ];
                   },
                 );
@@ -32290,6 +33089,7 @@ typedef $$TagsTableProcessedTableManager =
       PrefetchHooks Function({
         bool transactionTagsRefs,
         bool recurringRuleTagsRefs,
+        bool tagGroupTagsRefs,
       })
     >;
 typedef $$TransactionTagsTableCreateCompanionBuilder =
@@ -33025,6 +33825,633 @@ typedef $$RecurringRuleTagsTableProcessedTableManager =
       (RecurringRuleTagRow, $$RecurringRuleTagsTableReferences),
       RecurringRuleTagRow,
       PrefetchHooks Function({bool ruleId, bool tagId})
+    >;
+typedef $$TagGroupsTableCreateCompanionBuilder =
+    TagGroupsCompanion Function({
+      Value<int> id,
+      required String name,
+      required int colorValue,
+      Value<DateTime> createdAt,
+    });
+typedef $$TagGroupsTableUpdateCompanionBuilder =
+    TagGroupsCompanion Function({
+      Value<int> id,
+      Value<String> name,
+      Value<int> colorValue,
+      Value<DateTime> createdAt,
+    });
+
+final class $$TagGroupsTableReferences
+    extends BaseReferences<_$AppDatabase, $TagGroupsTable, TagGroupRow> {
+  $$TagGroupsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$TagGroupTagsTable, List<TagGroupTagRow>>
+  _tagGroupTagsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.tagGroupTags,
+    aliasName: $_aliasNameGenerator(db.tagGroups.id, db.tagGroupTags.groupId),
+  );
+
+  $$TagGroupTagsTableProcessedTableManager get tagGroupTagsRefs {
+    final manager = $$TagGroupTagsTableTableManager(
+      $_db,
+      $_db.tagGroupTags,
+    ).filter((f) => f.groupId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_tagGroupTagsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$TagGroupsTableFilterComposer
+    extends Composer<_$AppDatabase, $TagGroupsTable> {
+  $$TagGroupsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get colorValue => $composableBuilder(
+    column: $table.colorValue,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> tagGroupTagsRefs(
+    Expression<bool> Function($$TagGroupTagsTableFilterComposer f) f,
+  ) {
+    final $$TagGroupTagsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.tagGroupTags,
+      getReferencedColumn: (t) => t.groupId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupTagsTableFilterComposer(
+            $db: $db,
+            $table: $db.tagGroupTags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$TagGroupsTableOrderingComposer
+    extends Composer<_$AppDatabase, $TagGroupsTable> {
+  $$TagGroupsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get colorValue => $composableBuilder(
+    column: $table.colorValue,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$TagGroupsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $TagGroupsTable> {
+  $$TagGroupsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<int> get colorValue => $composableBuilder(
+    column: $table.colorValue,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  Expression<T> tagGroupTagsRefs<T extends Object>(
+    Expression<T> Function($$TagGroupTagsTableAnnotationComposer a) f,
+  ) {
+    final $$TagGroupTagsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.tagGroupTags,
+      getReferencedColumn: (t) => t.groupId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupTagsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.tagGroupTags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$TagGroupsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $TagGroupsTable,
+          TagGroupRow,
+          $$TagGroupsTableFilterComposer,
+          $$TagGroupsTableOrderingComposer,
+          $$TagGroupsTableAnnotationComposer,
+          $$TagGroupsTableCreateCompanionBuilder,
+          $$TagGroupsTableUpdateCompanionBuilder,
+          (TagGroupRow, $$TagGroupsTableReferences),
+          TagGroupRow,
+          PrefetchHooks Function({bool tagGroupTagsRefs})
+        > {
+  $$TagGroupsTableTableManager(_$AppDatabase db, $TagGroupsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$TagGroupsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$TagGroupsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$TagGroupsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<int> colorValue = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => TagGroupsCompanion(
+                id: id,
+                name: name,
+                colorValue: colorValue,
+                createdAt: createdAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String name,
+                required int colorValue,
+                Value<DateTime> createdAt = const Value.absent(),
+              }) => TagGroupsCompanion.insert(
+                id: id,
+                name: name,
+                colorValue: colorValue,
+                createdAt: createdAt,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$TagGroupsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({tagGroupTagsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (tagGroupTagsRefs) db.tagGroupTags],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (tagGroupTagsRefs)
+                    await $_getPrefetchedData<
+                      TagGroupRow,
+                      $TagGroupsTable,
+                      TagGroupTagRow
+                    >(
+                      currentTable: table,
+                      referencedTable: $$TagGroupsTableReferences
+                          ._tagGroupTagsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$TagGroupsTableReferences(
+                            db,
+                            table,
+                            p0,
+                          ).tagGroupTagsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.groupId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$TagGroupsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $TagGroupsTable,
+      TagGroupRow,
+      $$TagGroupsTableFilterComposer,
+      $$TagGroupsTableOrderingComposer,
+      $$TagGroupsTableAnnotationComposer,
+      $$TagGroupsTableCreateCompanionBuilder,
+      $$TagGroupsTableUpdateCompanionBuilder,
+      (TagGroupRow, $$TagGroupsTableReferences),
+      TagGroupRow,
+      PrefetchHooks Function({bool tagGroupTagsRefs})
+    >;
+typedef $$TagGroupTagsTableCreateCompanionBuilder =
+    TagGroupTagsCompanion Function({
+      required int groupId,
+      required int tagId,
+      Value<int> rowid,
+    });
+typedef $$TagGroupTagsTableUpdateCompanionBuilder =
+    TagGroupTagsCompanion Function({
+      Value<int> groupId,
+      Value<int> tagId,
+      Value<int> rowid,
+    });
+
+final class $$TagGroupTagsTableReferences
+    extends BaseReferences<_$AppDatabase, $TagGroupTagsTable, TagGroupTagRow> {
+  $$TagGroupTagsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $TagGroupsTable _groupIdTable(_$AppDatabase db) =>
+      db.tagGroups.createAlias(
+        $_aliasNameGenerator(db.tagGroupTags.groupId, db.tagGroups.id),
+      );
+
+  $$TagGroupsTableProcessedTableManager get groupId {
+    final $_column = $_itemColumn<int>('group_id')!;
+
+    final manager = $$TagGroupsTableTableManager(
+      $_db,
+      $_db.tagGroups,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_groupIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $TagsTable _tagIdTable(_$AppDatabase db) => db.tags.createAlias(
+    $_aliasNameGenerator(db.tagGroupTags.tagId, db.tags.id),
+  );
+
+  $$TagsTableProcessedTableManager get tagId {
+    final $_column = $_itemColumn<int>('tag_id')!;
+
+    final manager = $$TagsTableTableManager(
+      $_db,
+      $_db.tags,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_tagIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$TagGroupTagsTableFilterComposer
+    extends Composer<_$AppDatabase, $TagGroupTagsTable> {
+  $$TagGroupTagsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$TagGroupsTableFilterComposer get groupId {
+    final $$TagGroupsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.groupId,
+      referencedTable: $db.tagGroups,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupsTableFilterComposer(
+            $db: $db,
+            $table: $db.tagGroups,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TagsTableFilterComposer get tagId {
+    final $$TagsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.tagId,
+      referencedTable: $db.tags,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagsTableFilterComposer(
+            $db: $db,
+            $table: $db.tags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TagGroupTagsTableOrderingComposer
+    extends Composer<_$AppDatabase, $TagGroupTagsTable> {
+  $$TagGroupTagsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$TagGroupsTableOrderingComposer get groupId {
+    final $$TagGroupsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.groupId,
+      referencedTable: $db.tagGroups,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupsTableOrderingComposer(
+            $db: $db,
+            $table: $db.tagGroups,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TagsTableOrderingComposer get tagId {
+    final $$TagsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.tagId,
+      referencedTable: $db.tags,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagsTableOrderingComposer(
+            $db: $db,
+            $table: $db.tags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TagGroupTagsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $TagGroupTagsTable> {
+  $$TagGroupTagsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$TagGroupsTableAnnotationComposer get groupId {
+    final $$TagGroupsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.groupId,
+      referencedTable: $db.tagGroups,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagGroupsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.tagGroups,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$TagsTableAnnotationComposer get tagId {
+    final $$TagsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.tagId,
+      referencedTable: $db.tags,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TagsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.tags,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TagGroupTagsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $TagGroupTagsTable,
+          TagGroupTagRow,
+          $$TagGroupTagsTableFilterComposer,
+          $$TagGroupTagsTableOrderingComposer,
+          $$TagGroupTagsTableAnnotationComposer,
+          $$TagGroupTagsTableCreateCompanionBuilder,
+          $$TagGroupTagsTableUpdateCompanionBuilder,
+          (TagGroupTagRow, $$TagGroupTagsTableReferences),
+          TagGroupTagRow,
+          PrefetchHooks Function({bool groupId, bool tagId})
+        > {
+  $$TagGroupTagsTableTableManager(_$AppDatabase db, $TagGroupTagsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$TagGroupTagsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$TagGroupTagsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$TagGroupTagsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> groupId = const Value.absent(),
+                Value<int> tagId = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => TagGroupTagsCompanion(
+                groupId: groupId,
+                tagId: tagId,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required int groupId,
+                required int tagId,
+                Value<int> rowid = const Value.absent(),
+              }) => TagGroupTagsCompanion.insert(
+                groupId: groupId,
+                tagId: tagId,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$TagGroupTagsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({groupId = false, tagId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (groupId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.groupId,
+                                referencedTable: $$TagGroupTagsTableReferences
+                                    ._groupIdTable(db),
+                                referencedColumn: $$TagGroupTagsTableReferences
+                                    ._groupIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+                    if (tagId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.tagId,
+                                referencedTable: $$TagGroupTagsTableReferences
+                                    ._tagIdTable(db),
+                                referencedColumn: $$TagGroupTagsTableReferences
+                                    ._tagIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$TagGroupTagsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $TagGroupTagsTable,
+      TagGroupTagRow,
+      $$TagGroupTagsTableFilterComposer,
+      $$TagGroupTagsTableOrderingComposer,
+      $$TagGroupTagsTableAnnotationComposer,
+      $$TagGroupTagsTableCreateCompanionBuilder,
+      $$TagGroupTagsTableUpdateCompanionBuilder,
+      (TagGroupTagRow, $$TagGroupTagsTableReferences),
+      TagGroupTagRow,
+      PrefetchHooks Function({bool groupId, bool tagId})
     >;
 typedef $$TransactionSplitsTableCreateCompanionBuilder =
     TransactionSplitsCompanion Function({
@@ -36622,6 +38049,10 @@ class $AppDatabaseManager {
       $$TransactionTagsTableTableManager(_db, _db.transactionTags);
   $$RecurringRuleTagsTableTableManager get recurringRuleTags =>
       $$RecurringRuleTagsTableTableManager(_db, _db.recurringRuleTags);
+  $$TagGroupsTableTableManager get tagGroups =>
+      $$TagGroupsTableTableManager(_db, _db.tagGroups);
+  $$TagGroupTagsTableTableManager get tagGroupTags =>
+      $$TagGroupTagsTableTableManager(_db, _db.tagGroupTags);
   $$TransactionSplitsTableTableManager get transactionSplits =>
       $$TransactionSplitsTableTableManager(_db, _db.transactionSplits);
   $$TransactionLinksTableTableManager get transactionLinks =>

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -20087,6 +20087,791 @@ class CurrencyRatesCompanion extends UpdateCompanion<CurrencyRateRow> {
   }
 }
 
+class $CategoryTemplatesTable extends CategoryTemplates
+    with TableInfo<$CategoryTemplatesTable, CategoryTemplateRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoryTemplatesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 60,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, name, createdAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'category_templates';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CategoryTemplateRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CategoryTemplateRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CategoryTemplateRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $CategoryTemplatesTable createAlias(String alias) {
+    return $CategoryTemplatesTable(attachedDatabase, alias);
+  }
+}
+
+class CategoryTemplateRow extends DataClass
+    implements Insertable<CategoryTemplateRow> {
+  final int id;
+  final String name;
+  final DateTime createdAt;
+  const CategoryTemplateRow({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  CategoryTemplatesCompanion toCompanion(bool nullToAbsent) {
+    return CategoryTemplatesCompanion(
+      id: Value(id),
+      name: Value(name),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory CategoryTemplateRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CategoryTemplateRow(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  CategoryTemplateRow copyWith({int? id, String? name, DateTime? createdAt}) =>
+      CategoryTemplateRow(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  CategoryTemplateRow copyWithCompanion(CategoryTemplatesCompanion data) {
+    return CategoryTemplateRow(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateRow(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CategoryTemplateRow &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.createdAt == this.createdAt);
+}
+
+class CategoryTemplatesCompanion extends UpdateCompanion<CategoryTemplateRow> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<DateTime> createdAt;
+  const CategoryTemplatesCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  CategoryTemplatesCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    this.createdAt = const Value.absent(),
+  }) : name = Value(name);
+  static Insertable<CategoryTemplateRow> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  CategoryTemplatesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<DateTime>? createdAt,
+  }) {
+    return CategoryTemplatesCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplatesCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $CategoryTemplateItemsTable extends CategoryTemplateItems
+    with TableInfo<$CategoryTemplateItemsTable, CategoryTemplateItemRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoryTemplateItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _templateIdMeta = const VerificationMeta(
+    'templateId',
+  );
+  @override
+  late final GeneratedColumn<int> templateId = GeneratedColumn<int>(
+    'template_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES category_templates (id)',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 40,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<CategoryKind, String> kind =
+      GeneratedColumn<String>(
+        'kind',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<CategoryKind>($CategoryTemplateItemsTable.$converterkind);
+  static const VerificationMeta _colorValueMeta = const VerificationMeta(
+    'colorValue',
+  );
+  @override
+  late final GeneratedColumn<int> colorValue = GeneratedColumn<int>(
+    'color_value',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _iconKeyMeta = const VerificationMeta(
+    'iconKey',
+  );
+  @override
+  late final GeneratedColumn<String> iconKey = GeneratedColumn<String>(
+    'icon_key',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 40,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sortOrderMeta = const VerificationMeta(
+    'sortOrder',
+  );
+  @override
+  late final GeneratedColumn<int> sortOrder = GeneratedColumn<int>(
+    'sort_order',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _parentItemIdMeta = const VerificationMeta(
+    'parentItemId',
+  );
+  @override
+  late final GeneratedColumn<int> parentItemId = GeneratedColumn<int>(
+    'parent_item_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    templateId,
+    name,
+    kind,
+    colorValue,
+    iconKey,
+    sortOrder,
+    parentItemId,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'category_template_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CategoryTemplateItemRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('template_id')) {
+      context.handle(
+        _templateIdMeta,
+        templateId.isAcceptableOrUnknown(data['template_id']!, _templateIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_templateIdMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('color_value')) {
+      context.handle(
+        _colorValueMeta,
+        colorValue.isAcceptableOrUnknown(data['color_value']!, _colorValueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_colorValueMeta);
+    }
+    if (data.containsKey('icon_key')) {
+      context.handle(
+        _iconKeyMeta,
+        iconKey.isAcceptableOrUnknown(data['icon_key']!, _iconKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_iconKeyMeta);
+    }
+    if (data.containsKey('sort_order')) {
+      context.handle(
+        _sortOrderMeta,
+        sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta),
+      );
+    }
+    if (data.containsKey('parent_item_id')) {
+      context.handle(
+        _parentItemIdMeta,
+        parentItemId.isAcceptableOrUnknown(
+          data['parent_item_id']!,
+          _parentItemIdMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CategoryTemplateItemRow map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CategoryTemplateItemRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      templateId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}template_id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      kind: $CategoryTemplateItemsTable.$converterkind.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}kind'],
+        )!,
+      ),
+      colorValue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}color_value'],
+      )!,
+      iconKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}icon_key'],
+      )!,
+      sortOrder: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sort_order'],
+      )!,
+      parentItemId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}parent_item_id'],
+      ),
+    );
+  }
+
+  @override
+  $CategoryTemplateItemsTable createAlias(String alias) {
+    return $CategoryTemplateItemsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<CategoryKind, String, String> $converterkind =
+      const EnumNameConverter<CategoryKind>(CategoryKind.values);
+}
+
+class CategoryTemplateItemRow extends DataClass
+    implements Insertable<CategoryTemplateItemRow> {
+  final int id;
+  final int templateId;
+  final String name;
+  final CategoryKind kind;
+  final int colorValue;
+  final String iconKey;
+  final int sortOrder;
+  final int? parentItemId;
+  const CategoryTemplateItemRow({
+    required this.id,
+    required this.templateId,
+    required this.name,
+    required this.kind,
+    required this.colorValue,
+    required this.iconKey,
+    required this.sortOrder,
+    this.parentItemId,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['template_id'] = Variable<int>(templateId);
+    map['name'] = Variable<String>(name);
+    {
+      map['kind'] = Variable<String>(
+        $CategoryTemplateItemsTable.$converterkind.toSql(kind),
+      );
+    }
+    map['color_value'] = Variable<int>(colorValue);
+    map['icon_key'] = Variable<String>(iconKey);
+    map['sort_order'] = Variable<int>(sortOrder);
+    if (!nullToAbsent || parentItemId != null) {
+      map['parent_item_id'] = Variable<int>(parentItemId);
+    }
+    return map;
+  }
+
+  CategoryTemplateItemsCompanion toCompanion(bool nullToAbsent) {
+    return CategoryTemplateItemsCompanion(
+      id: Value(id),
+      templateId: Value(templateId),
+      name: Value(name),
+      kind: Value(kind),
+      colorValue: Value(colorValue),
+      iconKey: Value(iconKey),
+      sortOrder: Value(sortOrder),
+      parentItemId: parentItemId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentItemId),
+    );
+  }
+
+  factory CategoryTemplateItemRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CategoryTemplateItemRow(
+      id: serializer.fromJson<int>(json['id']),
+      templateId: serializer.fromJson<int>(json['templateId']),
+      name: serializer.fromJson<String>(json['name']),
+      kind: $CategoryTemplateItemsTable.$converterkind.fromJson(
+        serializer.fromJson<String>(json['kind']),
+      ),
+      colorValue: serializer.fromJson<int>(json['colorValue']),
+      iconKey: serializer.fromJson<String>(json['iconKey']),
+      sortOrder: serializer.fromJson<int>(json['sortOrder']),
+      parentItemId: serializer.fromJson<int?>(json['parentItemId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'templateId': serializer.toJson<int>(templateId),
+      'name': serializer.toJson<String>(name),
+      'kind': serializer.toJson<String>(
+        $CategoryTemplateItemsTable.$converterkind.toJson(kind),
+      ),
+      'colorValue': serializer.toJson<int>(colorValue),
+      'iconKey': serializer.toJson<String>(iconKey),
+      'sortOrder': serializer.toJson<int>(sortOrder),
+      'parentItemId': serializer.toJson<int?>(parentItemId),
+    };
+  }
+
+  CategoryTemplateItemRow copyWith({
+    int? id,
+    int? templateId,
+    String? name,
+    CategoryKind? kind,
+    int? colorValue,
+    String? iconKey,
+    int? sortOrder,
+    Value<int?> parentItemId = const Value.absent(),
+  }) => CategoryTemplateItemRow(
+    id: id ?? this.id,
+    templateId: templateId ?? this.templateId,
+    name: name ?? this.name,
+    kind: kind ?? this.kind,
+    colorValue: colorValue ?? this.colorValue,
+    iconKey: iconKey ?? this.iconKey,
+    sortOrder: sortOrder ?? this.sortOrder,
+    parentItemId: parentItemId.present
+        ? parentItemId.value
+        : this.parentItemId,
+  );
+  CategoryTemplateItemRow copyWithCompanion(
+    CategoryTemplateItemsCompanion data,
+  ) {
+    return CategoryTemplateItemRow(
+      id: data.id.present ? data.id.value : this.id,
+      templateId: data.templateId.present
+          ? data.templateId.value
+          : this.templateId,
+      name: data.name.present ? data.name.value : this.name,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      colorValue: data.colorValue.present
+          ? data.colorValue.value
+          : this.colorValue,
+      iconKey: data.iconKey.present ? data.iconKey.value : this.iconKey,
+      sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
+      parentItemId: data.parentItemId.present
+          ? data.parentItemId.value
+          : this.parentItemId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateItemRow(')
+          ..write('id: $id, ')
+          ..write('templateId: $templateId, ')
+          ..write('name: $name, ')
+          ..write('kind: $kind, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('iconKey: $iconKey, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('parentItemId: $parentItemId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    templateId,
+    name,
+    kind,
+    colorValue,
+    iconKey,
+    sortOrder,
+    parentItemId,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CategoryTemplateItemRow &&
+          other.id == this.id &&
+          other.templateId == this.templateId &&
+          other.name == this.name &&
+          other.kind == this.kind &&
+          other.colorValue == this.colorValue &&
+          other.iconKey == this.iconKey &&
+          other.sortOrder == this.sortOrder &&
+          other.parentItemId == this.parentItemId);
+}
+
+class CategoryTemplateItemsCompanion
+    extends UpdateCompanion<CategoryTemplateItemRow> {
+  final Value<int> id;
+  final Value<int> templateId;
+  final Value<String> name;
+  final Value<CategoryKind> kind;
+  final Value<int> colorValue;
+  final Value<String> iconKey;
+  final Value<int> sortOrder;
+  final Value<int?> parentItemId;
+  const CategoryTemplateItemsCompanion({
+    this.id = const Value.absent(),
+    this.templateId = const Value.absent(),
+    this.name = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.colorValue = const Value.absent(),
+    this.iconKey = const Value.absent(),
+    this.sortOrder = const Value.absent(),
+    this.parentItemId = const Value.absent(),
+  });
+  CategoryTemplateItemsCompanion.insert({
+    this.id = const Value.absent(),
+    required int templateId,
+    required String name,
+    required CategoryKind kind,
+    required int colorValue,
+    required String iconKey,
+    this.sortOrder = const Value.absent(),
+    this.parentItemId = const Value.absent(),
+  }) : templateId = Value(templateId),
+       name = Value(name),
+       kind = Value(kind),
+       colorValue = Value(colorValue),
+       iconKey = Value(iconKey);
+  static Insertable<CategoryTemplateItemRow> custom({
+    Expression<int>? id,
+    Expression<int>? templateId,
+    Expression<String>? name,
+    Expression<String>? kind,
+    Expression<int>? colorValue,
+    Expression<String>? iconKey,
+    Expression<int>? sortOrder,
+    Expression<int>? parentItemId,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (templateId != null) 'template_id': templateId,
+      if (name != null) 'name': name,
+      if (kind != null) 'kind': kind,
+      if (colorValue != null) 'color_value': colorValue,
+      if (iconKey != null) 'icon_key': iconKey,
+      if (sortOrder != null) 'sort_order': sortOrder,
+      if (parentItemId != null) 'parent_item_id': parentItemId,
+    });
+  }
+
+  CategoryTemplateItemsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? templateId,
+    Value<String>? name,
+    Value<CategoryKind>? kind,
+    Value<int>? colorValue,
+    Value<String>? iconKey,
+    Value<int>? sortOrder,
+    Value<int?>? parentItemId,
+  }) {
+    return CategoryTemplateItemsCompanion(
+      id: id ?? this.id,
+      templateId: templateId ?? this.templateId,
+      name: name ?? this.name,
+      kind: kind ?? this.kind,
+      colorValue: colorValue ?? this.colorValue,
+      iconKey: iconKey ?? this.iconKey,
+      sortOrder: sortOrder ?? this.sortOrder,
+      parentItemId: parentItemId ?? this.parentItemId,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (templateId.present) {
+      map['template_id'] = Variable<int>(templateId.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(
+        $CategoryTemplateItemsTable.$converterkind.toSql(kind.value),
+      );
+    }
+    if (colorValue.present) {
+      map['color_value'] = Variable<int>(colorValue.value);
+    }
+    if (iconKey.present) {
+      map['icon_key'] = Variable<String>(iconKey.value);
+    }
+    if (sortOrder.present) {
+      map['sort_order'] = Variable<int>(sortOrder.value);
+    }
+    if (parentItemId.present) {
+      map['parent_item_id'] = Variable<int>(parentItemId.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateItemsCompanion(')
+          ..write('id: $id, ')
+          ..write('templateId: $templateId, ')
+          ..write('name: $name, ')
+          ..write('kind: $kind, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('iconKey: $iconKey, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('parentItemId: $parentItemId')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -20131,6 +20916,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $CreditCardDetailsTable creditCardDetails =
       $CreditCardDetailsTable(this);
   late final $CurrencyRatesTable currencyRates = $CurrencyRatesTable(this);
+  late final $CategoryTemplatesTable categoryTemplates =
+      $CategoryTemplatesTable(this);
+  late final $CategoryTemplateItemsTable categoryTemplateItems =
+      $CategoryTemplateItemsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -20169,6 +20958,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     ocrCorrections,
     creditCardDetails,
     currencyRates,
+    categoryTemplates,
+    categoryTemplateItems,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -8772,6 +8772,18 @@ class $SettingsTable extends Settings
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
+  static const VerificationMeta _frequentIconKeysMeta = const VerificationMeta(
+    'frequentIconKeys',
+  );
+  @override
+  late final GeneratedColumn<String> frequentIconKeys = GeneratedColumn<String>(
+    'frequent_icon_keys',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(''),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -8830,6 +8842,7 @@ class $SettingsTable extends Settings
     fontWeightDelta,
     fontFamily,
     extraBottomInset,
+    frequentIconKeys,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -9284,6 +9297,15 @@ class $SettingsTable extends Settings
         ),
       );
     }
+    if (data.containsKey('frequent_icon_keys')) {
+      context.handle(
+        _frequentIconKeysMeta,
+        frequentIconKeys.isAcceptableOrUnknown(
+          data['frequent_icon_keys']!,
+          _frequentIconKeysMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -9522,6 +9544,10 @@ class $SettingsTable extends Settings
       extraBottomInset: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}extra_bottom_inset'],
+      )!,
+      frequentIconKeys: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}frequent_icon_keys'],
       )!,
     );
   }
@@ -9783,6 +9809,12 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
   /// every `SafeArea` in the app reads from — see `AppShell` and
   /// `LockScreen`, neither of which needed any change themselves.
   final int extraBottomInset;
+
+  /// Icon keys (see `AppIcons`) picked from the icon sheet, most-recent-first,
+  /// comma-joined — same convention as [bottomNavSlots]. Powers the
+  /// "Frequently used" row so the icon someone reaches for constantly (their
+  /// coffee cup, their gym) surfaces without scrolling or typing a search.
+  final String frequentIconKeys;
   const SettingRow({
     required this.id,
     required this.currencyCode,
@@ -9840,6 +9872,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     required this.fontWeightDelta,
     this.fontFamily,
     required this.extraBottomInset,
+    required this.frequentIconKeys,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -9948,6 +9981,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       map['font_family'] = Variable<String>(fontFamily);
     }
     map['extra_bottom_inset'] = Variable<int>(extraBottomInset);
+    map['frequent_icon_keys'] = Variable<String>(frequentIconKeys);
     return map;
   }
 
@@ -10039,6 +10073,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ? const Value.absent()
           : Value(fontFamily),
       extraBottomInset: Value(extraBottomInset),
+      frequentIconKeys: Value(frequentIconKeys),
     );
   }
 
@@ -10143,6 +10178,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       fontWeightDelta: serializer.fromJson<int>(json['fontWeightDelta']),
       fontFamily: serializer.fromJson<String?>(json['fontFamily']),
       extraBottomInset: serializer.fromJson<int>(json['extraBottomInset']),
+      frequentIconKeys: serializer.fromJson<String>(json['frequentIconKeys']),
     );
   }
   @override
@@ -10221,6 +10257,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       'fontWeightDelta': serializer.toJson<int>(fontWeightDelta),
       'fontFamily': serializer.toJson<String?>(fontFamily),
       'extraBottomInset': serializer.toJson<int>(extraBottomInset),
+      'frequentIconKeys': serializer.toJson<String>(frequentIconKeys),
     };
   }
 
@@ -10281,6 +10318,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     int? fontWeightDelta,
     Value<String?> fontFamily = const Value.absent(),
     int? extraBottomInset,
+    String? frequentIconKeys,
   }) => SettingRow(
     id: id ?? this.id,
     currencyCode: currencyCode ?? this.currencyCode,
@@ -10356,6 +10394,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     fontWeightDelta: fontWeightDelta ?? this.fontWeightDelta,
     fontFamily: fontFamily.present ? fontFamily.value : this.fontFamily,
     extraBottomInset: extraBottomInset ?? this.extraBottomInset,
+    frequentIconKeys: frequentIconKeys ?? this.frequentIconKeys,
   );
   SettingRow copyWithCompanion(SettingsCompanion data) {
     return SettingRow(
@@ -10509,6 +10548,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       extraBottomInset: data.extraBottomInset.present
           ? data.extraBottomInset.value
           : this.extraBottomInset,
+      frequentIconKeys: data.frequentIconKeys.present
+          ? data.frequentIconKeys.value
+          : this.frequentIconKeys,
     );
   }
 
@@ -10572,7 +10614,8 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ..write('fontScalePercent: $fontScalePercent, ')
           ..write('fontWeightDelta: $fontWeightDelta, ')
           ..write('fontFamily: $fontFamily, ')
-          ..write('extraBottomInset: $extraBottomInset')
+          ..write('extraBottomInset: $extraBottomInset, ')
+          ..write('frequentIconKeys: $frequentIconKeys')
           ..write(')'))
         .toString();
   }
@@ -10635,6 +10678,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     fontWeightDelta,
     fontFamily,
     extraBottomInset,
+    frequentIconKeys,
   ]);
   @override
   bool operator ==(Object other) =>
@@ -10697,7 +10741,8 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           other.fontScalePercent == this.fontScalePercent &&
           other.fontWeightDelta == this.fontWeightDelta &&
           other.fontFamily == this.fontFamily &&
-          other.extraBottomInset == this.extraBottomInset);
+          other.extraBottomInset == this.extraBottomInset &&
+          other.frequentIconKeys == this.frequentIconKeys);
 }
 
 class SettingsCompanion extends UpdateCompanion<SettingRow> {
@@ -10757,6 +10802,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
   final Value<int> fontWeightDelta;
   final Value<String?> fontFamily;
   final Value<int> extraBottomInset;
+  final Value<String> frequentIconKeys;
   const SettingsCompanion({
     this.id = const Value.absent(),
     this.currencyCode = const Value.absent(),
@@ -10814,6 +10860,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.fontWeightDelta = const Value.absent(),
     this.fontFamily = const Value.absent(),
     this.extraBottomInset = const Value.absent(),
+    this.frequentIconKeys = const Value.absent(),
   });
   SettingsCompanion.insert({
     this.id = const Value.absent(),
@@ -10872,6 +10919,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.fontWeightDelta = const Value.absent(),
     this.fontFamily = const Value.absent(),
     this.extraBottomInset = const Value.absent(),
+    this.frequentIconKeys = const Value.absent(),
   });
   static Insertable<SettingRow> custom({
     Expression<int>? id,
@@ -10930,6 +10978,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Expression<int>? fontWeightDelta,
     Expression<String>? fontFamily,
     Expression<int>? extraBottomInset,
+    Expression<String>? frequentIconKeys,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
@@ -11006,6 +11055,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       if (fontWeightDelta != null) 'font_weight_delta': fontWeightDelta,
       if (fontFamily != null) 'font_family': fontFamily,
       if (extraBottomInset != null) 'extra_bottom_inset': extraBottomInset,
+      if (frequentIconKeys != null) 'frequent_icon_keys': frequentIconKeys,
     });
   }
 
@@ -11066,6 +11116,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Value<int>? fontWeightDelta,
     Value<String?>? fontFamily,
     Value<int>? extraBottomInset,
+    Value<String>? frequentIconKeys,
   }) {
     return SettingsCompanion(
       id: id ?? this.id,
@@ -11134,6 +11185,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       fontWeightDelta: fontWeightDelta ?? this.fontWeightDelta,
       fontFamily: fontFamily ?? this.fontFamily,
       extraBottomInset: extraBottomInset ?? this.extraBottomInset,
+      frequentIconKeys: frequentIconKeys ?? this.frequentIconKeys,
     );
   }
 
@@ -11340,6 +11392,9 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     if (extraBottomInset.present) {
       map['extra_bottom_inset'] = Variable<int>(extraBottomInset.value);
     }
+    if (frequentIconKeys.present) {
+      map['frequent_icon_keys'] = Variable<String>(frequentIconKeys.value);
+    }
     return map;
   }
 
@@ -11403,7 +11458,8 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
           ..write('fontScalePercent: $fontScalePercent, ')
           ..write('fontWeightDelta: $fontWeightDelta, ')
           ..write('fontFamily: $fontFamily, ')
-          ..write('extraBottomInset: $extraBottomInset')
+          ..write('extraBottomInset: $extraBottomInset, ')
+          ..write('frequentIconKeys: $frequentIconKeys')
           ..write(')'))
         .toString();
   }
@@ -29685,6 +29741,7 @@ typedef $$SettingsTableCreateCompanionBuilder =
       Value<int> fontWeightDelta,
       Value<String?> fontFamily,
       Value<int> extraBottomInset,
+      Value<String> frequentIconKeys,
     });
 typedef $$SettingsTableUpdateCompanionBuilder =
     SettingsCompanion Function({
@@ -29744,6 +29801,7 @@ typedef $$SettingsTableUpdateCompanionBuilder =
       Value<int> fontWeightDelta,
       Value<String?> fontFamily,
       Value<int> extraBottomInset,
+      Value<String> frequentIconKeys,
     });
 
 final class $$SettingsTableReferences
@@ -30061,6 +30119,11 @@ class $$SettingsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get frequentIconKeys => $composableBuilder(
+    column: $table.frequentIconKeys,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$AccountsTableFilterComposer get quickAddAccountId {
     final $$AccountsTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -30369,6 +30432,11 @@ class $$SettingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get frequentIconKeys => $composableBuilder(
+    column: $table.frequentIconKeys,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$AccountsTableOrderingComposer get quickAddAccountId {
     final $$AccountsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -30662,6 +30730,11 @@ class $$SettingsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get frequentIconKeys => $composableBuilder(
+    column: $table.frequentIconKeys,
+    builder: (column) => column,
+  );
+
   $$AccountsTableAnnotationComposer get quickAddAccountId {
     final $$AccountsTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -30772,6 +30845,7 @@ class $$SettingsTableTableManager
                 Value<int> fontWeightDelta = const Value.absent(),
                 Value<String?> fontFamily = const Value.absent(),
                 Value<int> extraBottomInset = const Value.absent(),
+                Value<String> frequentIconKeys = const Value.absent(),
               }) => SettingsCompanion(
                 id: id,
                 currencyCode: currencyCode,
@@ -30829,6 +30903,7 @@ class $$SettingsTableTableManager
                 fontWeightDelta: fontWeightDelta,
                 fontFamily: fontFamily,
                 extraBottomInset: extraBottomInset,
+                frequentIconKeys: frequentIconKeys,
               ),
           createCompanionCallback:
               ({
@@ -30890,6 +30965,7 @@ class $$SettingsTableTableManager
                 Value<int> fontWeightDelta = const Value.absent(),
                 Value<String?> fontFamily = const Value.absent(),
                 Value<int> extraBottomInset = const Value.absent(),
+                Value<String> frequentIconKeys = const Value.absent(),
               }) => SettingsCompanion.insert(
                 id: id,
                 currencyCode: currencyCode,
@@ -30947,6 +31023,7 @@ class $$SettingsTableTableManager
                 fontWeightDelta: fontWeightDelta,
                 fontFamily: fontFamily,
                 extraBottomInset: extraBottomInset,
+                frequentIconKeys: frequentIconKeys,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -8908,6 +8908,21 @@ class $SettingsTable extends Settings
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _rtaEnabledMeta = const VerificationMeta(
+    'rtaEnabled',
+  );
+  @override
+  late final GeneratedColumn<bool> rtaEnabled = GeneratedColumn<bool>(
+    'rta_enabled',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("rta_enabled" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _paypalEnabledMeta = const VerificationMeta(
     'paypalEnabled',
   );
@@ -9436,6 +9451,7 @@ class $SettingsTable extends Settings
     myCashapp,
     myRevolut,
     upiEnabled,
+    rtaEnabled,
     paypalEnabled,
     venmoEnabled,
     cashappEnabled,
@@ -9616,6 +9632,12 @@ class $SettingsTable extends Settings
       context.handle(
         _upiEnabledMeta,
         upiEnabled.isAcceptableOrUnknown(data['upi_enabled']!, _upiEnabledMeta),
+      );
+    }
+    if (data.containsKey('rta_enabled')) {
+      context.handle(
+        _rtaEnabledMeta,
+        rtaEnabled.isAcceptableOrUnknown(data['rta_enabled']!, _rtaEnabledMeta),
       );
     }
     if (data.containsKey('paypal_enabled')) {
@@ -10020,6 +10042,10 @@ class $SettingsTable extends Settings
         DriftSqlType.bool,
         data['${effectivePrefix}upi_enabled'],
       )!,
+      rtaEnabled: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}rta_enabled'],
+      )!,
       paypalEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}paypal_enabled'],
@@ -10274,6 +10300,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
   /// entirely, rather than leaving a permanently-disabled button around.
   final bool upiEnabled;
 
+  /// Whether Ready to Assign is turned on globally.
+  final bool rtaEnabled;
+
   /// Same as [upiEnabled], for PayPal.
   final bool paypalEnabled;
 
@@ -10483,6 +10512,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     this.myCashapp,
     this.myRevolut,
     required this.upiEnabled,
+    required this.rtaEnabled,
     required this.paypalEnabled,
     required this.venmoEnabled,
     required this.cashappEnabled,
@@ -10559,6 +10589,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       map['my_revolut'] = Variable<String>(myRevolut);
     }
     map['upi_enabled'] = Variable<bool>(upiEnabled);
+    map['rta_enabled'] = Variable<bool>(rtaEnabled);
     map['paypal_enabled'] = Variable<bool>(paypalEnabled);
     map['venmo_enabled'] = Variable<bool>(venmoEnabled);
     map['cashapp_enabled'] = Variable<bool>(cashappEnabled);
@@ -10674,6 +10705,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ? const Value.absent()
           : Value(myRevolut),
       upiEnabled: Value(upiEnabled),
+      rtaEnabled: Value(rtaEnabled),
       paypalEnabled: Value(paypalEnabled),
       venmoEnabled: Value(venmoEnabled),
       cashappEnabled: Value(cashappEnabled),
@@ -10765,6 +10797,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       myCashapp: serializer.fromJson<String?>(json['myCashapp']),
       myRevolut: serializer.fromJson<String?>(json['myRevolut']),
       upiEnabled: serializer.fromJson<bool>(json['upiEnabled']),
+      rtaEnabled: serializer.fromJson<bool>(json['rtaEnabled']),
       paypalEnabled: serializer.fromJson<bool>(json['paypalEnabled']),
       venmoEnabled: serializer.fromJson<bool>(json['venmoEnabled']),
       cashappEnabled: serializer.fromJson<bool>(json['cashappEnabled']),
@@ -10864,6 +10897,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       'myCashapp': serializer.toJson<String?>(myCashapp),
       'myRevolut': serializer.toJson<String?>(myRevolut),
       'upiEnabled': serializer.toJson<bool>(upiEnabled),
+      'rtaEnabled': serializer.toJson<bool>(rtaEnabled),
       'paypalEnabled': serializer.toJson<bool>(paypalEnabled),
       'venmoEnabled': serializer.toJson<bool>(venmoEnabled),
       'cashappEnabled': serializer.toJson<bool>(cashappEnabled),
@@ -10942,6 +10976,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     Value<String?> myCashapp = const Value.absent(),
     Value<String?> myRevolut = const Value.absent(),
     bool? upiEnabled,
+    bool? rtaEnabled,
     bool? paypalEnabled,
     bool? venmoEnabled,
     bool? cashappEnabled,
@@ -11004,6 +11039,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     myCashapp: myCashapp.present ? myCashapp.value : this.myCashapp,
     myRevolut: myRevolut.present ? myRevolut.value : this.myRevolut,
     upiEnabled: upiEnabled ?? this.upiEnabled,
+    rtaEnabled: rtaEnabled ?? this.rtaEnabled,
     paypalEnabled: paypalEnabled ?? this.paypalEnabled,
     venmoEnabled: venmoEnabled ?? this.venmoEnabled,
     cashappEnabled: cashappEnabled ?? this.cashappEnabled,
@@ -11098,6 +11134,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       upiEnabled: data.upiEnabled.present
           ? data.upiEnabled.value
           : this.upiEnabled,
+      rtaEnabled: data.rtaEnabled.present
+          ? data.rtaEnabled.value
+          : this.rtaEnabled,
       paypalEnabled: data.paypalEnabled.present
           ? data.paypalEnabled.value
           : this.paypalEnabled,
@@ -11242,6 +11281,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ..write('myCashapp: $myCashapp, ')
           ..write('myRevolut: $myRevolut, ')
           ..write('upiEnabled: $upiEnabled, ')
+          ..write('rtaEnabled: $rtaEnabled, ')
           ..write('paypalEnabled: $paypalEnabled, ')
           ..write('venmoEnabled: $venmoEnabled, ')
           ..write('cashappEnabled: $cashappEnabled, ')
@@ -11308,6 +11348,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     myCashapp,
     myRevolut,
     upiEnabled,
+    rtaEnabled,
     paypalEnabled,
     venmoEnabled,
     cashappEnabled,
@@ -11371,6 +11412,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           other.myCashapp == this.myCashapp &&
           other.myRevolut == this.myRevolut &&
           other.upiEnabled == this.upiEnabled &&
+          other.rtaEnabled == this.rtaEnabled &&
           other.paypalEnabled == this.paypalEnabled &&
           other.venmoEnabled == this.venmoEnabled &&
           other.cashappEnabled == this.cashappEnabled &&
@@ -11434,6 +11476,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
   final Value<String?> myCashapp;
   final Value<String?> myRevolut;
   final Value<bool> upiEnabled;
+  final Value<bool> rtaEnabled;
   final Value<bool> paypalEnabled;
   final Value<bool> venmoEnabled;
   final Value<bool> cashappEnabled;
@@ -11493,6 +11536,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.myCashapp = const Value.absent(),
     this.myRevolut = const Value.absent(),
     this.upiEnabled = const Value.absent(),
+    this.rtaEnabled = const Value.absent(),
     this.paypalEnabled = const Value.absent(),
     this.venmoEnabled = const Value.absent(),
     this.cashappEnabled = const Value.absent(),
@@ -11553,6 +11597,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.myCashapp = const Value.absent(),
     this.myRevolut = const Value.absent(),
     this.upiEnabled = const Value.absent(),
+    this.rtaEnabled = const Value.absent(),
     this.paypalEnabled = const Value.absent(),
     this.venmoEnabled = const Value.absent(),
     this.cashappEnabled = const Value.absent(),
@@ -11613,6 +11658,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Expression<String>? myCashapp,
     Expression<String>? myRevolut,
     Expression<bool>? upiEnabled,
+    Expression<bool>? rtaEnabled,
     Expression<bool>? paypalEnabled,
     Expression<bool>? venmoEnabled,
     Expression<bool>? cashappEnabled,
@@ -11677,6 +11723,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       if (myCashapp != null) 'my_cashapp': myCashapp,
       if (myRevolut != null) 'my_revolut': myRevolut,
       if (upiEnabled != null) 'upi_enabled': upiEnabled,
+      if (rtaEnabled != null) 'rta_enabled': rtaEnabled,
       if (paypalEnabled != null) 'paypal_enabled': paypalEnabled,
       if (venmoEnabled != null) 'venmo_enabled': venmoEnabled,
       if (cashappEnabled != null) 'cashapp_enabled': cashappEnabled,
@@ -11753,6 +11800,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Value<String?>? myCashapp,
     Value<String?>? myRevolut,
     Value<bool>? upiEnabled,
+    Value<bool>? rtaEnabled,
     Value<bool>? paypalEnabled,
     Value<bool>? venmoEnabled,
     Value<bool>? cashappEnabled,
@@ -11815,6 +11863,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       myCashapp: myCashapp ?? this.myCashapp,
       myRevolut: myRevolut ?? this.myRevolut,
       upiEnabled: upiEnabled ?? this.upiEnabled,
+      rtaEnabled: rtaEnabled ?? this.rtaEnabled,
       paypalEnabled: paypalEnabled ?? this.paypalEnabled,
       venmoEnabled: venmoEnabled ?? this.venmoEnabled,
       cashappEnabled: cashappEnabled ?? this.cashappEnabled,
@@ -11926,6 +11975,9 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     }
     if (upiEnabled.present) {
       map['upi_enabled'] = Variable<bool>(upiEnabled.value);
+    }
+    if (rtaEnabled.present) {
+      map['rta_enabled'] = Variable<bool>(rtaEnabled.value);
     }
     if (paypalEnabled.present) {
       map['paypal_enabled'] = Variable<bool>(paypalEnabled.value);
@@ -12101,6 +12153,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
           ..write('myCashapp: $myCashapp, ')
           ..write('myRevolut: $myRevolut, ')
           ..write('upiEnabled: $upiEnabled, ')
+          ..write('rtaEnabled: $rtaEnabled, ')
           ..write('paypalEnabled: $paypalEnabled, ')
           ..write('venmoEnabled: $venmoEnabled, ')
           ..write('cashappEnabled: $cashappEnabled, ')
@@ -30978,6 +31031,7 @@ typedef $$SettingsTableCreateCompanionBuilder =
       Value<String?> myCashapp,
       Value<String?> myRevolut,
       Value<bool> upiEnabled,
+      Value<bool> rtaEnabled,
       Value<bool> paypalEnabled,
       Value<bool> venmoEnabled,
       Value<bool> cashappEnabled,
@@ -31039,6 +31093,7 @@ typedef $$SettingsTableUpdateCompanionBuilder =
       Value<String?> myCashapp,
       Value<String?> myRevolut,
       Value<bool> upiEnabled,
+      Value<bool> rtaEnabled,
       Value<bool> paypalEnabled,
       Value<bool> venmoEnabled,
       Value<bool> cashappEnabled,
@@ -31201,6 +31256,11 @@ class $$SettingsTableFilterComposer
 
   ColumnFilters<bool> get upiEnabled => $composableBuilder(
     column: $table.upiEnabled,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -31530,6 +31590,11 @@ class $$SettingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get paypalEnabled => $composableBuilder(
     column: $table.paypalEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -31830,6 +31895,11 @@ class $$SettingsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get rtaEnabled => $composableBuilder(
+    column: $table.rtaEnabled,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get paypalEnabled => $composableBuilder(
     column: $table.paypalEnabled,
     builder: (column) => column,
@@ -32099,6 +32169,7 @@ class $$SettingsTableTableManager
                 Value<String?> myCashapp = const Value.absent(),
                 Value<String?> myRevolut = const Value.absent(),
                 Value<bool> upiEnabled = const Value.absent(),
+                Value<bool> rtaEnabled = const Value.absent(),
                 Value<bool> paypalEnabled = const Value.absent(),
                 Value<bool> venmoEnabled = const Value.absent(),
                 Value<bool> cashappEnabled = const Value.absent(),
@@ -32160,6 +32231,7 @@ class $$SettingsTableTableManager
                 myCashapp: myCashapp,
                 myRevolut: myRevolut,
                 upiEnabled: upiEnabled,
+                rtaEnabled: rtaEnabled,
                 paypalEnabled: paypalEnabled,
                 venmoEnabled: venmoEnabled,
                 cashappEnabled: cashappEnabled,
@@ -32221,6 +32293,7 @@ class $$SettingsTableTableManager
                 Value<String?> myCashapp = const Value.absent(),
                 Value<String?> myRevolut = const Value.absent(),
                 Value<bool> upiEnabled = const Value.absent(),
+                Value<bool> rtaEnabled = const Value.absent(),
                 Value<bool> paypalEnabled = const Value.absent(),
                 Value<bool> venmoEnabled = const Value.absent(),
                 Value<bool> cashappEnabled = const Value.absent(),
@@ -32282,6 +32355,7 @@ class $$SettingsTableTableManager
                 myCashapp: myCashapp,
                 myRevolut: myRevolut,
                 upiEnabled: upiEnabled,
+                rtaEnabled: rtaEnabled,
                 paypalEnabled: paypalEnabled,
                 venmoEnabled: venmoEnabled,
                 cashappEnabled: cashappEnabled,

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -9039,6 +9039,16 @@ class $SettingsTable extends Settings
       ).withConverter<MoreScreenViewMode>(
         $SettingsTable.$convertermoreScreenViewMode,
       );
+  @override
+  late final GeneratedColumnWithTypeConverter<BudgetingMode, String>
+  budgetingMode = GeneratedColumn<String>(
+    'budgeting_mode',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('budgets'),
+  ).withConverter<BudgetingMode>($SettingsTable.$converterbudgetingMode);
   static const VerificationMeta _pinTimeoutMinutesMeta = const VerificationMeta(
     'pinTimeoutMinutes',
   );
@@ -9436,6 +9446,7 @@ class $SettingsTable extends Settings
     biometricEnabled,
     lockScreenStyle,
     moreScreenViewMode,
+    budgetingMode,
     pinTimeoutMinutes,
     masterPhraseHash,
     masterPhraseSalt,
@@ -10053,6 +10064,12 @@ class $SettingsTable extends Settings
           data['${effectivePrefix}more_screen_view_mode'],
         )!,
       ),
+      budgetingMode: $SettingsTable.$converterbudgetingMode.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}budgeting_mode'],
+        )!,
+      ),
       pinTimeoutMinutes: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}pin_timeout_minutes'],
@@ -10187,6 +10204,10 @@ class $SettingsTable extends Settings
   $convertermoreScreenViewMode = const EnumNameConverter<MoreScreenViewMode>(
     MoreScreenViewMode.values,
   );
+  static JsonTypeConverter2<BudgetingMode, String, String>
+  $converterbudgetingMode = const EnumNameConverter<BudgetingMode>(
+    BudgetingMode.values,
+  );
   static JsonTypeConverter2<AutoBackupFrequency, String, String>
   $converterautoBackupFrequency = const EnumNameConverter<AutoBackupFrequency>(
     AutoBackupFrequency.values,
@@ -10287,6 +10308,12 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
   /// How the More hub lays out its items — see [MoreScreenViewMode].
   /// Defaults to `list` so existing users see no change.
   final MoreScreenViewMode moreScreenViewMode;
+
+  /// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
+  /// Defaults to `budgets` so existing users see no change; switching to
+  /// `envelope` doesn't touch either system's data, it only changes which
+  /// one the Dashboard and More hub's "Budgets" tile surface.
+  final BudgetingMode budgetingMode;
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the
@@ -10466,6 +10493,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     required this.biometricEnabled,
     required this.lockScreenStyle,
     required this.moreScreenViewMode,
+    required this.budgetingMode,
     required this.pinTimeoutMinutes,
     this.masterPhraseHash,
     this.masterPhraseSalt,
@@ -10553,6 +10581,11 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     {
       map['more_screen_view_mode'] = Variable<String>(
         $SettingsTable.$convertermoreScreenViewMode.toSql(moreScreenViewMode),
+      );
+    }
+    {
+      map['budgeting_mode'] = Variable<String>(
+        $SettingsTable.$converterbudgetingMode.toSql(budgetingMode),
       );
     }
     map['pin_timeout_minutes'] = Variable<int>(pinTimeoutMinutes);
@@ -10657,6 +10690,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       biometricEnabled: Value(biometricEnabled),
       lockScreenStyle: Value(lockScreenStyle),
       moreScreenViewMode: Value(moreScreenViewMode),
+      budgetingMode: Value(budgetingMode),
       pinTimeoutMinutes: Value(pinTimeoutMinutes),
       masterPhraseHash: masterPhraseHash == null && nullToAbsent
           ? const Value.absent()
@@ -10744,6 +10778,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       ),
       moreScreenViewMode: $SettingsTable.$convertermoreScreenViewMode.fromJson(
         serializer.fromJson<String>(json['moreScreenViewMode']),
+      ),
+      budgetingMode: $SettingsTable.$converterbudgetingMode.fromJson(
+        serializer.fromJson<String>(json['budgetingMode']),
       ),
       pinTimeoutMinutes: serializer.fromJson<int>(json['pinTimeoutMinutes']),
       masterPhraseHash: serializer.fromJson<String?>(json['masterPhraseHash']),
@@ -10841,6 +10878,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       'moreScreenViewMode': serializer.toJson<String>(
         $SettingsTable.$convertermoreScreenViewMode.toJson(moreScreenViewMode),
       ),
+      'budgetingMode': serializer.toJson<String>(
+        $SettingsTable.$converterbudgetingMode.toJson(budgetingMode),
+      ),
       'pinTimeoutMinutes': serializer.toJson<int>(pinTimeoutMinutes),
       'masterPhraseHash': serializer.toJson<String?>(masterPhraseHash),
       'masterPhraseSalt': serializer.toJson<String?>(masterPhraseSalt),
@@ -10912,6 +10952,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     bool? biometricEnabled,
     LockScreenStyle? lockScreenStyle,
     MoreScreenViewMode? moreScreenViewMode,
+    BudgetingMode? budgetingMode,
     int? pinTimeoutMinutes,
     Value<String?> masterPhraseHash = const Value.absent(),
     Value<String?> masterPhraseSalt = const Value.absent(),
@@ -10975,6 +11016,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     biometricEnabled: biometricEnabled ?? this.biometricEnabled,
     lockScreenStyle: lockScreenStyle ?? this.lockScreenStyle,
     moreScreenViewMode: moreScreenViewMode ?? this.moreScreenViewMode,
+    budgetingMode: budgetingMode ?? this.budgetingMode,
     pinTimeoutMinutes: pinTimeoutMinutes ?? this.pinTimeoutMinutes,
     masterPhraseHash: masterPhraseHash.present
         ? masterPhraseHash.value
@@ -11086,6 +11128,9 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
       moreScreenViewMode: data.moreScreenViewMode.present
           ? data.moreScreenViewMode.value
           : this.moreScreenViewMode,
+      budgetingMode: data.budgetingMode.present
+          ? data.budgetingMode.value
+          : this.budgetingMode,
       pinTimeoutMinutes: data.pinTimeoutMinutes.present
           ? data.pinTimeoutMinutes.value
           : this.pinTimeoutMinutes,
@@ -11207,6 +11252,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           ..write('biometricEnabled: $biometricEnabled, ')
           ..write('lockScreenStyle: $lockScreenStyle, ')
           ..write('moreScreenViewMode: $moreScreenViewMode, ')
+          ..write('budgetingMode: $budgetingMode, ')
           ..write('pinTimeoutMinutes: $pinTimeoutMinutes, ')
           ..write('masterPhraseHash: $masterPhraseHash, ')
           ..write('masterPhraseSalt: $masterPhraseSalt, ')
@@ -11272,6 +11318,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
     biometricEnabled,
     lockScreenStyle,
     moreScreenViewMode,
+    budgetingMode,
     pinTimeoutMinutes,
     masterPhraseHash,
     masterPhraseSalt,
@@ -11334,6 +11381,7 @@ class SettingRow extends DataClass implements Insertable<SettingRow> {
           other.biometricEnabled == this.biometricEnabled &&
           other.lockScreenStyle == this.lockScreenStyle &&
           other.moreScreenViewMode == this.moreScreenViewMode &&
+          other.budgetingMode == this.budgetingMode &&
           other.pinTimeoutMinutes == this.pinTimeoutMinutes &&
           other.masterPhraseHash == this.masterPhraseHash &&
           other.masterPhraseSalt == this.masterPhraseSalt &&
@@ -11396,6 +11444,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
   final Value<bool> biometricEnabled;
   final Value<LockScreenStyle> lockScreenStyle;
   final Value<MoreScreenViewMode> moreScreenViewMode;
+  final Value<BudgetingMode> budgetingMode;
   final Value<int> pinTimeoutMinutes;
   final Value<String?> masterPhraseHash;
   final Value<String?> masterPhraseSalt;
@@ -11454,6 +11503,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.biometricEnabled = const Value.absent(),
     this.lockScreenStyle = const Value.absent(),
     this.moreScreenViewMode = const Value.absent(),
+    this.budgetingMode = const Value.absent(),
     this.pinTimeoutMinutes = const Value.absent(),
     this.masterPhraseHash = const Value.absent(),
     this.masterPhraseSalt = const Value.absent(),
@@ -11513,6 +11563,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     this.biometricEnabled = const Value.absent(),
     this.lockScreenStyle = const Value.absent(),
     this.moreScreenViewMode = const Value.absent(),
+    this.budgetingMode = const Value.absent(),
     this.pinTimeoutMinutes = const Value.absent(),
     this.masterPhraseHash = const Value.absent(),
     this.masterPhraseSalt = const Value.absent(),
@@ -11572,6 +11623,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Expression<bool>? biometricEnabled,
     Expression<String>? lockScreenStyle,
     Expression<String>? moreScreenViewMode,
+    Expression<String>? budgetingMode,
     Expression<int>? pinTimeoutMinutes,
     Expression<String>? masterPhraseHash,
     Expression<String>? masterPhraseSalt,
@@ -11636,6 +11688,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       if (lockScreenStyle != null) 'lock_screen_style': lockScreenStyle,
       if (moreScreenViewMode != null)
         'more_screen_view_mode': moreScreenViewMode,
+      if (budgetingMode != null) 'budgeting_mode': budgetingMode,
       if (pinTimeoutMinutes != null) 'pin_timeout_minutes': pinTimeoutMinutes,
       if (masterPhraseHash != null) 'master_phrase_hash': masterPhraseHash,
       if (masterPhraseSalt != null) 'master_phrase_salt': masterPhraseSalt,
@@ -11710,6 +11763,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
     Value<bool>? biometricEnabled,
     Value<LockScreenStyle>? lockScreenStyle,
     Value<MoreScreenViewMode>? moreScreenViewMode,
+    Value<BudgetingMode>? budgetingMode,
     Value<int>? pinTimeoutMinutes,
     Value<String?>? masterPhraseHash,
     Value<String?>? masterPhraseSalt,
@@ -11771,6 +11825,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
       biometricEnabled: biometricEnabled ?? this.biometricEnabled,
       lockScreenStyle: lockScreenStyle ?? this.lockScreenStyle,
       moreScreenViewMode: moreScreenViewMode ?? this.moreScreenViewMode,
+      budgetingMode: budgetingMode ?? this.budgetingMode,
       pinTimeoutMinutes: pinTimeoutMinutes ?? this.pinTimeoutMinutes,
       masterPhraseHash: masterPhraseHash ?? this.masterPhraseHash,
       masterPhraseSalt: masterPhraseSalt ?? this.masterPhraseSalt,
@@ -11906,6 +11961,11 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
         $SettingsTable.$convertermoreScreenViewMode.toSql(
           moreScreenViewMode.value,
         ),
+      );
+    }
+    if (budgetingMode.present) {
+      map['budgeting_mode'] = Variable<String>(
+        $SettingsTable.$converterbudgetingMode.toSql(budgetingMode.value),
       );
     }
     if (pinTimeoutMinutes.present) {
@@ -12051,6 +12111,7 @@ class SettingsCompanion extends UpdateCompanion<SettingRow> {
           ..write('biometricEnabled: $biometricEnabled, ')
           ..write('lockScreenStyle: $lockScreenStyle, ')
           ..write('moreScreenViewMode: $moreScreenViewMode, ')
+          ..write('budgetingMode: $budgetingMode, ')
           ..write('pinTimeoutMinutes: $pinTimeoutMinutes, ')
           ..write('masterPhraseHash: $masterPhraseHash, ')
           ..write('masterPhraseSalt: $masterPhraseSalt, ')
@@ -30927,6 +30988,7 @@ typedef $$SettingsTableCreateCompanionBuilder =
       Value<bool> biometricEnabled,
       Value<LockScreenStyle> lockScreenStyle,
       Value<MoreScreenViewMode> moreScreenViewMode,
+      Value<BudgetingMode> budgetingMode,
       Value<int> pinTimeoutMinutes,
       Value<String?> masterPhraseHash,
       Value<String?> masterPhraseSalt,
@@ -30987,6 +31049,7 @@ typedef $$SettingsTableUpdateCompanionBuilder =
       Value<bool> biometricEnabled,
       Value<LockScreenStyle> lockScreenStyle,
       Value<MoreScreenViewMode> moreScreenViewMode,
+      Value<BudgetingMode> budgetingMode,
       Value<int> pinTimeoutMinutes,
       Value<String?> masterPhraseHash,
       Value<String?> masterPhraseSalt,
@@ -31190,6 +31253,12 @@ class $$SettingsTableFilterComposer
   ColumnWithTypeConverterFilters<MoreScreenViewMode, MoreScreenViewMode, String>
   get moreScreenViewMode => $composableBuilder(
     column: $table.moreScreenViewMode,
+    builder: (column) => ColumnWithTypeConverterFilters(column),
+  );
+
+  ColumnWithTypeConverterFilters<BudgetingMode, BudgetingMode, String>
+  get budgetingMode => $composableBuilder(
+    column: $table.budgetingMode,
     builder: (column) => ColumnWithTypeConverterFilters(column),
   );
 
@@ -31511,6 +31580,11 @@ class $$SettingsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get budgetingMode => $composableBuilder(
+    column: $table.budgetingMode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get pinTimeoutMinutes => $composableBuilder(
     column: $table.pinTimeoutMinutes,
     builder: (column) => ColumnOrderings(column),
@@ -31808,6 +31882,12 @@ class $$SettingsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumnWithTypeConverter<BudgetingMode, String> get budgetingMode =>
+      $composableBuilder(
+        column: $table.budgetingMode,
+        builder: (column) => column,
+      );
+
   GeneratedColumn<int> get pinTimeoutMinutes => $composableBuilder(
     column: $table.pinTimeoutMinutes,
     builder: (column) => column,
@@ -32030,6 +32110,7 @@ class $$SettingsTableTableManager
                 Value<LockScreenStyle> lockScreenStyle = const Value.absent(),
                 Value<MoreScreenViewMode> moreScreenViewMode =
                     const Value.absent(),
+                Value<BudgetingMode> budgetingMode = const Value.absent(),
                 Value<int> pinTimeoutMinutes = const Value.absent(),
                 Value<String?> masterPhraseHash = const Value.absent(),
                 Value<String?> masterPhraseSalt = const Value.absent(),
@@ -32089,6 +32170,7 @@ class $$SettingsTableTableManager
                 biometricEnabled: biometricEnabled,
                 lockScreenStyle: lockScreenStyle,
                 moreScreenViewMode: moreScreenViewMode,
+                budgetingMode: budgetingMode,
                 pinTimeoutMinutes: pinTimeoutMinutes,
                 masterPhraseHash: masterPhraseHash,
                 masterPhraseSalt: masterPhraseSalt,
@@ -32150,6 +32232,7 @@ class $$SettingsTableTableManager
                 Value<LockScreenStyle> lockScreenStyle = const Value.absent(),
                 Value<MoreScreenViewMode> moreScreenViewMode =
                     const Value.absent(),
+                Value<BudgetingMode> budgetingMode = const Value.absent(),
                 Value<int> pinTimeoutMinutes = const Value.absent(),
                 Value<String?> masterPhraseHash = const Value.absent(),
                 Value<String?> masterPhraseSalt = const Value.absent(),
@@ -32209,6 +32292,7 @@ class $$SettingsTableTableManager
                 biometricEnabled: biometricEnabled,
                 lockScreenStyle: lockScreenStyle,
                 moreScreenViewMode: moreScreenViewMode,
+                budgetingMode: budgetingMode,
                 pinTimeoutMinutes: pinTimeoutMinutes,
                 masterPhraseHash: masterPhraseHash,
                 masterPhraseSalt: masterPhraseSalt,

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -384,48 +384,93 @@ final _envelopeSpentProvider = Provider<Map<(int, int), Money>>((ref) {
   return out;
 });
 
-/// `SUM(allocations) − SUM(expenses)` for one (account, category) pair. Never
-/// touches [Accounts.currentBalance] or `net worth` — Envelope Mode only
-/// re-labels money already correctly tracked by the ledger, it never moves
-/// any.
-final categoryBalanceProvider =
-    Provider.family<Money, ({int accountId, int categoryId})>((ref, key) {
-      final allocated = ref.watch(_envelopeAllocatedProvider);
-      final spent = ref.watch(_envelopeSpentProvider);
-      final pairKey = (key.accountId, key.categoryId);
-      return (allocated[pairKey] ?? const Money.zero()) -
-          (spent[pairKey] ?? const Money.zero());
-    });
+/// Every account currently in Envelope Mode, in the same order
+/// `watchAccounts()` returns (by `sortOrder`) — the shared "which accounts
+/// feed the pool" set behind [categoryBalanceProvider] and
+/// [readyToAssignProvider]. GitHub #48: multiple accounts can each opt in,
+/// but there is exactly one pool across all of them, not one per account.
+final envelopeModeAccountsProvider = Provider<List<AccountRow>>((ref) {
+  final accounts = ref.watch(accountsProvider).valueOrNull ?? const [];
+  return [
+    for (final a in accounts)
+      if (a.envelopeMode) a,
+  ];
+});
 
-/// `account.currentBalance − Σ(category_balance > 0)`, for every category
-/// this account has ever allocated to or spent from. A category that has
-/// gone negative (overspent — allowed, shown in red, never blocked) does
-/// *not* reduce this further: those rupees already left the account and are
-/// already reflected in `currentBalance`, so only a category still holding a
+/// The account [addAllocation]/[moveAllocation] record a manual assign
+/// against when there's no real transaction-level account to attribute it
+/// to (e.g. a move made from the shared Ready to Assign screen rather than
+/// alongside a specific transfer). Purely an audit trail — see
+/// [Allocations.accountId] — never read back by [categoryBalanceProvider]
+/// or [readyToAssignProvider], both of which pool across every account in
+/// [envelopeModeAccountsProvider] regardless of which one a row names.
+final defaultEnvelopeAccountIdProvider = Provider<int?>((ref) {
+  final accounts = ref.watch(envelopeModeAccountsProvider);
+  return accounts.isEmpty ? null : accounts.first.id;
+});
+
+/// `SUM(allocations) − SUM(expenses)` for one category, pooled across every
+/// account in [envelopeModeAccountsProvider] — GitHub #48: one shared
+/// balance per category, not one per account. An account that isn't (or is
+/// no longer) in Envelope Mode never contributes here, even if it shares a
+/// category with an Envelope-Mode account; otherwise an ordinary account's
+/// everyday spending would silently drain the shared pool. Never touches
+/// [Accounts.currentBalance] or `net worth` — Envelope Mode only re-labels
+/// money already correctly tracked by the ledger, it never moves any.
+final categoryBalanceProvider = Provider.family<Money, int>((
+  ref,
+  categoryId,
+) {
+  final poolAccountIds = {
+    for (final a in ref.watch(envelopeModeAccountsProvider)) a.id,
+  };
+  final allocated = ref.watch(_envelopeAllocatedProvider);
+  final spent = ref.watch(_envelopeSpentProvider);
+
+  var balance = const Money.zero();
+  for (final accountId in poolAccountIds) {
+    final pairKey = (accountId, categoryId);
+    balance +=
+        (allocated[pairKey] ?? const Money.zero()) -
+        (spent[pairKey] ?? const Money.zero());
+  }
+  return balance;
+});
+
+/// `Σ(currentBalance) − Σ(category_balance > 0)`, across every account in
+/// [envelopeModeAccountsProvider] — GitHub #48: one shared Ready to Assign
+/// figure, not one per account. A category that has gone negative
+/// (overspent — allowed, shown in red, never blocked) does *not* reduce
+/// this further: those rupees already left an account and are already
+/// reflected in its `currentBalance`, so only a category still holding a
 /// **positive**, unspent balance counts as "claimed". This keeps
-/// `ready_to_assign` bounded by the account's real balance in every case.
-final readyToAssignProvider = Provider.family<Money, int>((ref, accountId) {
-  final account = ref.watch(accountMapProvider)[accountId];
-  if (account == null) return const Money.zero();
+/// `ready_to_assign` bounded by the pool's real combined balance in every
+/// case.
+final readyToAssignProvider = Provider<Money>((ref) {
+  final poolAccounts = ref.watch(envelopeModeAccountsProvider);
+  if (poolAccounts.isEmpty) return const Money.zero();
+  final poolAccountIds = {for (final a in poolAccounts) a.id};
 
   final allocated = ref.watch(_envelopeAllocatedProvider);
   final spent = ref.watch(_envelopeSpentProvider);
   final categoryIds = <int>{
     for (final k in allocated.keys)
-      if (k.$1 == accountId) k.$2,
+      if (poolAccountIds.contains(k.$1)) k.$2,
     for (final k in spent.keys)
-      if (k.$1 == accountId) k.$2,
+      if (poolAccountIds.contains(k.$1)) k.$2,
   };
 
   var claimed = const Money.zero();
   for (final categoryId in categoryIds) {
-    final pairKey = (accountId, categoryId);
-    final balance =
-        (allocated[pairKey] ?? const Money.zero()) -
-        (spent[pairKey] ?? const Money.zero());
+    final balance = ref.watch(categoryBalanceProvider(categoryId));
     if (balance.isPositive) claimed += balance;
   }
-  return account.currentBalance - claimed;
+
+  var totalBalance = const Money.zero();
+  for (final a in poolAccounts) {
+    totalBalance += a.currentBalance;
+  }
+  return totalBalance - claimed;
 });
 
 // ── Persons ─────────────────────────────────────────────────────────────────

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -789,6 +789,12 @@ final lockScreenStyleProvider = Provider<LockScreenStyle>((ref) {
       LockScreenStyle.classic;
 });
 
+/// How the More hub lays out its items — see [MoreScreenViewMode].
+final moreScreenViewModeProvider = Provider<MoreScreenViewMode>((ref) {
+  return ref.watch(settingsProvider).valueOrNull?.moreScreenViewMode ??
+      MoreScreenViewMode.list;
+});
+
 /// Whether every amount app-wide is masked — the top bar's eye icon. See
 /// `AmountVisibilityScope` in `money_text.dart`.
 final hideAmountsProvider = Provider<bool>((ref) {
@@ -1189,6 +1195,30 @@ final transactionTagsByTxProvider = Provider<Map<int, List<TagRow>>>((ref) {
     final tag = tagMap[link.tagId];
     if (tag == null) continue;
     (out[link.transactionId] ??= []).add(tag);
+  }
+  return out;
+});
+
+// ── Tag groups ──────────────────────────────────────────────────────────────
+
+final tagGroupsProvider = StreamProvider<List<TagGroupRow>>(
+  (ref) => ref.watch(dbProvider).watchTagGroups(),
+);
+
+final _tagGroupTagLinksProvider = StreamProvider<List<TagGroupTagRow>>(
+  (ref) => ref.watch(dbProvider).watchAllTagGroupTags(),
+);
+
+/// Every group's member tags, keyed by group id — same compose-don't-
+/// resubscribe shape as [transactionTagsByTxProvider].
+final tagGroupTagsByGroupProvider = Provider<Map<int, List<TagRow>>>((ref) {
+  final links = ref.watch(_tagGroupTagLinksProvider).valueOrNull ?? const [];
+  final tagMap = ref.watch(tagMapProvider);
+  final out = <int, List<TagRow>>{};
+  for (final link in links) {
+    final tag = tagMap[link.tagId];
+    if (tag == null) continue;
+    (out[link.groupId] ??= []).add(tag);
   }
   return out;
 });

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -128,6 +128,19 @@ final statsShowYearProvider = StateProvider<bool>((ref) => false);
 /// or a per-subcategory breakdown. See GitHub #40.
 final statsShowSubcategoriesProvider = StateProvider<bool>((ref) => false);
 
+/// Stats "Standings" section: ranks either individual transactions or
+/// categories (the latter respecting [statsShowSubcategoriesProvider], same
+/// grouping as the pie above). See GitHub #95.
+enum StandingsMetric { transactions, categories }
+
+final statsStandingsMetricProvider = StateProvider<StandingsMetric>(
+  (ref) => StandingsMetric.transactions,
+);
+
+/// Standings sort direction: false (the default) ranks the highest amount
+/// first; true reverses it to lowest first.
+final statsStandingsAscendingProvider = StateProvider<bool>((ref) => false);
+
 // ── Transactions search & filter ───────────────────────────────────────────
 // Shared between the shared top bar (which owns the search/filter buttons —
 // see `AppShell`) and `TransactionsScreen` (which applies them to the list),

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -67,6 +67,18 @@ final categoryMapProvider = Provider<Map<int, CategoryRow>>((ref) {
   };
 });
 
+/// Saved category templates (GitHub #101), newest first.
+final categoryTemplatesProvider = StreamProvider<List<CategoryTemplateRow>>(
+  (ref) => ref.watch(dbProvider).watchCategoryTemplates(),
+);
+
+/// One template's own category items, for previewing before applying it.
+final categoryTemplateItemsProvider =
+    StreamProvider.family<List<CategoryTemplateItemRow>, int>(
+      (ref, templateId) =>
+          ref.watch(dbProvider).watchCategoryTemplateItems(templateId),
+    );
+
 /// A category's top-level ancestor. The tree is two deep, so a child resolves
 /// to its parent and a parent (or an unknown id) resolves to itself. Used to
 /// roll subcategory spend up into the parent it belongs to.
@@ -430,10 +442,7 @@ final defaultEnvelopeAccountIdProvider = Provider<int?>((ref) {
 /// everyday spending would silently drain the shared pool. Never touches
 /// [Accounts.currentBalance] or `net worth` — Envelope Mode only re-labels
 /// money already correctly tracked by the ledger, it never moves any.
-final categoryBalanceProvider = Provider.family<Money, int>((
-  ref,
-  categoryId,
-) {
+final categoryBalanceProvider = Provider.family<Money, int>((ref, categoryId) {
   final poolAccountIds = {
     for (final a in ref.watch(envelopeModeAccountsProvider)) a.id,
   };
@@ -462,21 +471,19 @@ enum CategoryFundingState { overspent, funded, underfunded }
 
 /// Returns null when [categoryId] has no [Budgets] row — there's nothing to
 /// color either way, in RTA on or off.
-final categoryFundingStateProvider = Provider.family<CategoryFundingState?, int>((
-  ref,
-  categoryId,
-) {
-  final p = ref
-      .watch(budgetProgressProvider)
-      .where((p) => p.budget.categoryId == categoryId)
-      .firstOrNull;
-  if (p == null) return null;
-  if (p.overspent) return CategoryFundingState.overspent;
-  final balance = ref.watch(categoryBalanceProvider(categoryId));
-  return balance >= p.budget.amount
-      ? CategoryFundingState.funded
-      : CategoryFundingState.underfunded;
-});
+final categoryFundingStateProvider =
+    Provider.family<CategoryFundingState?, int>((ref, categoryId) {
+      final p = ref
+          .watch(budgetProgressProvider)
+          .where((p) => p.budget.categoryId == categoryId)
+          .firstOrNull;
+      if (p == null) return null;
+      if (p.overspent) return CategoryFundingState.overspent;
+      final balance = ref.watch(categoryBalanceProvider(categoryId));
+      return balance >= p.budget.amount
+          ? CategoryFundingState.funded
+          : CategoryFundingState.underfunded;
+    });
 
 /// `Σ(currentBalance) − Σ(category_balance > 0)`, across every account in
 /// [envelopeModeAccountsProvider] — GitHub #48: one shared Ready to Assign
@@ -575,7 +582,8 @@ final groupExpensesProvider = StreamProvider.family<List<GroupExpenseRow>, int>(
 /// [personBalancesProvider] over exactly that group's member ids. Not new
 /// balance math; a group is never a second source of truth for money.
 final groupBalanceProvider = Provider.family<Money, int>((ref, groupId) {
-  final members = ref.watch(groupMembersProvider(groupId)).valueOrNull ?? const [];
+  final members =
+      ref.watch(groupMembersProvider(groupId)).valueOrNull ?? const [];
   final balances =
       ref.watch(personBalancesProvider).valueOrNull ?? const <int, Money>{};
   return members.fold(
@@ -821,7 +829,10 @@ final hasMasterPhraseProvider = Provider<bool>((ref) {
 });
 
 final masterPhraseAttemptThresholdProvider = Provider<int>((ref) {
-  return ref.watch(settingsProvider).valueOrNull?.masterPhraseAttemptThreshold ??
+  return ref
+          .watch(settingsProvider)
+          .valueOrNull
+          ?.masterPhraseAttemptThreshold ??
       5;
 });
 

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -686,6 +686,12 @@ final showCurrencySymbolProvider = Provider<bool>((ref) {
   return ref.watch(settingsProvider).valueOrNull?.showCurrencySymbol ?? true;
 });
 
+/// One row per currency that has a rate entered, each the most recent — the
+/// Currency settings screen's list.
+final currencyRatesProvider = StreamProvider<List<CurrencyRateRow>>(
+  (ref) => ref.watch(dbProvider).watchCurrentRates(),
+);
+
 /// Whether "Mark as repaid" (Persons) is offered at all. Off by default —
 /// lending/borrowing stays out of income/expense unless asked for.
 final countRepaymentsAsIncomeProvider = Provider<bool>((ref) {

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -450,6 +450,34 @@ final categoryBalanceProvider = Provider.family<Money, int>((
   return balance;
 });
 
+/// The three-state (RTA on) / two-state (RTA off) funding indicator for a
+/// category with a [Budgets] ceiling — GitHub #100 v2. `overspent` always
+/// wins regardless of funding; `funded`/`underfunded` only distinguish
+/// whether the pooled envelope balance ([categoryBalanceProvider]) fully
+/// backs the ceiling yet. Callers should only use this while
+/// [rtaEnabledProvider] is on — with RTA off, fall back to
+/// [BudgetProgress.nearingLimit] instead, which this deliberately doesn't
+/// touch or replace.
+enum CategoryFundingState { overspent, funded, underfunded }
+
+/// Returns null when [categoryId] has no [Budgets] row — there's nothing to
+/// color either way, in RTA on or off.
+final categoryFundingStateProvider = Provider.family<CategoryFundingState?, int>((
+  ref,
+  categoryId,
+) {
+  final p = ref
+      .watch(budgetProgressProvider)
+      .where((p) => p.budget.categoryId == categoryId)
+      .firstOrNull;
+  if (p == null) return null;
+  if (p.overspent) return CategoryFundingState.overspent;
+  final balance = ref.watch(categoryBalanceProvider(categoryId));
+  return balance >= p.budget.amount
+      ? CategoryFundingState.funded
+      : CategoryFundingState.underfunded;
+});
+
 /// `Σ(currentBalance) − Σ(category_balance > 0)`, across every account in
 /// [envelopeModeAccountsProvider] — GitHub #48: one shared Ready to Assign
 /// figure, not one per account. A category that has gone negative
@@ -872,10 +900,12 @@ final hideAmountsProvider = Provider<bool>((ref) {
   return ref.watch(settingsProvider).valueOrNull?.hideAmounts ?? false;
 });
 
-/// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
-final budgetingModeProvider = Provider<BudgetingMode>((ref) {
-  return ref.watch(settingsProvider).valueOrNull?.budgetingMode ??
-      BudgetingMode.budgets;
+/// Whether Ready to Assign — the shared envelope pool — is turned on
+/// globally (GitHub #100 v2). Budget (the per-category ceiling system) is
+/// always on regardless of this flag; see [BudgetingMode]'s doc comment for
+/// the superseded enum this replaces.
+final rtaEnabledProvider = Provider<bool>((ref) {
+  return ref.watch(settingsProvider).valueOrNull?.rtaEnabled ?? false;
 });
 
 /// A standing notification with "Add expense" / "Add income" shortcuts —

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -872,6 +872,12 @@ final hideAmountsProvider = Provider<bool>((ref) {
   return ref.watch(settingsProvider).valueOrNull?.hideAmounts ?? false;
 });
 
+/// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
+final budgetingModeProvider = Provider<BudgetingMode>((ref) {
+  return ref.watch(settingsProvider).valueOrNull?.budgetingMode ??
+      BudgetingMode.budgets;
+});
+
 /// A standing notification with "Add expense" / "Add income" shortcuts —
 /// off by default. See GitHub #38.
 final notificationQuickAddEnabledProvider = Provider<bool>((ref) {

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -821,6 +821,13 @@ final extraBottomInsetProvider = Provider<int>((ref) {
   return ref.watch(settingsProvider).valueOrNull?.extraBottomInset ?? 0;
 });
 
+/// Icon keys most recently picked from the icon sheet, newest first — see
+/// `Settings.frequentIconKeys` and `AppDatabase.recordIconUsed`.
+final frequentIconKeysProvider = Provider<List<String>>((ref) {
+  final raw = ref.watch(settingsProvider).valueOrNull?.frequentIconKeys ?? '';
+  return raw.isEmpty ? const [] : raw.split(',');
+});
+
 /// Minutes the app may sit backgrounded before the next resume re-locks it —
 /// `0` means immediately. See GitHub #60.
 final pinTimeoutMinutesProvider = Provider<int>((ref) {

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -262,6 +262,18 @@ class Transactions extends Table {
   /// both at once.
   IntColumn get paymentGroupId =>
       integer().nullable().references(Transactions, #id)();
+
+  /// What this cost in another currency, manually entered — e.g. "$9.99" for
+  /// a subscription actually charged as [amount] home-currency rupees
+  /// (GitHub #85). [amount] stays authoritative for every balance/net-worth/
+  /// envelope computation; this is a purely informational annotation. Always
+  /// null exactly when [foreignAmount] is null — never one without the
+  /// other, same pairing as [RecurringRules.promoAmount]/
+  /// [RecurringRules.promoOccurrencesLeft]. The implied conversion rate is
+  /// `amount / foreignAmount`, recomputed for display rather than stored.
+  TextColumn get foreignCurrencyCode => text().nullable()();
+  IntColumn get foreignAmount =>
+      integer().nullable().map(const MoneyConverter())();
 }
 
 @DataClassName('BudgetRow')
@@ -596,6 +608,17 @@ class RecurringRules extends Table {
   IntColumn get promoOccurrencesLeft => integer().nullable()();
 
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+
+  /// Same annotation as [Transactions.foreignCurrencyCode]/
+  /// [Transactions.foreignAmount] (GitHub #85), carried on the rule so every
+  /// occurrence it posts keeps showing its original foreign-currency price
+  /// (e.g. a $9.99 subscription). Copied onto each posted transaction by
+  /// [AppDatabase.runDueRecurringRules] — except while a promo price is
+  /// active, since there is no tracked foreign equivalent for [promoAmount].
+  /// Always null exactly when [foreignAmount] is null.
+  TextColumn get foreignCurrencyCode => text().nullable()();
+  IntColumn get foreignAmount =>
+      integer().nullable().map(const MoneyConverter())();
 }
 
 /// Single-row app settings.

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -126,6 +126,31 @@ class MoneyConverter extends TypeConverter<Money, int> {
   int toSql(Money value) => value.paise;
 }
 
+/// A manually-entered exchange rate: how many units of the parent currency
+/// (`Settings.currencyCode`) equal one unit of some other currency, as of a
+/// given date. Never fetched live — see the design spec's "Non-goals".
+///
+/// Rows accumulate as history; adding a new rate is always an insert, never
+/// an update, so a transaction posted under an old rate stays resolvable
+/// (`AppDatabase.latestRate`) even after the rate moves on. This is what
+/// makes converted historical totals stable when the rate changes later.
+@DataClassName('CurrencyRateRow')
+class CurrencyRates extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// The non-parent currency this rate prices, e.g. `USD`. Never the parent
+  /// currency itself, which is always 1:1 with itself.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3)();
+
+  /// Units of the parent currency per 1 unit of [currencyCode], scaled by
+  /// [currencyRateScale] so it's an exact integer — never a `double`, the
+  /// same rule [Money] follows. `83_120_000` means 1 unit = 83.12 parent.
+  IntColumn get rateToBaseMicros => integer()();
+
+  DateTimeColumn get effectiveAt => dateTime()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+
 // ─── Tables ─────────────────────────────────────────────────────────────────
 
 @DataClassName('AccountRow')
@@ -173,6 +198,15 @@ class Accounts extends Table {
   /// they treat as their real spendable net worth.
   BoolColumn get includeInNetWorth =>
       boolean().withDefault(const Constant(true))();
+
+  /// Null = this account is in the parent currency (`Settings.currencyCode`)
+  /// — true for every account that existed before this feature, and for
+  /// every account a user never explicitly changes. Locked once the account
+  /// has a transaction (enforced in `AppDatabase.setAccountCurrency`, not
+  /// here — Drift columns can't express that rule). A debit-card/UPI
+  /// instrument (non-null `linkedAccountId`) never gets its own value here —
+  /// it always mirrors its linked account's currency.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
 }
 
 @DataClassName('CategoryRow')
@@ -274,6 +308,32 @@ class Transactions extends Table {
   TextColumn get foreignCurrencyCode => text().nullable()();
   IntColumn get foreignAmount =>
       integer().nullable().map(const MoneyConverter())();
+
+  /// This transaction's own ledger currency, snapshotted from its account's
+  /// [Accounts.currencyCode] at post time. Null = parent currency, which
+  /// matches [amount]'s existing meaning exactly (no conversion needed).
+  /// Distinct from the #85 [foreignCurrencyCode]/[foreignAmount] pair above,
+  /// which is a manual informational annotation on a parent-currency
+  /// transaction — this pair instead describes the transaction's *real*
+  /// native currency, inherited from its account.
+  TextColumn get currencyCode => text().withLength(min: 3, max: 3).nullable()();
+
+  /// Snapshot of `CurrencyRates.rateToBaseMicros` as of [date], for
+  /// [currencyCode]. Null iff [currencyCode] is null.
+  IntColumn get fxRateToBaseMicros => integer().nullable()();
+
+  /// Transfer only, and only when the source and destination accounts don't
+  /// share a currency: the amount credited to [toAccountId], in *its own*
+  /// currency. Null for a same-currency transfer, where crediting [amount]
+  /// unchanged is already correct — see `AppDatabase._applyTxEffect`.
+  IntColumn get toAmount => integer().map(const MoneyConverter()).nullable()();
+
+  /// Transfer only, mirrors [currencyCode]/[fxRateToBaseMicros] for the
+  /// destination leg — the two accounts can each be a different currency
+  /// from the parent (and from each other), so the destination needs its
+  /// own independent snapshot.
+  TextColumn get toCurrencyCode => text().withLength(min: 3, max: 3).nullable()();
+  IntColumn get toFxRateToBaseMicros => integer().nullable()();
 }
 
 @DataClassName('BudgetRow')

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -876,6 +876,12 @@ class Settings extends Table {
   IntColumn get extraBottomInset =>
       integer().withDefault(const Constant(0))();
 
+  /// Icon keys (see `AppIcons`) picked from the icon sheet, most-recent-first,
+  /// comma-joined — same convention as [bottomNavSlots]. Powers the
+  /// "Frequently used" row so the icon someone reaches for constantly (their
+  /// coffee cup, their gym) surfaces without scrolling or typing a search.
+  TextColumn get frequentIconKeys => text().withDefault(const Constant(''))();
+
   @override
   Set<Column> get primaryKey => {id};
 }

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -245,6 +245,36 @@ class Categories extends Table {
   IntColumn get parentId => integer().nullable()();
 }
 
+/// A saved snapshot of a category/sub-category structure (GitHub #101) — its
+/// rows live in [CategoryTemplateItems]. Independent of [Categories]: saving
+/// or applying a template never touches a transaction, only which
+/// `Categories` rows are archived vs. active. See
+/// `docs/superpowers/specs/2026-09-06-category-templates-design.md`.
+@DataClassName('CategoryTemplateRow')
+class CategoryTemplates extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().withLength(min: 1, max: 60)();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+/// One category in a saved template. Mirrors [Categories]' own shape (name,
+/// kind, colour, icon, two-level parent nesting) but [parentItemId] resolves
+/// against *other rows of the same template*, never a live [Categories.id] —
+/// a template must be applicable on a device that has never seen these
+/// categories before. [AppDatabase.applyCategoryTemplate] matches these
+/// against live categories by name, not id.
+@DataClassName('CategoryTemplateItemRow')
+class CategoryTemplateItems extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get templateId => integer().references(CategoryTemplates, #id)();
+  TextColumn get name => text().withLength(min: 1, max: 40)();
+  TextColumn get kind => textEnum<CategoryKind>()();
+  IntColumn get colorValue => integer()();
+  TextColumn get iconKey => text().withLength(min: 1, max: 40)();
+  IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+  IntColumn get parentItemId => integer().nullable()();
+}
+
 @DataClassName('TransactionRow')
 class Transactions extends Table {
   IntColumn get id => integer().autoIncrement()();
@@ -346,7 +376,8 @@ class Transactions extends Table {
   /// destination leg — the two accounts can each be a different currency
   /// from the parent (and from each other), so the destination needs its
   /// own independent snapshot.
-  TextColumn get toCurrencyCode => text().withLength(min: 3, max: 3).nullable()();
+  TextColumn get toCurrencyCode =>
+      text().withLength(min: 3, max: 3).nullable()();
   IntColumn get toFxRateToBaseMicros => integer().nullable()();
 }
 
@@ -565,16 +596,20 @@ class GroupExpenseShares extends Table {
   /// at any time. This share row survives with the link cleared, reading
   /// exactly like any other untracked share — a graceful downgrade, not a
   /// dangling reference `deleteGroupExpense` has to work around blind.
-  IntColumn get personEntryId => integer()
-      .nullable()
-      .references(PersonEntries, #id, onDelete: KeyAction.setNull)();
+  IntColumn get personEntryId => integer().nullable().references(
+    PersonEntries,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
 
   /// Set (with [personEntryId] null) only for my own share when I'm the
   /// payer — a real [TxType.expense] transaction, not a debt. Same
   /// `onDelete: setNull` reasoning as [personEntryId].
-  IntColumn get transactionId => integer()
-      .nullable()
-      .references(Transactions, #id, onDelete: KeyAction.setNull)();
+  IntColumn get transactionId => integer().nullable().references(
+    Transactions,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
 }
 
 /// Cash Reminders. A reminder **posts nothing on its own** — the user taps
@@ -632,8 +667,7 @@ class RecurringRules extends Table {
   /// [accountId] to this goal or loan account instead of an
   /// income/expense transaction. Null (the common case) means the rule
   /// posts an ordinary expense/income per [kind].
-  IntColumn get toAccountId =>
-      integer().nullable().references(Accounts, #id)();
+  IntColumn get toAccountId => integer().nullable().references(Accounts, #id)();
 
   /// Same free-text field as [Transactions.payee] — who the rule pays (an
   /// expense) or who it's paid by (income, e.g. an employer for a salary
@@ -766,12 +800,10 @@ class Settings extends Table {
   BoolColumn get upiEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for PayPal.
-  BoolColumn get paypalEnabled =>
-      boolean().withDefault(const Constant(true))();
+  BoolColumn get paypalEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for Venmo.
-  BoolColumn get venmoEnabled =>
-      boolean().withDefault(const Constant(true))();
+  BoolColumn get venmoEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for Cash App.
   BoolColumn get cashappEnabled =>
@@ -987,8 +1019,7 @@ class Settings extends Table {
   /// (GitHub #78). Applied once, in `XpencApp`'s `builder`, to the `padding`
   /// every `SafeArea` in the app reads from — see `AppShell` and
   /// `LockScreen`, neither of which needed any change themselves.
-  IntColumn get extraBottomInset =>
-      integer().withDefault(const Constant(0))();
+  IntColumn get extraBottomInset => integer().withDefault(const Constant(0))();
 
   /// Icon keys (see `AppIcons`) picked from the icon sheet, most-recent-first,
   /// comma-joined — same convention as [bottomNavSlots]. Powers the

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -113,6 +113,16 @@ enum LockScreenStyle { classic, bigNumpad, scrambled }
 /// row instead, still grouped the same way.
 enum MoreScreenViewMode { list, cards }
 
+/// Which budgeting system the Dashboard and More hub surface as primary
+/// (GitHub #100). `budgets` shows the classic per-category spending-ceiling
+/// system (`BudgetsScreen`). `envelope` shows Ready to Assign / category
+/// envelopes instead. Both systems keep working and keep their own data
+/// either way — this only decides which one the Dashboard highlights and
+/// which one the More hub's "Budgets" tile opens; a user can still reach
+/// the other from wherever it's already linked from today (Account Detail's
+/// Envelope Mode toggle, or `/more/budgets` directly).
+enum BudgetingMode { budgets, envelope }
+
 // ─── Converters ─────────────────────────────────────────────────────────────
 
 /// Money crosses the DB boundary as an integer number of paise. Never a double.
@@ -792,6 +802,13 @@ class Settings extends Table {
   /// Defaults to `list` so existing users see no change.
   TextColumn get moreScreenViewMode =>
       textEnum<MoreScreenViewMode>().withDefault(const Constant('list'))();
+
+  /// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
+  /// Defaults to `budgets` so existing users see no change; switching to
+  /// `envelope` doesn't touch either system's data, it only changes which
+  /// one the Dashboard and More hub's "Budgets" tile surface.
+  TextColumn get budgetingMode =>
+      textEnum<BudgetingMode>().withDefault(const Constant('budgets'))();
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -108,6 +108,11 @@ enum AutoBackupFrequency { daily, monthly, custom }
 /// position can't infer the PIN.
 enum LockScreenStyle { classic, bigNumpad, scrambled }
 
+/// How the More hub (`MoreScreen`) lays out its items. `list` is the
+/// original one-column row layout. `cards` shows two square-ish cards per
+/// row instead, still grouped the same way.
+enum MoreScreenViewMode { list, cards }
+
 // ─── Converters ─────────────────────────────────────────────────────────────
 
 /// Money crosses the DB boundary as an integer number of paise. Never a double.
@@ -521,12 +526,28 @@ class RecurringRules extends Table {
   TextColumn get name => text().withLength(min: 1, max: 60)();
 
   /// Reuses [CategoryKind] rather than a bespoke enum — a rule is exactly as
-  /// income-or-expense as the category it posts under.
+  /// income-or-expense as the category it posts under. For a G&L rule (see
+  /// [toAccountId]) this is always [CategoryKind.expense] — money leaves
+  /// [accountId] the same direction as an expense — but it's otherwise
+  /// unread: every code path branches on [toAccountId] first.
   TextColumn get kind => textEnum<CategoryKind>()();
 
   IntColumn get amount => integer().map(const MoneyConverter())();
   IntColumn get accountId => integer().references(Accounts, #id)();
-  IntColumn get categoryId => integer().references(Categories, #id)();
+
+  /// Null for a G&L rule (see [toAccountId]) — a transfer into a goal or
+  /// loan is only ever optionally tagged, exactly like
+  /// [GoalDetails.categoryId]/[LoanDetails.categoryId]. Required for an
+  /// expense/income rule.
+  IntColumn get categoryId =>
+      integer().nullable().references(Categories, #id)();
+
+  /// Non-null makes this a "G&L" rule: it posts a [TxType.transfer] from
+  /// [accountId] to this goal or loan account instead of an
+  /// income/expense transaction. Null (the common case) means the rule
+  /// posts an ordinary expense/income per [kind].
+  IntColumn get toAccountId =>
+      integer().nullable().references(Accounts, #id)();
 
   /// Same free-text field as [Transactions.payee] — who the rule pays (an
   /// expense) or who it's paid by (income, e.g. an employer for a salary
@@ -683,6 +704,11 @@ class Settings extends Table {
   /// Defaults to `classic` so existing users see no change.
   TextColumn get lockScreenStyle =>
       textEnum<LockScreenStyle>().withDefault(const Constant('classic'))();
+
+  /// How the More hub lays out its items — see [MoreScreenViewMode].
+  /// Defaults to `list` so existing users see no change.
+  TextColumn get moreScreenViewMode =>
+      textEnum<MoreScreenViewMode>().withDefault(const Constant('list'))();
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the
@@ -1007,6 +1033,36 @@ class RecurringRuleTags extends Table {
 
   @override
   Set<Column> get primaryKey => {ruleId, tagId};
+}
+
+/// A named bundle of [Tags] (e.g. "Work trip" = Travel + Meals + Client) —
+/// picked as one unit from [TagPickerSheet] instead of hunting down each tag
+/// individually every time the same combination gets used. See GitHub #92.
+///
+/// Purely a shortcut for *selecting* tags: applying a group to a transaction
+/// still just writes ordinary [TransactionTags] rows, so nothing downstream
+/// (filters, stats, exports) needs to know groups exist at all.
+@DataClassName('TagGroupRow')
+class TagGroups extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().withLength(min: 1, max: 30)();
+  IntColumn get colorValue => integer()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {name},
+  ];
+}
+
+/// Many-to-many join: which tags belong to a [TagGroups] bundle.
+@DataClassName('TagGroupTagRow')
+class TagGroupTags extends Table {
+  IntColumn get groupId => integer().references(TagGroups, #id)();
+  IntColumn get tagId => integer().references(Tags, #id)();
+
+  @override
+  Set<Column> get primaryKey => {groupId, tagId};
 }
 
 /// One named shopping list (e.g. "Weekly groceries", "Diwali"). A user can

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -113,14 +113,13 @@ enum LockScreenStyle { classic, bigNumpad, scrambled }
 /// row instead, still grouped the same way.
 enum MoreScreenViewMode { list, cards }
 
-/// Which budgeting system the Dashboard and More hub surface as primary
-/// (GitHub #100). `budgets` shows the classic per-category spending-ceiling
-/// system (`BudgetsScreen`). `envelope` shows Ready to Assign / category
-/// envelopes instead. Both systems keep working and keep their own data
-/// either way — this only decides which one the Dashboard highlights and
-/// which one the More hub's "Budgets" tile opens; a user can still reach
-/// the other from wherever it's already linked from today (Account Detail's
-/// Envelope Mode toggle, or `/more/budgets` directly).
+/// Legacy — superseded by `Settings.rtaEnabled` (GitHub #100 v2). Budget
+/// (the per-category ceiling system) is now always on for everyone, and
+/// Ready to Assign is a single on/off layer on top of it rather than a
+/// mutually-exclusive alternative. This enum/column is kept only so the
+/// `from < 62` migration can read a pre-existing user's choice once, to
+/// decide whether to backfill `rtaEnabled = true` — nothing writes to it
+/// anymore.
 enum BudgetingMode { budgets, envelope }
 
 // ─── Converters ─────────────────────────────────────────────────────────────
@@ -194,11 +193,16 @@ class Accounts extends Table {
   IntColumn get sortOrder => integer().withDefault(const Constant(0))();
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
 
-  /// Turns this one account into "every rupee has a job" budgeting — an
-  /// expense on it must carry a category, and that category's balance is
-  /// funded from this account's own Ready to Assign via [Allocations]. Off
-  /// by default and per-account: every other account keeps working exactly
-  /// as it does today. See `AppDatabase.categoryBalance` / `readyToAssign`.
+  /// Whether this account is "on-budget" — inside the shared Ready to
+  /// Assign pool — rather than off-budget/tracking-only (a balance-only
+  /// account, outside the pool, like a vending-machine key fob). Only
+  /// meaningful while `Settings.rtaEnabled` is on: turning RTA on globally
+  /// sets this to true for every account at once, and turning it off for
+  /// the last pool account while RTA is on turns RTA off automatically
+  /// (see `AppDatabase.setRtaEnabled` / `_maybeAutoDisableRta`). An
+  /// on-budget account's expenses are funded from the pool via
+  /// [Allocations] — see `categoryBalanceProvider` / `readyToAssignProvider`
+  /// in `data/providers.dart`.
   BoolColumn get envelopeMode => boolean().withDefault(const Constant(false))();
 
   /// Whether this account's balance counts toward Net Worth (dashboard,
@@ -803,12 +807,22 @@ class Settings extends Table {
   TextColumn get moreScreenViewMode =>
       textEnum<MoreScreenViewMode>().withDefault(const Constant('list'))();
 
-  /// Which budgeting system is primary — see [BudgetingMode] (GitHub #100).
-  /// Defaults to `budgets` so existing users see no change; switching to
-  /// `envelope` doesn't touch either system's data, it only changes which
-  /// one the Dashboard and More hub's "Budgets" tile surface.
+  /// Legacy — see [BudgetingMode]. Superseded by [rtaEnabled]; kept only for
+  /// the `from < 62` migration's one-time backfill read. Nothing writes to
+  /// this column anymore.
   TextColumn get budgetingMode =>
       textEnum<BudgetingMode>().withDefault(const Constant('budgets'))();
+
+  /// Whether Ready to Assign — the shared envelope pool — is turned on
+  /// globally (GitHub #100 v2). Off by default. Budget (the per-category
+  /// spending ceiling) is always on regardless of this flag; this only
+  /// decides whether accounts also participate in the shared RTA pool via
+  /// [Accounts.envelopeMode]. Replaces [BudgetingMode] as a mutually
+  /// exclusive Budgets-vs-Envelope choice — enabling this auto-enrolls
+  /// every account into the pool (see `AppDatabase.setRtaEnabled`), and it
+  /// turns itself back off automatically the moment the pool would
+  /// otherwise go empty (see `AppDatabase._maybeAutoDisableRta`).
+  BoolColumn get rtaEnabled => boolean().withDefault(const Constant(false))();
 
   /// Minutes the app may sit backgrounded before the next resume re-locks it
   /// — `0` means immediately (see GitHub #60). Checked against how long the

--- a/lib/features/accounts/account_detail_screen.dart
+++ b/lib/features/accounts/account_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/widgets/error_view.dart';
@@ -14,6 +15,17 @@ import '../../data/providers.dart';
 import '../../data/tables.dart';
 import 'credit_card_statement_section.dart';
 import 'envelope_section.dart';
+
+/// [account]'s own currency — null for the parent currency, matching
+/// [AccountRow.currencyCode]'s own convention. A debit/UPI instrument
+/// carries no currency of its own, so this follows [AccountRow.linkedAccountId]
+/// once to the account that actually holds the money.
+Currency? _accountCurrency(AccountRow account, Map<int, AccountRow> accountMap) {
+  final code = account.linkedAccountId == null
+      ? account.currencyCode
+      : accountMap[account.linkedAccountId]?.currencyCode;
+  return code == null ? null : currencyForCode(code);
+}
 
 /// One account's balance, context and full history.
 ///
@@ -97,7 +109,11 @@ class _AccountDetailView extends ConsumerWidget {
       body: CustomScrollView(
         slivers: [
           SliverToBoxAdapter(
-            child: _HeaderCard(account: account, linkedBank: linkedBank),
+            child: _HeaderCard(
+              account: account,
+              linkedBank: linkedBank,
+              currency: _accountCurrency(account, accountMap),
+            ),
           ),
           // A linked instrument (debit card / UPI) holds no balance of its
           // own — there is no money on it to give a job to.
@@ -114,6 +130,7 @@ class _AccountDetailView extends ConsumerWidget {
             accountMap: accountMap,
             categoryMap: categoryMap,
             ownIds: ownIds,
+            currency: _accountCurrency(account, accountMap),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 32)),
         ],
@@ -127,6 +144,7 @@ class _AccountDetailView extends ConsumerWidget {
     required Map<int, AccountRow> accountMap,
     required Map<int, CategoryRow> categoryMap,
     required Set<int> ownIds,
+    required Currency? currency,
   }) {
     final theme = Theme.of(context);
 
@@ -182,7 +200,7 @@ class _AccountDetailView extends ConsumerWidget {
           for (final tx in rows) {
             net += accountMovement(tx, ownIds);
           }
-          children.add(_DayHeader(day: day, net: net));
+          children.add(_DayHeader(day: day, net: net, currency: currency));
           for (final tx in rows) {
             children.add(
               _HistoryRow(
@@ -190,6 +208,7 @@ class _AccountDetailView extends ConsumerWidget {
                 accountMap: accountMap,
                 categoryMap: categoryMap,
                 ownIds: ownIds,
+                currency: currency,
               ),
             );
           }
@@ -205,10 +224,15 @@ class _AccountDetailView extends ConsumerWidget {
 
 /// Balance + a one-line story about this account, plus type / bank chips.
 class _HeaderCard extends ConsumerWidget {
-  const _HeaderCard({required this.account, required this.linkedBank});
+  const _HeaderCard({
+    required this.account,
+    required this.linkedBank,
+    required this.currency,
+  });
 
   final AccountRow account;
   final AccountRow? linkedBank;
+  final Currency? currency;
 
   bool get _isDebitCard => account.linkedAccountId != null;
   bool get _isCreditCard =>
@@ -242,8 +266,10 @@ class _HeaderCard extends ConsumerWidget {
         contextColor = AppColors.income;
       }
     } else {
-      contextLine =
-          'Opening balance ${MoneyFormat.symbol(account.openingBalance)}';
+      final openingBalanceText = currency == null
+          ? MoneyFormat.symbol(account.openingBalance)
+          : MoneyFormat.symbolIn(account.openingBalance, currency!);
+      contextLine = 'Opening balance $openingBalanceText';
       contextColor = cs.onSurfaceVariant;
     }
 
@@ -279,6 +305,7 @@ class _HeaderCard extends ConsumerWidget {
                 alignment: Alignment.centerLeft,
                 child: BalanceText(
                   shownBalance,
+                  currency: currency,
                   style: theme.textTheme.headlineMedium?.copyWith(
                     fontWeight: FontWeight.w700,
                   ),
@@ -337,10 +364,11 @@ class _InfoChip extends StatelessWidget {
 // ── History ─────────────────────────────────────────────────────────────────
 
 class _DayHeader extends StatelessWidget {
-  const _DayHeader({required this.day, required this.net});
+  const _DayHeader({required this.day, required this.net, required this.currency});
 
   final DateTime day;
   final Money net;
+  final Currency? currency;
 
   @override
   Widget build(BuildContext context) {
@@ -368,6 +396,7 @@ class _DayHeader extends StatelessWidget {
             net,
             signed: true,
             color: netColor,
+            currency: currency,
             style: theme.textTheme.titleSmall?.copyWith(
               fontWeight: FontWeight.w600,
             ),
@@ -385,12 +414,14 @@ class _HistoryRow extends StatelessWidget {
     required this.accountMap,
     required this.categoryMap,
     required this.ownIds,
+    required this.currency,
   });
 
   final TransactionRow tx;
   final Map<int, AccountRow> accountMap;
   final Map<int, CategoryRow> categoryMap;
   final Set<int> ownIds;
+  final Currency? currency;
 
   @override
   Widget build(BuildContext context) {
@@ -428,6 +459,7 @@ class _HistoryRow extends StatelessWidget {
         movement,
         signed: true,
         color: colorForTxType(tx.type),
+        currency: currency,
         style: theme.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w700,
         ),

--- a/lib/features/accounts/accounts_screen.dart
+++ b/lib/features/accounts/accounts_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/widgets/money_text.dart';
 import '../../core/widgets/statement_range_picker.dart';
@@ -284,6 +285,11 @@ class _AccountTile extends ConsumerWidget {
   bool get _isPayLater => account.type == AccountType.payLater;
   bool get _owesLikeCredit => _isCreditCard || _isPayLater;
 
+  /// Null = parent currency, matching every existing account before this
+  /// feature — [BalanceText] then renders exactly as it always has.
+  Currency? get _currency =>
+      account.currencyCode == null ? null : currencyForCode(account.currencyCode!);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
@@ -302,6 +308,7 @@ class _AccountTile extends ConsumerWidget {
       );
       trailing = BalanceText(
         account.currentBalance,
+        currency: _currency,
         style: theme.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w600,
         ),
@@ -317,6 +324,7 @@ class _AccountTile extends ConsumerWidget {
       subtitle = parts.isEmpty ? null : _subtitle(theme, parts.join('   '));
       trailing = BalanceText(
         account.currentBalance,
+        currency: _currency,
         style: theme.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w600,
         ),

--- a/lib/features/accounts/accounts_screen.dart
+++ b/lib/features/accounts/accounts_screen.dart
@@ -518,8 +518,9 @@ class _AccountTile extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(account.id);
+      rtaAutoDisabled = await ref.read(dbProvider).deleteAccount(account.id);
     } on ArgumentError catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context)
@@ -534,7 +535,16 @@ class _AccountTile extends ConsumerWidget {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Account removed')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Account removed. Ready to Assign turned off — no '
+                      'accounts left in the pool.'
+                : 'Account removed',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/accounts/add_account_sheet.dart
+++ b/lib/features/accounts/add_account_sheet.dart
@@ -3,11 +3,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/widgets/icon_picker_sheet.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
+import '../settings/currency_picker_sheet.dart';
 
 /// Preset colours for an account. Plain ints — colour here is decorative,
 /// not a money-direction signal.
@@ -57,6 +59,11 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
   int _colorValue = _presetColors.first;
   String _iconKey = 'cash';
   bool _submitting = false;
+
+  /// Null = parent currency (the default for every account). Never offered
+  /// for a debit card / UPI instrument, which always mirrors the account it
+  /// draws from.
+  String? _currencyCode;
 
   @override
   void dispose() {
@@ -142,6 +149,7 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
             colorValue: _colorValue,
             iconKey: _iconKey,
             openingBalance: openingBalance,
+            currencyCode: _isDebitCard ? null : _currencyCode,
           );
       if (!mounted) return;
       Navigator.of(context).pop();
@@ -241,6 +249,11 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
             const SizedBox(height: 20),
 
             ..._typeSpecificFields(theme, banks),
+
+            if (!_isDebitCard) ...[
+              _currencyField(theme),
+              const SizedBox(height: 20),
+            ],
 
             _fieldLabel(theme, 'Colour'),
             const SizedBox(height: 12),
@@ -410,6 +423,58 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
         labelText: label,
         prefixText: MoneyFormat.inputPrefix,
         hintText: '0.00',
+      ),
+    );
+  }
+
+  /// Only ever offered for an account that will hold its own balance — see
+  /// the `if (!_isDebitCard)` guard around this field's only call site. Null
+  /// [_currencyCode] (the default) means the parent currency
+  /// (`Settings.currencyCode`); an unset field submits `null` to
+  /// `AppDatabase.addAccount`, identical to every account created before
+  /// this feature existed.
+  Widget _currencyField(ThemeData theme) {
+    final selected = _currencyCode == null
+        ? null
+        : currencyForCode(_currencyCode!);
+    return GestureDetector(
+      onTap: () async {
+        final picked = await CurrencyPickerSheet.pick(
+          context,
+          initialCode: _currencyCode,
+        );
+        if (picked != null) setState(() => _currencyCode = picked.code);
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+        decoration: BoxDecoration(
+          border: Border.all(color: theme.colorScheme.outline),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Row(
+          children: [
+            const Text('Currency'),
+            const Spacer(),
+            Flexible(
+              child: Text(
+                selected == null
+                    ? '${ref.watch(currencyProvider).symbol} '
+                          '${ref.watch(currencyProvider).code}'
+                    : '${selected.symbol} ${selected.code}',
+                textAlign: TextAlign.right,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(
+              Icons.chevron_right_rounded,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/accounts/add_account_sheet.dart
+++ b/lib/features/accounts/add_account_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/app_icons.dart';
 import '../../core/money.dart';
+import '../../core/widgets/icon_picker_sheet.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
@@ -19,16 +20,6 @@ const _presetColors = <int>[
   0xFF0EA5E9,
   0xFF78716C,
   0xFFEC4899,
-];
-
-const _iconKeys = <String>[
-  'cash',
-  'bank',
-  'card',
-  'wallet',
-  'savings',
-  'pay_later',
-  'prepaid_balance',
 ];
 
 /// Opens the "add account" bottom sheet.
@@ -262,11 +253,7 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
 
             _fieldLabel(theme, 'Icon'),
             const SizedBox(height: 12),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [for (final k in _iconKeys) _iconTile(theme, k)],
-            ),
+            _iconField(theme),
             const SizedBox(height: 28),
 
             FilledButton(
@@ -504,30 +491,51 @@ class _AddAccountSheetState extends ConsumerState<AddAccountSheet> {
     );
   }
 
-  Widget _iconTile(ThemeData theme, String key) {
-    final selected = _iconKey == key;
+  /// A single tile showing the chosen icon; tapping it opens the searchable
+  /// icon sheet instead of a fixed row limited to the account types above.
+  Widget _iconField(ThemeData theme) {
+    final color = Color(_colorValue);
     return GestureDetector(
-      onTap: () => setState(() => _iconKey = key),
+      onTap: () async {
+        final picked = await showIconPickerSheet(
+          context,
+          selected: _iconKey,
+          accentColor: color,
+        );
+        if (picked != null) setState(() => _iconKey = picked);
+      },
       child: Container(
-        width: 52,
-        height: 52,
-        alignment: Alignment.center,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         decoration: BoxDecoration(
-          color: selected
-              ? theme.colorScheme.onSurface
-              : theme.colorScheme.surface,
+          border: Border.all(color: theme.colorScheme.outline),
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: selected
-                ? theme.colorScheme.onSurface
-                : theme.colorScheme.outline,
-          ),
         ),
-        child: Icon(
-          AppIcons.resolve(key),
-          color: selected
-              ? theme.colorScheme.surface
-              : theme.colorScheme.onSurfaceVariant,
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(AppIcons.resolve(_iconKey), color: color),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Text(
+                'Tap to change',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/accounts/envelope_outflow.dart
+++ b/lib/features/accounts/envelope_outflow.dart
@@ -14,11 +14,12 @@ import '../../data/tables.dart';
 /// the way it does for an expense. Left unresolved, an envelope would keep
 /// claiming money that has actually already left the account.
 ///
-/// The part of [amount] that [accountId]'s current Ready to Assign already
-/// covers needs nothing: Ready to Assign drops by exactly that much on its
-/// own, since `current_balance` does. Only the **shortfall** — the part that
-/// would otherwise have to come out of an already-claimed category — needs
-/// the user to say which one.
+/// The part of [amount] that the shared Ready to Assign pool (GitHub #48 —
+/// one pool across every Envelope-Mode account, not one per account)
+/// already covers needs nothing: Ready to Assign drops by exactly that much
+/// on its own, since `current_balance` does. Only the **shortfall** — the
+/// part that would otherwise have to come out of an already-claimed
+/// category — needs the user to say which one.
 Money envelopeOutflowShortfall(
   WidgetRef ref, {
   required int accountId,
@@ -27,7 +28,7 @@ Money envelopeOutflowShortfall(
   final account = ref.read(accountMapProvider)[accountId];
   if (account == null || !account.envelopeMode) return const Money.zero();
 
-  final rta = ref.read(readyToAssignProvider(accountId));
+  final rta = ref.read(readyToAssignProvider);
   final available = rta.isPositive ? rta : const Money.zero();
   final shortfall = amount - available;
   return shortfall.isPositive ? shortfall : const Money.zero();
@@ -46,18 +47,13 @@ Future<int?> pickEnvelopeShortfallCategory({
     context: context,
     isScrollControlled: true,
     showDragHandle: true,
-    builder: (_) =>
-        _EnvelopeSourceSheet(accountId: accountId, shortfall: shortfall),
+    builder: (_) => _EnvelopeSourceSheet(shortfall: shortfall),
   );
 }
 
 class _EnvelopeSourceSheet extends ConsumerWidget {
-  const _EnvelopeSourceSheet({
-    required this.accountId,
-    required this.shortfall,
-  });
+  const _EnvelopeSourceSheet({required this.shortfall});
 
-  final int accountId;
   final Money shortfall;
 
   @override
@@ -109,12 +105,7 @@ class _EnvelopeSourceSheet extends ConsumerWidget {
                   itemCount: categories.length,
                   itemBuilder: (context, i) {
                     final c = categories[i];
-                    final balance = ref.watch(
-                      categoryBalanceProvider((
-                        accountId: accountId,
-                        categoryId: c.id,
-                      )),
-                    );
+                    final balance = ref.watch(categoryBalanceProvider(c.id));
                     return ListTile(
                       title: Text(c.name),
                       trailing: MoneyText(

--- a/lib/features/accounts/envelope_section.dart
+++ b/lib/features/accounts/envelope_section.dart
@@ -1,19 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-import '../../core/app_icons.dart';
-import '../../core/money.dart';
-import '../../core/theme/app_colors.dart';
-import '../../core/widgets/money_text.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
-import '../../data/tables.dart';
 
-/// The Envelope Mode toggle plus — once it's on — Ready to Assign and every
-/// expense category's balance for [account]. Lives on the account's own
-/// detail page rather than the (never account-scoped) Budgets screen, since
-/// Ready to Assign and a category's envelope balance are both inherently
-/// per-account.
+/// The Envelope Mode toggle for [account]. The shared Ready to Assign figure
+/// and category envelope list this account feeds once it's on live on
+/// [lib/features/budgets/ready_to_assign_screen.dart] instead — GitHub #48:
+/// every Envelope-Mode account pools into one figure and one balance per
+/// category, so there's nothing account-scoped left to show here.
 class EnvelopeSection extends ConsumerWidget {
   const EnvelopeSection({required this.account, super.key});
 
@@ -23,6 +19,7 @@ class EnvelopeSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
+    final poolSize = ref.watch(envelopeModeAccountsProvider).length;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -44,11 +41,25 @@ class EnvelopeSection extends ConsumerWidget {
             onChanged: (v) => _onToggle(context, ref, v),
           ),
         ),
-        if (account.envelopeMode) ...[
-          _ReadyToAssignCard(accountId: account.id),
-          const SizedBox(height: 8),
-          _CategoryEnvelopeList(account: account),
-        ],
+        if (account.envelopeMode)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
+            child: Card(
+              child: ListTile(
+                leading: const Icon(Icons.account_balance_wallet_outlined),
+                title: Text(
+                  poolSize > 1
+                      ? 'Shares one Ready to Assign pool with '
+                            '${poolSize - 1} other account'
+                            '${poolSize - 1 == 1 ? '' : 's'}'
+                      : 'Its own Ready to Assign pool for now',
+                ),
+                subtitle: const Text('View shared budget'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.push('/more/ready-to-assign'),
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -83,290 +94,5 @@ class EnvelopeSection extends ConsumerWidget {
       if (confirmed != true) return;
     }
     await ref.read(dbProvider).setEnvelopeMode(account.id, enabled);
-  }
-}
-
-class _ReadyToAssignCard extends ConsumerWidget {
-  const _ReadyToAssignCard({required this.accountId});
-
-  final int accountId;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final rta = ref.watch(readyToAssignProvider(accountId));
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 4, 20, 4),
-      child: Card(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Ready to Assign',
-                      style: theme.textTheme.labelLarge?.copyWith(
-                        color: cs.onSurfaceVariant,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    MoneyText(
-                      rta,
-                      style: theme.textTheme.headlineSmall?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: rta.isNegative ? AppColors.expense : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              if (rta.isNegative)
-                Icon(Icons.warning_amber_rounded, color: AppColors.expense),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _CategoryEnvelopeList extends ConsumerWidget {
-  const _CategoryEnvelopeList({required this.account});
-
-  final AccountRow account;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final categoriesAsync = ref.watch(categoriesProvider(CategoryKind.expense));
-
-    return categoriesAsync.when(
-      loading: () => const Padding(
-        padding: EdgeInsets.all(24),
-        child: Center(child: CircularProgressIndicator()),
-      ),
-      error: (_, _) => const SizedBox.shrink(),
-      data: (categories) => Padding(
-        padding: const EdgeInsets.fromLTRB(20, 8, 20, 4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8, left: 4),
-              child: Text(
-                'Categories',
-                style: theme.textTheme.titleSmall?.copyWith(
-                  color: cs.onSurfaceVariant,
-                ),
-              ),
-            ),
-            Card(
-              child: Column(
-                children: [
-                  for (var i = 0; i < categories.length; i++) ...[
-                    if (i > 0)
-                      Divider(height: 1, indent: 70, color: cs.outline),
-                    _CategoryEnvelopeRow(
-                      account: account,
-                      category: categories[i],
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _CategoryEnvelopeRow extends ConsumerWidget {
-  const _CategoryEnvelopeRow({required this.account, required this.category});
-
-  final AccountRow account;
-  final CategoryRow category;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final catColor = Color(category.colorValue);
-    final balance = ref.watch(
-      categoryBalanceProvider((accountId: account.id, categoryId: category.id)),
-    );
-    final overspent = balance.isNegative;
-
-    return ListTile(
-      leading: Container(
-        width: 40,
-        height: 40,
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: catColor.withValues(alpha: 0.15),
-          shape: BoxShape.circle,
-        ),
-        child: Icon(AppIcons.resolve(category.iconKey), color: catColor, size: 18),
-      ),
-      title: Text(category.name),
-      trailing: MoneyText(
-        balance,
-        style: theme.textTheme.titleMedium?.copyWith(
-          fontWeight: FontWeight.w600,
-          color: overspent ? AppColors.expense : null,
-        ),
-      ),
-      onTap: () => showModalBottomSheet<void>(
-        context: context,
-        isScrollControlled: true,
-        builder: (_) => _AssignSheet(
-          accountId: account.id,
-          category: category,
-          currentBalance: balance,
-        ),
-      ),
-    );
-  }
-}
-
-/// Move money between this category's envelope and Ready to Assign — a
-/// positive amount assigns in, a negative one unassigns back out. Both are
-/// the same [AppDatabase.addAllocation] call; only the sign differs.
-class _AssignSheet extends ConsumerStatefulWidget {
-  const _AssignSheet({
-    required this.accountId,
-    required this.category,
-    required this.currentBalance,
-  });
-
-  final int accountId;
-  final CategoryRow category;
-  final Money currentBalance;
-
-  @override
-  ConsumerState<_AssignSheet> createState() => _AssignSheetState();
-}
-
-class _AssignSheetState extends ConsumerState<_AssignSheet> {
-  final _amountCtrl = TextEditingController();
-  bool _unassign = false;
-
-  @override
-  void dispose() {
-    _amountCtrl.dispose();
-    super.dispose();
-  }
-
-  Future<void> _save() async {
-    final typed = Money.tryParse(_amountCtrl.text);
-    if (typed == null || !typed.isPositive) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Enter an amount greater than zero')),
-      );
-      return;
-    }
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      await ref.read(dbProvider).addAllocation(
-        accountId: widget.accountId,
-        categoryId: widget.category.id,
-        amount: _unassign ? -typed : typed,
-      );
-    } on ArgumentError catch (e) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(e.message?.toString() ?? 'Could not save')),
-      );
-      return;
-    }
-    if (mounted) Navigator.of(context).pop();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final rta = ref.watch(readyToAssignProvider(widget.accountId));
-
-    return Padding(
-      padding: EdgeInsets.only(
-        left: 20,
-        right: 20,
-        top: 8,
-        bottom:
-            MediaQuery.of(context).padding.bottom +
-            MediaQuery.of(context).viewInsets.bottom +
-            20,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Center(
-            child: Container(
-              width: 40,
-              height: 4,
-              margin: const EdgeInsets.only(bottom: 20),
-              decoration: BoxDecoration(
-                color: cs.outlineVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
-          Text(
-            widget.category.name,
-            style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            'Currently ${MoneyFormat.symbol(widget.currentBalance)} · '
-            'Ready to Assign: ${MoneyFormat.symbol(rta)}',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: cs.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 20),
-          SegmentedButton<bool>(
-            segments: const [
-              ButtonSegment(value: false, label: Text('Assign')),
-              ButtonSegment(value: true, label: Text('Unassign')),
-            ],
-            selected: {_unassign},
-            onSelectionChanged: (s) => setState(() => _unassign = s.first),
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _amountCtrl,
-            autofocus: true,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w700,
-              fontFeatures: kTabularFigures,
-            ),
-            decoration: InputDecoration(
-              labelText: _unassign
-                  ? 'Move back to Ready to Assign'
-                  : 'Assign from Ready to Assign',
-              prefixText: MoneyFormat.inputPrefix,
-            ),
-            onSubmitted: (_) => _save(),
-          ),
-          const SizedBox(height: 16),
-          FilledButton(
-            onPressed: _save,
-            child: const Padding(
-              padding: EdgeInsets.symmetric(vertical: 4),
-              child: Text('Save'),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/features/accounts/envelope_section.dart
+++ b/lib/features/accounts/envelope_section.dart
@@ -5,11 +5,13 @@ import 'package:go_router/go_router.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 
-/// The Envelope Mode toggle for [account]. The shared Ready to Assign figure
-/// and category envelope list this account feeds once it's on live on
+/// The on-budget (pool participation) toggle for [account] — only shown
+/// while Ready to Assign is on globally (GitHub #100 v2); there's nothing to
+/// configure here until then. The shared Ready to Assign figure and category
+/// envelope list this account feeds once it's on-budget live on
 /// [lib/features/budgets/ready_to_assign_screen.dart] instead — GitHub #48:
-/// every Envelope-Mode account pools into one figure and one balance per
-/// category, so there's nothing account-scoped left to show here.
+/// every pool account pools into one figure and one balance per category, so
+/// there's nothing account-scoped left to show here.
 class EnvelopeSection extends ConsumerWidget {
   const EnvelopeSection({required this.account, super.key});
 
@@ -17,6 +19,7 @@ class EnvelopeSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (!ref.watch(rtaEnabledProvider)) return const SizedBox.shrink();
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final poolSize = ref.watch(envelopeModeAccountsProvider).length;
@@ -27,12 +30,13 @@ class EnvelopeSection extends ConsumerWidget {
         Card(
           margin: const EdgeInsets.fromLTRB(20, 8, 20, 4),
           child: SwitchListTile(
-            title: const Text('Envelope Mode'),
+            title: const Text('On-budget'),
             subtitle: Text(
               account.envelopeMode
-                  ? 'Every rupee here has a job. An expense needs a category.'
-                  : 'Optional — "every rupee has a job" budgeting for just '
-                        'this account.',
+                  ? 'In the shared Ready to Assign pool. An expense needs a '
+                        'category.'
+                  : 'Off-budget — balance-only, like a vending-machine key '
+                        'fob. Outside the shared pool.',
               style: theme.textTheme.bodySmall?.copyWith(
                 color: cs.onSurfaceVariant,
               ),
@@ -73,7 +77,7 @@ class EnvelopeSection extends ConsumerWidget {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (dialogContext) => AlertDialog(
-          title: const Text('Turn on Envelope Mode?'),
+          title: const Text('Mark this account on-budget?'),
           content: const Text(
             'Money you assign to a category becomes reserved for it. '
             'Unassigned money sits in Ready to Assign. From now on, an '
@@ -93,6 +97,18 @@ class EnvelopeSection extends ConsumerWidget {
       );
       if (confirmed != true) return;
     }
-    await ref.read(dbProvider).setEnvelopeMode(account.id, enabled);
+    final rtaAutoDisabled = await ref
+        .read(dbProvider)
+        .setEnvelopeMode(account.id, enabled);
+    if (rtaAutoDisabled && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Ready to Assign turned off — this was the last account in the '
+            'pool.',
+          ),
+        ),
+      );
+    }
   }
 }

--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -78,14 +78,30 @@ class _PaymentLegEntry {
 ///
 /// With a [transactionId] the screen edits that existing transaction instead
 /// of creating a new one.
+///
+/// With a [duplicateFromId] instead, every field is prefilled from that
+/// transaction — same as editing — but [transactionId] stays null, so Save
+/// creates a brand-new row rather than touching the source (GitHub #92:
+/// "publish another one" of an existing transaction). The date resets to
+/// today rather than copying the source's, nudging the user to notice this
+/// is a separate entry and pick the date it actually happened on; the
+/// receipt photo is never copied, since it's evidence of the original
+/// purchase, not this new one.
 class AddTransactionScreen extends ConsumerStatefulWidget {
-  const AddTransactionScreen({this.transactionId, this.initialType, super.key});
+  const AddTransactionScreen({
+    this.transactionId,
+    this.duplicateFromId,
+    this.initialType,
+    super.key,
+  });
 
   final int? transactionId;
+  final int? duplicateFromId;
 
   /// Preselects Expense or Income — used by the home-screen widget's "+
   /// Expense" / "+ Income" shortcuts to skip the type-picker step. Ignored
-  /// when [transactionId] is set, since editing loads its own type.
+  /// when [transactionId] or [duplicateFromId] is set, since both load their
+  /// own type.
   final TxType? initialType;
 
   @override
@@ -211,6 +227,9 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     if (_isEditing) {
       _loading = true;
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadForEdit());
+    } else if (widget.duplicateFromId != null) {
+      _loading = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) => _loadForDuplicate());
     }
   }
 
@@ -289,6 +308,70 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
       _payeeController.text = row.payee ?? '';
       _tagIds = tagIds.toSet();
       _imagePath = row.imagePath;
+      _isSplit = splits.isNotEmpty;
+      for (final s in splits) {
+        _splitRows.add(
+          _SplitEntry(
+            categoryId: s.categoryId,
+            amountText: _bufferFromMoney(s.amount),
+            onFocusChange: _onFieldFocusChanged,
+          ),
+        );
+      }
+      _loading = false;
+    });
+  }
+
+  /// Fetch the transaction being duplicated and prefill every field from it,
+  /// same as [_loadForEdit] — except [_date] resets to today instead of
+  /// copying the source's, and the receipt (if any) is never carried over.
+  /// [widget.transactionId] stays null throughout, so `_save` inserts a new
+  /// row instead of updating the source.
+  Future<void> _loadForDuplicate() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
+    final db = ref.read(dbProvider);
+    final sourceId = widget.duplicateFromId!;
+    final row = await db.transactionById(sourceId);
+    final tagIds = await db.tagIdsForTransaction(sourceId);
+    final splits = await db.splitsForTransaction(sourceId);
+    if (!mounted) return;
+
+    if (row == null) {
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Transaction not found')),
+      );
+      return;
+    }
+
+    // Same restriction as `_loadForEdit`: this screen has no shape for a
+    // person movement (or a repayment counted as income), so there is
+    // nothing sensible to prefill it into.
+    final isPersonLinked =
+        row.type.isPersonMovement ||
+        (row.type.isIncomeOrExpense &&
+            await db.isPersonLinkedTransaction(row.id));
+    if (!mounted) return;
+    if (isPersonLinked) {
+      navigator.pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text("This can't be duplicated from here.")),
+      );
+      return;
+    }
+
+    setState(() {
+      _type = row.type;
+      _buffer = _bufferFromMoney(row.amount);
+      _freshAmountEntry = true;
+      _accountId = row.accountId;
+      _toAccountId = row.toAccountId;
+      _categoryId = row.categoryId;
+      _noteController.text = row.note ?? '';
+      _payeeController.text = row.payee ?? '';
+      _tagIds = tagIds.toSet();
       _isSplit = splits.isNotEmpty;
       for (final s in splits) {
         _splitRows.add(

--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/widgets/money_text.dart';
@@ -13,6 +14,7 @@ import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
 import '../accounts/envelope_outflow.dart';
+import '../settings/currency_picker_sheet.dart';
 import '../tags/tag_picker_sheet.dart';
 import 'amount_buffer.dart';
 import 'receipt_storage.dart';
@@ -163,6 +165,17 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
   final _changeAmountController = TextEditingController();
   final _changeAmountFocus = FocusNode();
 
+  /// Income/expense only — "this was originally paid in another currency"
+  /// (GitHub #85), purely informational: [_amount] stays what actually moved
+  /// through the account. Unlike hybrid payment/change, this can be edited
+  /// after the fact, so it isn't gated on `!_isEditing`. Mutually exclusive
+  /// with hybrid payment and change (same toggle group); coexists with
+  /// split, since a split doesn't touch the transaction's own amount/currency.
+  bool _hasForeignCurrency = false;
+  String? _foreignCurrencyCode;
+  final _foreignAmountController = TextEditingController();
+  final _foreignAmountFocus = FocusNode();
+
   /// The receipt path that will be saved — an existing one loaded for
   /// editing, a freshly picked one, or null.
   String? _imagePath;
@@ -201,6 +214,16 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
   Money get _changeAmount =>
       Money.tryParse(_changeAmountController.text) ?? const Money.zero();
 
+  /// Foreign currency only ever applies to an income or expense — a transfer
+  /// moves money between the user's own accounts, with nothing "paid" in
+  /// another currency.
+  bool get _isForeignCurrency =>
+      (_type == TxType.income || _type == TxType.expense) &&
+      _hasForeignCurrency;
+
+  Money get _foreignAmount =>
+      Money.tryParse(_foreignAmountController.text) ?? const Money.zero();
+
   /// The on-screen keypad and the system keyboard must never both be up —
   /// they'd fight over the same strip of screen and hide whatever the user
   /// just typed. The keypad only shows while no text field has focus,
@@ -210,7 +233,8 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
       _payeeFocus.hasFocus ||
       _splitRows.any((r) => r.focusNode.hasFocus) ||
       _hybridLegs.any((r) => r.focusNode.hasFocus) ||
-      _changeAmountFocus.hasFocus;
+      _changeAmountFocus.hasFocus ||
+      _foreignAmountFocus.hasFocus;
 
   @override
   void initState() {
@@ -253,6 +277,8 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     }
     _changeAmountController.dispose();
     _changeAmountFocus.dispose();
+    _foreignAmountController.dispose();
+    _foreignAmountFocus.dispose();
     // Best-effort: leaving without saving shouldn't leak the copy made on
     // pick. Fire-and-forget — nothing in this widget survives to await it.
     if (_unsavedPickedPath != null) _deleteQuietly(_unsavedPickedPath!);
@@ -318,6 +344,11 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           ),
         );
       }
+      _hasForeignCurrency = row.foreignAmount != null;
+      _foreignCurrencyCode = row.foreignCurrencyCode;
+      if (row.foreignAmount != null) {
+        _foreignAmountController.text = _bufferFromMoney(row.foreignAmount!);
+      }
       _loading = false;
     });
   }
@@ -381,6 +412,11 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
             onFocusChange: _onFieldFocusChanged,
           ),
         );
+      }
+      _hasForeignCurrency = row.foreignAmount != null;
+      _foreignCurrencyCode = row.foreignCurrencyCode;
+      if (row.foreignAmount != null) {
+        _foreignAmountController.text = _bufferFromMoney(row.foreignAmount!);
       }
       _loading = false;
     });
@@ -676,6 +712,7 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           if (v) {
             _isSplit = false;
             _hasChange = false;
+            _hasForeignCurrency = false;
           }
           while (v && _hybridLegs.length < 2) {
             _hybridLegs.add(
@@ -852,6 +889,7 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           if (v) {
             _isSplit = false;
             _isHybridPayment = false;
+            _hasForeignCurrency = false;
           }
         }),
         secondary: Icon(
@@ -862,6 +900,124 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
         subtitle: _hasChange
             ? null
             : const Text('Part of the change lands in another account'),
+      ),
+    );
+  }
+
+  // ── Foreign currency ─────────────────────────────────────────────────────
+
+  Future<void> _pickForeignCurrency() async {
+    final picked = await CurrencyPickerSheet.pick(
+      context,
+      initialCode: _foreignCurrencyCode ?? MoneyFormat.currency.code,
+    );
+    if (picked == null || !mounted) return;
+    setState(() => _foreignCurrencyCode = picked.code);
+  }
+
+  Widget _foreignToggleTile() {
+    final theme = Theme.of(context);
+    return Card(
+      margin: EdgeInsets.zero,
+      clipBehavior: Clip.antiAlias,
+      child: SwitchListTile(
+        value: _hasForeignCurrency,
+        onChanged: (v) => setState(() {
+          _hasForeignCurrency = v;
+          if (v) {
+            _isHybridPayment = false;
+            _hasChange = false;
+          }
+        }),
+        secondary: Icon(
+          Icons.public_rounded,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+        title: const Text('Foreign currency'),
+        subtitle: _hasForeignCurrency
+            ? null
+            : const Text('Record what this cost in another currency'),
+      ),
+    );
+  }
+
+  Widget _foreignCurrencyEditorCard() {
+    final theme = Theme.of(context);
+    final currency = currencyForCode(_foreignCurrencyCode);
+    final foreignAmount = _foreignAmount;
+    final rateLine = foreignAmount.isPositive
+        ? '1 ${currency.code} ≈ '
+              '${MoneyFormat.symbol(Money.fromRupees(_amount.rupees / foreignAmount.rupees))}'
+        : null;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                InkWell(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: _pickForeignCurrency,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 10,
+                    ),
+                    decoration: BoxDecoration(
+                      border: Border.all(color: theme.colorScheme.outline),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          currency.symbol,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                        Text(currency.code, style: theme.textTheme.bodyMedium),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: TextField(
+                    controller: _foreignAmountController,
+                    focusNode: _foreignAmountFocus,
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                    ),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                    ],
+                    decoration: const InputDecoration(
+                      isDense: true,
+                      hintText: '0.00',
+                    ),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                ),
+              ],
+            ),
+            if (rateLine != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                rateLine,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }
@@ -1287,6 +1443,15 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
       );
       return;
     }
+    if (_isForeignCurrency &&
+        (_foreignCurrencyCode == null || !_foreignAmount.isPositive)) {
+      messenger.showSnackBar(
+        const SnackBar(
+          content: Text('Choose a currency and enter its amount'),
+        ),
+      );
+      return;
+    }
 
     final note = _noteController.text.trim();
     final payeeText = _payeeController.text.trim();
@@ -1300,6 +1465,8 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     final categoryId = (_type == TxType.transfer || _isSplitting)
         ? null
         : _categoryId;
+    final foreignCurrencyCode = _isForeignCurrency ? _foreignCurrencyCode : null;
+    final foreignAmount = _isForeignCurrency ? _foreignAmount : null;
     try {
       final db = ref.read(dbProvider);
       int id;
@@ -1316,6 +1483,8 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           note: note.isEmpty ? null : note,
           payee: payee,
           imagePath: _imagePath,
+          foreignCurrencyCode: foreignCurrencyCode,
+          foreignAmount: foreignAmount,
         );
       } else {
         id = await db.addTransaction(
@@ -1328,6 +1497,8 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           note: note.isEmpty ? null : note,
           payee: payee,
           imagePath: _imagePath,
+          foreignCurrencyCode: foreignCurrencyCode,
+          foreignAmount: foreignAmount,
         );
       }
       // The receipt (if any) is now referenced by a saved row — no longer an
@@ -1576,6 +1747,11 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
         );
         tiles.add(const SizedBox(height: 12));
       }
+      // Foreign currency applies to both income and expense (unlike
+      // split/hybrid/change, which are expense-only) and stays available
+      // while editing.
+      tiles.add(_foreignToggleTile());
+      tiles.add(const SizedBox(height: 12));
       if (_type == TxType.expense) {
         tiles.add(_splitToggleTile());
         tiles.add(const SizedBox(height: 12));
@@ -1601,6 +1777,10 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
       }
       if (_isChange) {
         tiles.add(_changeEditorCard(accountMap));
+        tiles.add(const SizedBox(height: 12));
+      }
+      if (_isForeignCurrency) {
+        tiles.add(_foreignCurrencyEditorCard());
         tiles.add(const SizedBox(height: 12));
       }
       if (_isSplitting) {

--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -2209,12 +2209,7 @@ class _CategoryPickerSheetState extends ConsumerState<_CategoryPickerSheet> {
           if (envelopeAccountId != null)
             Consumer(
               builder: (context, ref, _) {
-                final balance = ref.watch(
-                  categoryBalanceProvider((
-                    accountId: envelopeAccountId,
-                    categoryId: categoryId,
-                  )),
-                );
+                final balance = ref.watch(categoryBalanceProvider(categoryId));
                 return Text(
                   '${MoneyFormat.symbol(balance)} left',
                   textAlign: TextAlign.center,

--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -10,6 +10,7 @@ import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/widgets/money_text.dart';
+import '../../data/currency_conversion.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
@@ -503,6 +504,76 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     );
     if (selected == null || !mounted) return;
     setState(() => _categoryId = selected);
+  }
+
+  /// The currency [accountId] actually posts in — null for the parent
+  /// currency, same "null means parent" convention as
+  /// [AccountRow.currencyCode] itself. A debit/UPI instrument has no
+  /// currency of its own (see `tables.dart`'s doc on `Accounts.currencyCode`)
+  /// so this follows [AccountRow.linkedAccountId] once to the account that
+  /// actually holds the money.
+  Currency? _currencyForAccount(int? accountId, Map<int, AccountRow> accountMap) {
+    final account = accountMap[accountId];
+    if (account == null) return null;
+    final code = account.linkedAccountId == null
+        ? account.currencyCode
+        : accountMap[account.linkedAccountId]?.currencyCode;
+    return code == null ? null : currencyForCode(code);
+  }
+
+  /// An informational "≈ X received" line for a transfer between two
+  /// accounts that don't share a currency — read-only, purely a preview of
+  /// what `AppDatabase.addTransaction` will itself compute and store as
+  /// `toAmount` at save time (see its `_resolveTxCurrency`/cross-currency
+  /// logic), using whatever rate is current right now. `null` whenever
+  /// there's nothing to preview: not a transfer, no destination picked yet,
+  /// both legs share a currency, the amount is still zero, or a needed rate
+  /// hasn't loaded/been entered yet — the save button itself is the one
+  /// source of truth for whether posting will actually succeed.
+  Widget? _crossCurrencyTransferPreview(Map<int, AccountRow> accountMap) {
+    if (_type != TxType.transfer || _toAccountId == null) return null;
+    final sourceCurrency = _currencyForAccount(_accountId, accountMap);
+    final destCurrency = _currencyForAccount(_toAccountId, accountMap);
+    if (sourceCurrency?.code == destCurrency?.code) return null;
+
+    final amount = _amount;
+    if (!amount.isPositive) return null;
+
+    final rates = ref.watch(currencyRatesProvider).valueOrNull;
+    if (rates == null) return null;
+    final rateFor = {for (final r in rates) r.currencyCode: r.rateToBaseMicros};
+
+    Money sourceBase;
+    if (sourceCurrency == null) {
+      sourceBase = amount;
+    } else {
+      final rate = rateFor[sourceCurrency.code];
+      if (rate == null) return null;
+      sourceBase = convertUsingRate(amount, rate);
+    }
+
+    Money destAmount;
+    if (destCurrency == null) {
+      destAmount = sourceBase;
+    } else {
+      final rate = rateFor[destCurrency.code];
+      if (rate == null) return null;
+      destAmount = Money((sourceBase.paise * currencyRateScale) ~/ rate);
+    }
+
+    final theme = Theme.of(context);
+    final formatted = destCurrency == null
+        ? MoneyFormat.symbol(destAmount)
+        : MoneyFormat.symbolIn(destAmount, destCurrency);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(
+        '≈ $formatted received, at today\'s rate',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
   }
 
   /// Non-null only for an expense on an Envelope Mode account — the signal
@@ -1600,6 +1671,12 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     // else here watches only starts loading on its first read.
     ref.watch(allAllocationsProvider);
     final amount = _amount;
+    // The amount always debits/credits _accountId — the source account for
+    // every type, transfer included — so that's whose currency the hero
+    // figure and its keypad are in. Null means the parent currency, which
+    // is also what every existing screen already renders (no account
+    // selected yet defaults to the same thing it always has).
+    final txCurrency = _currencyForAccount(_accountId, accountMap);
 
     return Scaffold(
       appBar: AppBar(
@@ -1678,7 +1755,9 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
                         fit: BoxFit.scaleDown,
                         child: Text(
                           key: const Key('amountDisplay'),
-                          MoneyFormat.symbol(amount),
+                          txCurrency == null
+                              ? MoneyFormat.symbol(amount)
+                              : MoneyFormat.symbolIn(amount, txCurrency),
                           style: theme.textTheme.displayMedium?.copyWith(
                             fontWeight: FontWeight.w700,
                             color: colorForTxType(_type),
@@ -1732,6 +1811,11 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
           onTap: () => _pickAccount(isFrom: false),
         ),
       );
+      final preview = _crossCurrencyTransferPreview(accountMap);
+      if (preview != null) {
+        tiles.add(const SizedBox(height: 8));
+        tiles.add(preview);
+      }
     } else {
       // A hybrid payment has no single "paid via" account of its own — its
       // editor below picks each leg's account instead.
@@ -1749,9 +1833,14 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
       }
       // Foreign currency applies to both income and expense (unlike
       // split/hybrid/change, which are expense-only) and stays available
-      // while editing.
-      tiles.add(_foreignToggleTile());
-      tiles.add(const SizedBox(height: 12));
+      // while editing. Hidden once the account itself already carries a
+      // non-parent currency — the transaction's real amount is already
+      // natively foreign then, so a second manual foreign-currency
+      // annotation on top would be redundant and confusing.
+      if (_currencyForAccount(_accountId, accountMap) == null) {
+        tiles.add(_foreignToggleTile());
+        tiles.add(const SizedBox(height: 12));
+      }
       if (_type == TxType.expense) {
         tiles.add(_splitToggleTile());
         tiles.add(const SizedBox(height: 12));

--- a/lib/features/add_transaction/add_transaction_screen.dart
+++ b/lib/features/add_transaction/add_transaction_screen.dart
@@ -255,7 +255,19 @@ class _AddTransactionScreenState extends ConsumerState<AddTransactionScreen> {
     } else if (widget.duplicateFromId != null) {
       _loading = true;
       WidgetsBinding.instance.addPostFrameCallback((_) => _loadForDuplicate());
+    } else {
+      // Pre-select the last-used account on a brand-new transaction, once the
+      // one-shot query resolves. Still freely changeable via "Paid via", and
+      // the guard on `_accountId` below means it never overwrites a
+      // selection the user already made while this was loading.
+      _seedLastUsedAccount();
     }
+  }
+
+  Future<void> _seedLastUsedAccount() async {
+    final txs = await ref.read(dbProvider).watchTransactions(limit: 1).first;
+    if (!mounted || _accountId != null || txs.isEmpty) return;
+    setState(() => _accountId = txs.first.accountId);
   }
 
   void _onFieldFocusChanged() => setState(() {});

--- a/lib/features/auto/archived_auto_rules_screen.dart
+++ b/lib/features/auto/archived_auto_rules_screen.dart
@@ -58,17 +58,24 @@ class _ArchivedRuleTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final isGoalOrLoan = rule.toAccountId != null;
     final isExpense = rule.kind == CategoryKind.expense;
-    final color = isExpense ? AppColors.expense : AppColors.income;
+    final color = isGoalOrLoan
+        ? AppColors.transfer
+        : (isExpense ? AppColors.expense : AppColors.income);
+    final icon = isGoalOrLoan
+        ? (ref.watch(accountMapProvider)[rule.toAccountId]?.type ==
+                  AccountType.loan
+              ? Icons.account_balance_rounded
+              : Icons.savings_rounded)
+        : (isExpense ? Icons.north_east_rounded : Icons.south_west_rounded);
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       leading: CircleAvatar(
         backgroundColor: theme.colorScheme.surfaceContainerHighest,
         foregroundColor: theme.colorScheme.onSurfaceVariant,
-        child: Icon(
-          isExpense ? Icons.north_east_rounded : Icons.south_west_rounded,
-        ),
+        child: Icon(icon),
       ),
       title: Text(
         rule.name,

--- a/lib/features/auto/auto_screen.dart
+++ b/lib/features/auto/auto_screen.dart
@@ -65,10 +65,19 @@ class AutoScreen extends ConsumerWidget {
                 return const SliverToBoxAdapter(child: _EmptyAuto());
               }
               final expenses = rules
-                  .where((r) => r.kind == CategoryKind.expense)
+                  .where(
+                    (r) =>
+                        r.toAccountId == null && r.kind == CategoryKind.expense,
+                  )
                   .toList();
               final income = rules
-                  .where((r) => r.kind == CategoryKind.income)
+                  .where(
+                    (r) =>
+                        r.toAccountId == null && r.kind == CategoryKind.income,
+                  )
+                  .toList();
+              final goalOrLoan = rules
+                  .where((r) => r.toAccountId != null)
                   .toList();
               return SliverList.list(
                 children: [
@@ -79,6 +88,10 @@ class AutoScreen extends ConsumerWidget {
                   if (income.isNotEmpty) ...[
                     _sectionHeader(theme, 'Auto Income'),
                     _section(context, theme, income),
+                  ],
+                  if (goalOrLoan.isNotEmpty) ...[
+                    _sectionHeader(theme, 'G&L'),
+                    _section(context, theme, goalOrLoan),
                   ],
                 ],
               );
@@ -168,7 +181,8 @@ class _EmptyAuto extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'Nothing set up yet — tap + to automate a fixed expense like '
-            'rent or a subscription, or income like salary.',
+            'rent or a subscription, income like salary, or a fixed '
+            'contribution toward a goal or loan payment.',
             textAlign: TextAlign.center,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
@@ -190,22 +204,32 @@ class _RuleTile extends ConsumerWidget {
 
   bool get _isExpense => rule.kind == CategoryKind.expense;
 
+  bool get _isGoalOrLoan => rule.toAccountId != null;
+
   bool get _onPromo =>
       rule.promoAmount != null && (rule.promoOccurrencesLeft ?? 0) > 0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final color = _isExpense ? AppColors.expense : AppColors.income;
+    final destination = _isGoalOrLoan
+        ? ref.watch(accountMapProvider)[rule.toAccountId]
+        : null;
+    final color = _isGoalOrLoan
+        ? AppColors.transfer
+        : (_isExpense ? AppColors.expense : AppColors.income);
+    final icon = _isGoalOrLoan
+        ? (destination?.type == AccountType.loan
+              ? Icons.account_balance_rounded
+              : Icons.savings_rounded)
+        : (_isExpense ? Icons.north_east_rounded : Icons.south_west_rounded);
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       leading: CircleAvatar(
         backgroundColor: color.withValues(alpha: 0.14),
         foregroundColor: color,
-        child: Icon(
-          _isExpense ? Icons.north_east_rounded : Icons.south_west_rounded,
-        ),
+        child: Icon(icon),
       ),
       title: Text(
         rule.name,
@@ -215,6 +239,7 @@ class _RuleTile extends ConsumerWidget {
       ),
       subtitle: Text(
         '${_frequencyLabel(rule)} · Next ${DateFormat('d MMM').format(rule.nextDueDate)}'
+        '${destination != null ? ' → ${destination.name}' : ''}'
         '${rule.isEstimate ? ' · Estimate' : ''}'
         '${_onPromo ? ' · Promo ×${rule.promoOccurrencesLeft}' : ''}',
         maxLines: 1,

--- a/lib/features/auto/recurring_rule_sheet.dart
+++ b/lib/features/auto/recurring_rule_sheet.dart
@@ -40,6 +40,10 @@ class RecurringRuleSheet extends ConsumerStatefulWidget {
   ConsumerState<RecurringRuleSheet> createState() => _RecurringRuleSheetState();
 }
 
+/// What a rule posts. [goalOrLoan] is the "G&L" option — a transfer into a
+/// goal or loan account instead of a category-tagged income/expense.
+enum _RuleKind { expense, income, goalOrLoan }
+
 class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   final _nameController = TextEditingController();
   final _amountController = TextEditingController();
@@ -49,9 +53,10 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   final _promoAmountController = TextEditingController();
   final _promoOccurrencesController = TextEditingController();
 
-  CategoryKind _kind = CategoryKind.expense;
+  _RuleKind _ruleKind = _RuleKind.expense;
   int? _accountId;
   int? _categoryId;
+  int? _toAccountId;
   RecurringFrequency _frequency = RecurringFrequency.monthly;
   late DateTime _dueDate;
   double _notifyDays = 3;
@@ -61,6 +66,12 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   Set<int> _tagIds = {};
 
   bool get _isEditing => widget.existing != null;
+
+  /// The [CategoryKind] the database call needs — meaningless for
+  /// [_RuleKind.goalOrLoan] (see [RecurringRules.kind]), so pinned to
+  /// [CategoryKind.expense] there.
+  CategoryKind get _kind =>
+      _ruleKind == _RuleKind.income ? CategoryKind.income : CategoryKind.expense;
 
   @override
   void initState() {
@@ -74,9 +85,12 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
     _amountController.text = _bufferFromMoney(e.amount);
     _payeeController.text = e.payee ?? '';
     _noteController.text = e.note ?? '';
-    _kind = e.kind;
+    _ruleKind = e.toAccountId != null
+        ? _RuleKind.goalOrLoan
+        : (e.kind == CategoryKind.income ? _RuleKind.income : _RuleKind.expense);
     _accountId = e.accountId;
     _categoryId = e.categoryId;
+    _toAccountId = e.toAccountId;
     _frequency = e.frequency;
     _dueDate = e.nextDueDate;
     _notifyDays = e.notifyDaysBefore.toDouble();
@@ -146,15 +160,21 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
       _showError('Enter an amount greater than zero.');
       return;
     }
+    final isGoalOrLoan = _ruleKind == _RuleKind.goalOrLoan;
     if (_accountId == null) {
-      _showError('Choose an account.');
+      _showError(isGoalOrLoan ? 'Choose a from account.' : 'Choose an account.');
       return;
     }
-    if (_categoryId == null) {
+    if (isGoalOrLoan) {
+      if (_toAccountId == null) {
+        _showError('Choose a goal or loan.');
+        return;
+      }
+    } else if (_categoryId == null) {
       _showError('Choose a category.');
       return;
     }
-    final payeeText = _payeeController.text.trim();
+    final payeeText = isGoalOrLoan ? '' : _payeeController.text.trim();
     final payee = payeeText.isEmpty ? null : payeeText;
     final noteText = _noteController.text.trim();
     final note = noteText.isEmpty ? null : noteText;
@@ -188,7 +208,8 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               kind: _kind,
               amount: amount,
               accountId: _accountId!,
-              categoryId: _categoryId!,
+              categoryId: _categoryId,
+              toAccountId: isGoalOrLoan ? _toAccountId : null,
               payee: payee,
               note: note,
               frequency: _frequency,
@@ -207,7 +228,8 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               kind: _kind,
               amount: amount,
               accountId: _accountId!,
-              categoryId: _categoryId!,
+              categoryId: _categoryId,
+              toAccountId: isGoalOrLoan ? _toAccountId : null,
               payee: payee,
               note: note,
               frequency: _frequency,
@@ -237,13 +259,34 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    // A goal is a savings store, not a spendable/depositable account — a
-    // recurring rule always posts as income or expense, never a transfer.
-    final accounts = (ref.watch(accountsProvider).valueOrNull ?? const [])
-        .where((a) => a.type != AccountType.goal)
+    final isGoalOrLoan = _ruleKind == _RuleKind.goalOrLoan;
+    final allAccounts = ref.watch(accountsProvider).valueOrNull ?? const [];
+    // A goal/loan is not a spendable/depositable account — an expense/income
+    // rule (or the "from" side of a G&L rule) never posts against one; only
+    // a transfer can.
+    final fromAccounts = allAccounts
+        .where(
+          (a) => a.type != AccountType.goal && a.type != AccountType.loan,
+        )
         .toList();
-    final categories =
-        ref.watch(categoriesProvider(_kind)).valueOrNull ?? const [];
+    // A rule saved before loan accounts were excluded here may still point
+    // at one — keep it selectable in its own dropdown rather than crashing
+    // on a value with no matching item.
+    if (_accountId != null && !fromAccounts.any((a) => a.id == _accountId)) {
+      final stale = allAccounts.where((a) => a.id == _accountId);
+      fromAccounts.addAll(stale);
+    }
+    final toAccounts = allAccounts
+        .where((a) => a.type == AccountType.goal || a.type == AccountType.loan)
+        .toList();
+    final categories = isGoalOrLoan
+        ? [
+            ...ref.watch(categoriesProvider(CategoryKind.expense)).valueOrNull ??
+                const [],
+            ...ref.watch(categoriesProvider(CategoryKind.income)).valueOrNull ??
+                const [],
+          ]
+        : ref.watch(categoriesProvider(_kind)).valueOrNull ?? const [];
     final categoryMap = ref.watch(categoryMapProvider);
 
     // The chosen category may no longer match the kind after toggling —
@@ -251,6 +294,13 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
     if (_categoryId != null && !categories.any((c) => c.id == _categoryId)) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) setState(() => _categoryId = null);
+      });
+    }
+    // The chosen destination may no longer be a goal/loan account (deleted,
+    // converted) — clear it the same way.
+    if (_toAccountId != null && !toAccounts.any((a) => a.id == _toAccountId)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) setState(() => _toAccountId = null);
       });
     }
 
@@ -276,21 +326,32 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               ),
             ),
             const SizedBox(height: 20),
-            SegmentedButton<CategoryKind>(
+            SegmentedButton<_RuleKind>(
               segments: const [
                 ButtonSegment(
-                  value: CategoryKind.expense,
+                  value: _RuleKind.expense,
                   label: Text('Expense'),
                 ),
+                ButtonSegment(value: _RuleKind.income, label: Text('Income')),
                 ButtonSegment(
-                  value: CategoryKind.income,
-                  label: Text('Income'),
+                  value: _RuleKind.goalOrLoan,
+                  label: Text('G&L'),
                 ),
               ],
-              selected: {_kind},
+              selected: {_ruleKind},
               showSelectedIcon: false,
-              onSelectionChanged: (s) => setState(() => _kind = s.first),
+              onSelectionChanged: (s) => setState(() => _ruleKind = s.first),
             ),
+            if (isGoalOrLoan) ...[
+              const SizedBox(height: 6),
+              Text(
+                'Automatically moves money into a goal or pays down a loan '
+                'on schedule.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+            ],
             const SizedBox(height: 16),
             TextField(
               controller: _nameController,
@@ -298,9 +359,11 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               textCapitalization: TextCapitalization.words,
               decoration: InputDecoration(
                 labelText: 'Name',
-                hintText: _kind == CategoryKind.expense
-                    ? 'e.g. Netflix, Rent'
-                    : 'e.g. Salary',
+                hintText: isGoalOrLoan
+                    ? 'e.g. Emergency Fund, Car Loan EMI'
+                    : (_kind == CategoryKind.expense
+                          ? 'e.g. Netflix, Rent'
+                          : 'e.g. Salary'),
               ),
             ),
             const SizedBox(height: 16),
@@ -380,21 +443,48 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
             DropdownButtonFormField<int>(
               initialValue: _accountId,
               isExpanded: true,
-              decoration: const InputDecoration(labelText: 'Account'),
+              decoration: InputDecoration(
+                labelText: isGoalOrLoan ? 'From account' : 'Account',
+              ),
               items: [
-                for (final a in accounts)
+                for (final a in fromAccounts)
                   DropdownMenuItem(value: a.id, child: Text(a.name)),
               ],
               onChanged: (v) => setState(() => _accountId = v),
             ),
+            if (isGoalOrLoan) ...[
+              const SizedBox(height: 16),
+              DropdownButtonFormField<int>(
+                initialValue: toAccounts.any((a) => a.id == _toAccountId)
+                    ? _toAccountId
+                    : null,
+                isExpanded: true,
+                decoration: const InputDecoration(labelText: 'Goal or loan'),
+                items: [
+                  for (final a in toAccounts)
+                    DropdownMenuItem(
+                      value: a.id,
+                      child: Text(
+                        '${a.name} '
+                        '(${a.type == AccountType.goal ? 'Goal' : 'Loan'})',
+                      ),
+                    ),
+                ],
+                onChanged: (v) => setState(() => _toAccountId = v),
+              ),
+            ],
             const SizedBox(height: 16),
-            DropdownButtonFormField<int>(
+            DropdownButtonFormField<int?>(
               initialValue: categories.any((c) => c.id == _categoryId)
                   ? _categoryId
                   : null,
               isExpanded: true,
-              decoration: const InputDecoration(labelText: 'Category'),
+              decoration: InputDecoration(
+                labelText: isGoalOrLoan ? 'Category (optional)' : 'Category',
+              ),
               items: [
+                if (isGoalOrLoan)
+                  const DropdownMenuItem(value: null, child: Text('None')),
                 for (final c in categories)
                   DropdownMenuItem(
                     value: c.id,
@@ -403,8 +493,10 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               ],
               onChanged: (v) => setState(() => _categoryId = v),
             ),
-            const SizedBox(height: 16),
-            _payeeField(theme),
+            if (!isGoalOrLoan) ...[
+              const SizedBox(height: 16),
+              _payeeField(theme),
+            ],
             const SizedBox(height: 16),
             TextField(
               controller: _noteController,

--- a/lib/features/auto/recurring_rule_sheet.dart
+++ b/lib/features/auto/recurring_rule_sheet.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
+import '../settings/currency_picker_sheet.dart';
 import '../tags/tag_picker_sheet.dart';
 
 /// Opens the add/edit sheet. Pass [existing] to edit that rule instead of
@@ -52,6 +54,7 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   final _noteController = TextEditingController();
   final _promoAmountController = TextEditingController();
   final _promoOccurrencesController = TextEditingController();
+  final _foreignAmountController = TextEditingController();
 
   _RuleKind _ruleKind = _RuleKind.expense;
   int? _accountId;
@@ -64,6 +67,13 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
   bool _hasPromo = false;
   bool _submitting = false;
   Set<int> _tagIds = {};
+
+  /// Same annotation as a transaction's own (GitHub #85) — "this is really a
+  /// $9.99 subscription" — carried on the rule so every occurrence it posts
+  /// keeps showing it. Not offered for a goal/loan rule: a transfer into a
+  /// goal or loan has no external "cost" to record.
+  bool _hasForeignCurrency = false;
+  String? _foreignCurrencyCode;
 
   bool get _isEditing => widget.existing != null;
 
@@ -102,6 +112,11 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
     if (e.promoOccurrencesLeft != null) {
       _promoOccurrencesController.text = '${e.promoOccurrencesLeft}';
     }
+    _hasForeignCurrency = e.foreignAmount != null;
+    _foreignCurrencyCode = e.foreignCurrencyCode;
+    if (e.foreignAmount != null) {
+      _foreignAmountController.text = _bufferFromMoney(e.foreignAmount!);
+    }
     _loadTagIds(e.id);
   }
 
@@ -130,6 +145,7 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
     _noteController.dispose();
     _promoAmountController.dispose();
     _promoOccurrencesController.dispose();
+    _foreignAmountController.dispose();
     super.dispose();
   }
 
@@ -196,6 +212,19 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
       }
     }
 
+    String? foreignCurrencyCode;
+    Money? foreignAmount;
+    if (_hasForeignCurrency && !isGoalOrLoan) {
+      foreignCurrencyCode = _foreignCurrencyCode;
+      foreignAmount = Money.tryParse(_foreignAmountController.text);
+      if (foreignCurrencyCode == null ||
+          foreignAmount == null ||
+          !foreignAmount.isPositive) {
+        _showError('Choose a currency and enter its amount.');
+        return;
+      }
+    }
+
     setState(() => _submitting = true);
     final navigator = Navigator.of(context);
     try {
@@ -219,6 +248,8 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               promoAmount: promoAmount,
               promoOccurrences: promoOccurrences,
               tagIds: _tagIds,
+              foreignCurrencyCode: foreignCurrencyCode,
+              foreignAmount: foreignAmount,
             );
       } else {
         await ref
@@ -239,6 +270,8 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
               promoAmount: promoAmount,
               promoOccurrences: promoOccurrences,
               tagIds: _tagIds,
+              foreignCurrencyCode: foreignCurrencyCode,
+              foreignAmount: foreignAmount,
             );
       }
     } on ArgumentError catch (e) {
@@ -438,6 +471,55 @@ class _RecurringRuleSheetState extends ConsumerState<RecurringRuleSheet> {
                   ),
                 ],
               ),
+            ],
+            if (!isGoalOrLoan) ...[
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Foreign currency'),
+                subtitle: const Text(
+                  'Record what this really costs in another currency.',
+                ),
+                value: _hasForeignCurrency,
+                onChanged: (v) => setState(() => _hasForeignCurrency = v),
+              ),
+              if (_hasForeignCurrency) ...[
+                const SizedBox(height: 4),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () async {
+                          final picked = await CurrencyPickerSheet.pick(
+                            context,
+                            initialCode:
+                                _foreignCurrencyCode ??
+                                MoneyFormat.currency.code,
+                          );
+                          if (picked == null || !mounted) return;
+                          setState(() => _foreignCurrencyCode = picked.code);
+                        },
+                        child: Text(
+                          currencyForCode(_foreignCurrencyCode).code,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      flex: 2,
+                      child: TextField(
+                        controller: _foreignAmountController,
+                        keyboardType: const TextInputType.numberWithOptions(
+                          decimal: true,
+                        ),
+                        decoration: const InputDecoration(
+                          labelText: 'Foreign amount',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
             ],
             const SizedBox(height: 4),
             DropdownButtonFormField<int>(

--- a/lib/features/budgets/budget_detail_screen.dart
+++ b/lib/features/budgets/budget_detail_screen.dart
@@ -37,6 +37,10 @@ class BudgetDetailScreen extends ConsumerWidget {
         .watch(budgetProgressProvider)
         .where((p) => p.category.id == categoryId)
         .firstOrNull;
+    final rtaOn = ref.watch(rtaEnabledProvider);
+    final fundingState = rtaOn
+        ? ref.watch(categoryFundingStateProvider(categoryId))
+        : null;
     final txs = ref.watch(categoryTransactionsProvider(categoryId));
     final accounts = ref.watch(accountMapProvider);
 
@@ -68,6 +72,8 @@ class BudgetDetailScreen extends ConsumerWidget {
             color: catColor,
             periodLabel: periodLabel,
             progress: progress,
+            rtaOn: rtaOn,
+            fundingState: fundingState,
           ),
           const SizedBox(height: 24),
           Text(
@@ -134,11 +140,15 @@ class _SummaryCard extends StatelessWidget {
     required this.color,
     required this.periodLabel,
     required this.progress,
+    required this.rtaOn,
+    required this.fundingState,
   });
 
   final Color color;
   final String periodLabel;
   final BudgetProgress? progress;
+  final bool rtaOn;
+  final CategoryFundingState? fundingState;
 
   @override
   Widget build(BuildContext context) {
@@ -189,7 +199,14 @@ class _SummaryCard extends StatelessWidget {
                   value: p.fraction.clamp(0.0, 1.0),
                   minHeight: 10,
                   backgroundColor: cs.surfaceContainerHighest,
-                  color: p.overspent ? AppColors.expense : color,
+                  color: !rtaOn
+                      ? (p.overspent ? AppColors.expense : color)
+                      : switch (fundingState) {
+                          CategoryFundingState.overspent => AppColors.expense,
+                          CategoryFundingState.funded => AppColors.income,
+                          CategoryFundingState.underfunded => Colors.amber,
+                          null => color,
+                        },
                 ),
               ),
               const SizedBox(height: 12),

--- a/lib/features/budgets/budgets_screen.dart
+++ b/lib/features/budgets/budgets_screen.dart
@@ -333,7 +333,7 @@ class _SummaryCard extends StatelessWidget {
 /// button. Tapping anywhere opens the set/edit sheet. [compact] renders a
 /// visibly smaller tile for a subcategory threaded under its parent — see
 /// [_ChildBudgetThread].
-class _BudgetTile extends StatelessWidget {
+class _BudgetTile extends ConsumerWidget {
   const _BudgetTile({
     required this.category,
     required this.progress,
@@ -347,10 +347,14 @@ class _BudgetTile extends StatelessWidget {
   final bool compact;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final catColor = Color(category.colorValue);
     final p = progress;
     final iconSize = compact ? 32.0 : 44.0;
+    final rtaOn = ref.watch(rtaEnabledProvider);
+    final fundingState = rtaOn
+        ? ref.watch(categoryFundingStateProvider(category.id))
+        : null;
 
     return Card(
       margin: compact ? EdgeInsets.zero : const EdgeInsets.only(bottom: 12),
@@ -378,7 +382,7 @@ class _BudgetTile extends StatelessWidget {
               Expanded(
                 child: p == null
                     ? _noBudget(context)
-                    : _withBudget(context, p, catColor),
+                    : _withBudget(context, p, catColor, rtaOn, fundingState),
               ),
             ],
           ),
@@ -419,15 +423,31 @@ class _BudgetTile extends StatelessWidget {
     );
   }
 
-  Widget _withBudget(BuildContext context, BudgetProgress p, Color catColor) {
+  Widget _withBudget(
+    BuildContext context,
+    BudgetProgress p,
+    Color catColor,
+    bool rtaOn,
+    CategoryFundingState? fundingState,
+  ) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final pct = (p.fraction * 100).round();
-    final barColor = p.overspent
-        ? AppColors.expense
-        : p.nearingLimit
-        ? Colors.amber
-        : catColor;
+    // RTA off: unchanged from before — overspent/nearing-limit/plain.
+    // RTA on: the three-state funding indicator replaces nearing-limit
+    // (GitHub #100 v2) — overspent still wins regardless of funding.
+    final barColor = !rtaOn
+        ? (p.overspent
+              ? AppColors.expense
+              : p.nearingLimit
+              ? Colors.amber
+              : catColor)
+        : switch (fundingState) {
+            CategoryFundingState.overspent => AppColors.expense,
+            CategoryFundingState.funded => AppColors.income,
+            CategoryFundingState.underfunded => Colors.amber,
+            null => catColor,
+          };
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/budgets/ready_to_assign_screen.dart
+++ b/lib/features/budgets/ready_to_assign_screen.dart
@@ -69,7 +69,7 @@ class ReadyToAssignScreen extends ConsumerWidget {
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Ready to Assign')),
+      appBar: AppBar(title: const Text('Envelope')),
       body: poolAccounts.isEmpty
           ? const _EmptyState()
           : ListView(
@@ -103,7 +103,8 @@ class _EmptyState extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(32),
         child: Text(
-          'Turn on Envelope Mode for an account to start assigning money.',
+          'Add an account, then come back here to start assigning money '
+          'into categories.',
           textAlign: TextAlign.center,
           style: Theme.of(
             context,
@@ -186,9 +187,13 @@ class _CategoryEnvelopeRow extends ConsumerWidget {
 /// Move money between this category's shared envelope and the shared Ready
 /// to Assign pool — a positive amount assigns in, a negative one unassigns
 /// back out. Both are the same [AppDatabase.addAllocation] call; only the
-/// sign differs. The `accountId` that call still requires is nominal here
-/// (see [defaultEnvelopeAccountIdProvider]) — there's no real "which
-/// account" question once every Envelope-Mode account shares one pool.
+/// sign differs. Since the pool is shared (GitHub #48), the `accountId` that
+/// call requires doesn't change the math — [categoryBalanceProvider] and
+/// [readyToAssignProvider] sum across every pool account regardless. It's
+/// still offered as a picker (GitHub #100) so the historical/audit trail
+/// records which real account this particular movement came from, defaulting
+/// to [defaultEnvelopeAccountIdProvider] and hidden entirely when there's
+/// only one pool account to begin with.
 class _AssignSheet extends ConsumerStatefulWidget {
   const _AssignSheet({required this.category, required this.currentBalance});
 
@@ -202,6 +207,13 @@ class _AssignSheet extends ConsumerStatefulWidget {
 class _AssignSheetState extends ConsumerState<_AssignSheet> {
   final _amountCtrl = TextEditingController();
   bool _unassign = false;
+  int? _accountId;
+
+  @override
+  void initState() {
+    super.initState();
+    _accountId = ref.read(defaultEnvelopeAccountIdProvider);
+  }
 
   @override
   void dispose() {
@@ -217,7 +229,7 @@ class _AssignSheetState extends ConsumerState<_AssignSheet> {
       );
       return;
     }
-    final accountId = ref.read(defaultEnvelopeAccountIdProvider);
+    final accountId = _accountId ?? ref.read(defaultEnvelopeAccountIdProvider);
     if (accountId == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('No account is in Envelope Mode')),
@@ -245,6 +257,7 @@ class _AssignSheetState extends ConsumerState<_AssignSheet> {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final rta = ref.watch(readyToAssignProvider);
+    final poolAccounts = ref.watch(envelopeModeAccountsProvider);
 
     return Padding(
       padding: EdgeInsets.only(
@@ -295,6 +308,25 @@ class _AssignSheetState extends ConsumerState<_AssignSheet> {
             onSelectionChanged: (s) => setState(() => _unassign = s.first),
           ),
           const SizedBox(height: 16),
+          if (poolAccounts.length > 1)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: DropdownButtonFormField<int>(
+                initialValue: poolAccounts.any((a) => a.id == _accountId)
+                    ? _accountId
+                    : poolAccounts.first.id,
+                isExpanded: true,
+                decoration: const InputDecoration(labelText: 'Account'),
+                items: [
+                  for (final account in poolAccounts)
+                    DropdownMenuItem(
+                      value: account.id,
+                      child: Text(account.name),
+                    ),
+                ],
+                onChanged: (v) => setState(() => _accountId = v),
+              ),
+            ),
           TextField(
             controller: _amountCtrl,
             autofocus: true,

--- a/lib/features/budgets/ready_to_assign_screen.dart
+++ b/lib/features/budgets/ready_to_assign_screen.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/app_icons.dart';
+import '../../core/money.dart';
+import '../../core/theme/app_colors.dart';
+import '../../core/widgets/money_text.dart';
+import '../../data/database.dart';
+import '../../data/providers.dart';
+import '../../data/tables.dart';
+
+/// The shared Ready to Assign figure, pooled across every Envelope-Mode
+/// account (see `readyToAssignProvider` in `data/providers.dart` —
+/// GitHub #48). Public so both [ReadyToAssignScreen] and the Dashboard's
+/// summary tile render the exact same card instead of two copies.
+class ReadyToAssignCard extends ConsumerWidget {
+  const ReadyToAssignCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final rta = ref.watch(readyToAssignProvider);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Ready to Assign',
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  MoneyText(
+                    rta,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: rta.isNegative ? AppColors.expense : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (rta.isNegative)
+              Icon(Icons.warning_amber_rounded, color: AppColors.expense),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One shared Ready to Assign figure plus the category envelope list it
+/// pools across — every account with Envelope Mode on shares this single
+/// screen (GitHub #48) instead of each getting its own copy on its Account
+/// Detail page.
+class ReadyToAssignScreen extends ConsumerWidget {
+  const ReadyToAssignScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final poolAccounts = ref.watch(envelopeModeAccountsProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Ready to Assign')),
+      body: poolAccounts.isEmpty
+          ? const _EmptyState()
+          : ListView(
+              padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+              children: [
+                const ReadyToAssignCard(),
+                const SizedBox(height: 16),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8, left: 4),
+                  child: Text(
+                    'Categories',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                const _CategoryEnvelopeList(),
+              ],
+            ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(
+          'Turn on Envelope Mode for an account to start assigning money.',
+          textAlign: TextAlign.center,
+          style: Theme.of(
+            context,
+          ).textTheme.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryEnvelopeList extends ConsumerWidget {
+  const _CategoryEnvelopeList();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cs = Theme.of(context).colorScheme;
+    final categoriesAsync = ref.watch(categoriesProvider(CategoryKind.expense));
+
+    return categoriesAsync.when(
+      loading: () => const Padding(
+        padding: EdgeInsets.all(24),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+      error: (_, _) => const SizedBox.shrink(),
+      data: (categories) => Card(
+        child: Column(
+          children: [
+            for (var i = 0; i < categories.length; i++) ...[
+              if (i > 0) Divider(height: 1, indent: 70, color: cs.outline),
+              _CategoryEnvelopeRow(category: categories[i]),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryEnvelopeRow extends ConsumerWidget {
+  const _CategoryEnvelopeRow({required this.category});
+
+  final CategoryRow category;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final catColor = Color(category.colorValue);
+    final balance = ref.watch(categoryBalanceProvider(category.id));
+    final overspent = balance.isNegative;
+
+    return ListTile(
+      leading: Container(
+        width: 40,
+        height: 40,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: catColor.withValues(alpha: 0.15),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(AppIcons.resolve(category.iconKey), color: catColor, size: 18),
+      ),
+      title: Text(category.name),
+      trailing: MoneyText(
+        balance,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+          color: overspent ? AppColors.expense : null,
+        ),
+      ),
+      onTap: () => showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) =>
+            _AssignSheet(category: category, currentBalance: balance),
+      ),
+    );
+  }
+}
+
+/// Move money between this category's shared envelope and the shared Ready
+/// to Assign pool — a positive amount assigns in, a negative one unassigns
+/// back out. Both are the same [AppDatabase.addAllocation] call; only the
+/// sign differs. The `accountId` that call still requires is nominal here
+/// (see [defaultEnvelopeAccountIdProvider]) — there's no real "which
+/// account" question once every Envelope-Mode account shares one pool.
+class _AssignSheet extends ConsumerStatefulWidget {
+  const _AssignSheet({required this.category, required this.currentBalance});
+
+  final CategoryRow category;
+  final Money currentBalance;
+
+  @override
+  ConsumerState<_AssignSheet> createState() => _AssignSheetState();
+}
+
+class _AssignSheetState extends ConsumerState<_AssignSheet> {
+  final _amountCtrl = TextEditingController();
+  bool _unassign = false;
+
+  @override
+  void dispose() {
+    _amountCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final typed = Money.tryParse(_amountCtrl.text);
+    if (typed == null || !typed.isPositive) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Enter an amount greater than zero')),
+      );
+      return;
+    }
+    final accountId = ref.read(defaultEnvelopeAccountIdProvider);
+    if (accountId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No account is in Envelope Mode')),
+      );
+      return;
+    }
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(dbProvider).addAllocation(
+        accountId: accountId,
+        categoryId: widget.category.id,
+        amount: _unassign ? -typed : typed,
+      );
+    } on ArgumentError catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text(e.message?.toString() ?? 'Could not save')),
+      );
+      return;
+    }
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final rta = ref.watch(readyToAssignProvider);
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 8,
+        bottom:
+            MediaQuery.of(context).padding.bottom +
+            MediaQuery.of(context).viewInsets.bottom +
+            20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 20),
+              decoration: BoxDecoration(
+                color: cs.outlineVariant,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Text(
+            widget.category.name,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Currently ${MoneyFormat.symbol(widget.currentBalance)} · '
+            'Ready to Assign: ${MoneyFormat.symbol(rta)}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 20),
+          SegmentedButton<bool>(
+            segments: const [
+              ButtonSegment(value: false, label: Text('Assign')),
+              ButtonSegment(value: true, label: Text('Unassign')),
+            ],
+            selected: {_unassign},
+            onSelectionChanged: (s) => setState(() => _unassign = s.first),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _amountCtrl,
+            autofocus: true,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+              fontFeatures: kTabularFigures,
+            ),
+            decoration: InputDecoration(
+              labelText: _unassign
+                  ? 'Move back to Ready to Assign'
+                  : 'Assign from Ready to Assign',
+              prefixText: MoneyFormat.inputPrefix,
+            ),
+            onSubmitted: (_) => _save(),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: _save,
+            child: const Padding(
+              padding: EdgeInsets.symmetric(vertical: 4),
+              child: Text('Save'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/budgets/ready_to_assign_screen.dart
+++ b/lib/features/budgets/ready_to_assign_screen.dart
@@ -69,7 +69,7 @@ class ReadyToAssignScreen extends ConsumerWidget {
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Envelope')),
+      appBar: AppBar(title: const Text('Ready to Assign')),
       body: poolAccounts.isEmpty
           ? const _EmptyState()
           : ListView(
@@ -153,7 +153,17 @@ class _CategoryEnvelopeRow extends ConsumerWidget {
     final theme = Theme.of(context);
     final catColor = Color(category.colorValue);
     final balance = ref.watch(categoryBalanceProvider(category.id));
-    final overspent = balance.isNegative;
+    // A category with a Budgets ceiling gets the full three-state funding
+    // color; one with only an envelope balance and no ceiling (still
+    // possible — the two systems are independent) falls back to today's
+    // red-if-negative/plain look.
+    final fundingState = ref.watch(categoryFundingStateProvider(category.id));
+    final balanceColor = switch (fundingState) {
+      CategoryFundingState.overspent => AppColors.expense,
+      CategoryFundingState.funded => AppColors.income,
+      CategoryFundingState.underfunded => Colors.amber,
+      null => balance.isNegative ? AppColors.expense : null,
+    };
 
     return ListTile(
       leading: Container(
@@ -171,7 +181,7 @@ class _CategoryEnvelopeRow extends ConsumerWidget {
         balance,
         style: theme.textTheme.titleMedium?.copyWith(
           fontWeight: FontWeight.w600,
-          color: overspent ? AppColors.expense : null,
+          color: balanceColor,
         ),
       ),
       onTap: () => showModalBottomSheet<void>(

--- a/lib/features/categories/categories_screen.dart
+++ b/lib/features/categories/categories_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/app_icons.dart';
 import '../../core/widgets/error_view.dart';
+import '../../core/widgets/icon_picker_sheet.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
@@ -496,13 +497,7 @@ class _CategoryEditorSheetState extends ConsumerState<_CategoryEditorSheet> {
             const SizedBox(height: 24),
             _fieldLabel(theme, 'Icon'),
             const SizedBox(height: 12),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                for (final k in AppIcons.allKeys) _iconCircle(theme, k),
-              ],
-            ),
+            _iconField(theme),
             const SizedBox(height: 28),
             FilledButton(
               onPressed: _submitting ? null : _save,
@@ -626,28 +621,51 @@ class _CategoryEditorSheetState extends ConsumerState<_CategoryEditorSheet> {
     );
   }
 
-  Widget _iconCircle(ThemeData theme, String key) {
-    final selected = _iconKey == key;
+  /// A single tile showing the chosen icon; tapping it opens the searchable
+  /// icon sheet (GitHub #102) instead of laying every icon out inline.
+  Widget _iconField(ThemeData theme) {
     final color = Color(_colorValue);
     return GestureDetector(
-      onTap: () => setState(() => _iconKey = key),
+      onTap: () async {
+        final picked = await showIconPickerSheet(
+          context,
+          selected: _iconKey,
+          accentColor: color,
+        );
+        if (picked != null) setState(() => _iconKey = picked);
+      },
       child: Container(
-        width: 52,
-        height: 52,
-        alignment: Alignment.center,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         decoration: BoxDecoration(
-          color: selected
-              ? color.withValues(alpha: 0.15)
-              : theme.colorScheme.surface,
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? color : theme.colorScheme.outline,
-            width: selected ? 2.5 : 1,
-          ),
+          border: Border.all(color: theme.colorScheme.outline),
+          borderRadius: BorderRadius.circular(16),
         ),
-        child: Icon(
-          AppIcons.resolve(key),
-          color: selected ? color : theme.colorScheme.onSurfaceVariant,
+        child: Row(
+          children: [
+            Container(
+              width: 44,
+              height: 44,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: 0.15),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(AppIcons.resolve(_iconKey), color: color),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Text(
+                'Tap to change',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/categories/categories_screen.dart
+++ b/lib/features/categories/categories_screen.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../core/app_icons.dart';
 import '../../core/widgets/error_view.dart';
@@ -53,6 +54,13 @@ class _CategoriesScreenState extends ConsumerState<CategoriesScreen>
     return Scaffold(
       appBar: AppBar(
         title: const Text('Categories'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.dashboard_customize_outlined),
+            tooltip: 'Templates',
+            onPressed: () => context.push('/more/categories/templates'),
+          ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: const [

--- a/lib/features/categories/category_templates_screen.dart
+++ b/lib/features/categories/category_templates_screen.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/widgets/error_view.dart';
+import '../../data/database.dart';
+import '../../data/providers.dart';
+
+/// Save the current category structure as a reusable template, and switch
+/// between saved templates (GitHub #101). Switching never touches a
+/// transaction — it only archives categories the target template doesn't
+/// have and (re)creates the ones it does, exactly like a manual archive.
+class CategoryTemplatesScreen extends ConsumerWidget {
+  const CategoryTemplatesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final templatesAsync = ref.watch(categoryTemplatesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Category templates')),
+      body: templatesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => const Center(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: InlineErrorView(message: "Couldn't load templates"),
+          ),
+        ),
+        data: (templates) => ListView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 96),
+          children: [
+            Text(
+              'A template is a saved snapshot of your category and '
+              'sub-category structure. Save your current one before trying '
+              'a reorganization, or switch to another template any time — '
+              "past transactions always keep the category they're already "
+              'tagged with, whether or not it stays in the template you '
+              'switch to.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            if (templates.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 32),
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.dashboard_customize_outlined,
+                      size: 48,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No templates saved yet — tap + to save your current '
+                      'categories as one.',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else
+              Card(
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  children: [
+                    for (var i = 0; i < templates.length; i++) ...[
+                      if (i > 0) Divider(height: 1, indent: 60),
+                      _TemplateTile(template: templates[i]),
+                    ],
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        tooltip: 'Save current as template',
+        onPressed: () => _saveCurrentAsTemplate(context, ref),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _TemplateTile extends ConsumerWidget {
+  const _TemplateTile({required this.template});
+
+  final CategoryTemplateRow template;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final itemCount = ref
+        .watch(categoryTemplateItemsProvider(template.id))
+        .valueOrNull
+        ?.length;
+    final subtitle = itemCount == null
+        ? 'Loading…'
+        : '$itemCount ${itemCount == 1 ? 'category' : 'categories'}';
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.primaryContainer,
+        child: Icon(
+          Icons.dashboard_customize_outlined,
+          color: theme.colorScheme.onPrimaryContainer,
+        ),
+      ),
+      title: Text(
+        template.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: PopupMenuButton<_TemplateAction>(
+        onSelected: (action) => switch (action) {
+          _TemplateAction.apply => _applyTemplate(context, ref, template),
+          _TemplateAction.rename => _renameTemplate(context, ref, template),
+          _TemplateAction.delete => _deleteTemplate(context, ref, template),
+        },
+        itemBuilder: (_) => const [
+          PopupMenuItem(
+            value: _TemplateAction.apply,
+            child: Text('Switch to this template'),
+          ),
+          PopupMenuItem(value: _TemplateAction.rename, child: Text('Rename')),
+          PopupMenuItem(value: _TemplateAction.delete, child: Text('Delete')),
+        ],
+      ),
+      onTap: () => _applyTemplate(context, ref, template),
+    );
+  }
+}
+
+enum _TemplateAction { apply, rename, delete }
+
+Future<void> _saveCurrentAsTemplate(BuildContext context, WidgetRef ref) async {
+  final name = await _promptForName(context, title: 'Save as template');
+  if (name == null || name.isEmpty) return;
+  if (!context.mounted) return;
+
+  final messenger = ScaffoldMessenger.of(context);
+  await ref.read(dbProvider).saveCategoriesAsTemplate(name);
+  messenger
+    ..hideCurrentSnackBar()
+    ..showSnackBar(SnackBar(content: Text('Saved "$name"')));
+}
+
+Future<void> _renameTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final name = await _promptForName(
+    context,
+    title: 'Rename template',
+    initialValue: template.name,
+  );
+  if (name == null || name.isEmpty || name == template.name) return;
+  if (!context.mounted) return;
+
+  await ref.read(dbProvider).renameCategoryTemplate(template.id, name);
+}
+
+Future<String?> _promptForName(
+  BuildContext context, {
+  required String title,
+  String initialValue = '',
+}) {
+  final controller = TextEditingController(text: initialValue);
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        maxLength: 60,
+        textCapitalization: TextCapitalization.words,
+        decoration: const InputDecoration(
+          labelText: 'Name',
+          hintText: 'e.g. Minimalist, Detailed tracking',
+          counterText: '',
+        ),
+        onSubmitted: (v) => Navigator.of(dialogContext).pop(v.trim()),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () =>
+              Navigator.of(dialogContext).pop(controller.text.trim()),
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<void> _applyTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text('Switch to "${template.name}"?'),
+      content: const Text(
+        'Categories not in this template are archived, not deleted — every '
+        "transaction keeps the category it's already tagged with, and "
+        'switching back later brings the same categories back. Categories '
+        'this template adds are created fresh.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('Switch'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  final messenger = ScaffoldMessenger.of(context);
+  try {
+    await ref.read(dbProvider).applyCategoryTemplate(template.id);
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('Switched to "${template.name}"')));
+  } on ArgumentError catch (e) {
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text(e.message?.toString() ?? "Couldn't switch.")),
+      );
+  }
+}
+
+Future<void> _deleteTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text('Delete "${template.name}"?'),
+      content: const Text(
+        'This only deletes the saved template — your current categories '
+        'and every transaction are untouched.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(dialogContext).colorScheme.error,
+          ),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+
+  await ref.read(dbProvider).deleteCategoryTemplate(template.id);
+}

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -1557,6 +1557,7 @@ class _SpendByCategorySection extends ConsumerWidget {
                             color: cats[e.key] != null
                                 ? Color(cats[e.key]!.colorValue)
                                 : theme.colorScheme.secondary,
+                            id: e.key,
                           ),
                       ],
                     ),

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -991,7 +991,7 @@ class _ReadyToAssignSection extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SectionHeader('Ready to Assign'),
+          const _SectionHeader('Envelope'),
           InkWell(
             borderRadius: BorderRadius.circular(_cardRadius),
             onTap: () => context.push('/more/ready-to-assign'),

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -980,6 +980,9 @@ class _ReadyToAssignSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (ref.watch(budgetingModeProvider) != BudgetingMode.envelope) {
+      return const SizedBox.shrink();
+    }
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
     if (poolAccounts.isEmpty) return const SizedBox.shrink();
 
@@ -1371,6 +1374,9 @@ class _BudgetsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (ref.watch(budgetingModeProvider) != BudgetingMode.budgets) {
+      return const SizedBox.shrink();
+    }
     final progress = ref.watch(budgetProgressProvider);
 
     if (progress.isEmpty) return const _SetBudgetCard();

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -12,6 +12,7 @@ import '../../core/widgets/motion.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
+import '../budgets/ready_to_assign_screen.dart';
 import '../message_capture/review_inbox_screen.dart';
 import '../reports/chart_widgets.dart';
 import 'sparkline.dart';
@@ -971,17 +972,16 @@ class _AccountCard extends StatelessWidget {
 
 // ── 3¼. Ready to Assign (Envelope Mode) ──────────────────────────────────
 
-/// One card per Envelope Mode account, showing how much of its balance
-/// hasn't been given a job yet. Hidden entirely when no account has Envelope
-/// Mode on — this is a per-account, opt-in feature, never a global mode.
+/// The one shared Ready to Assign figure, pooled across every account with
+/// Envelope Mode on (GitHub #48 — one pool, not one per account). Hidden
+/// entirely when no account has Envelope Mode on.
 class _ReadyToAssignSection extends ConsumerWidget {
   const _ReadyToAssignSection();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accounts = ref.watch(accountsProvider).valueOrNull ?? const [];
-    final envelopeAccounts = accounts.where((a) => a.envelopeMode).toList();
-    if (envelopeAccounts.isEmpty) return const SizedBox.shrink();
+    final poolAccounts = ref.watch(envelopeModeAccountsProvider);
+    if (poolAccounts.isEmpty) return const SizedBox.shrink();
 
     return Padding(
       padding: _sectionPad,
@@ -989,64 +989,12 @@ class _ReadyToAssignSection extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const _SectionHeader('Ready to Assign'),
-          for (final account in envelopeAccounts)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 10),
-              child: _ReadyToAssignCard(account: account),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ReadyToAssignCard extends ConsumerWidget {
-  const _ReadyToAssignCard({required this.account});
-
-  final AccountRow account;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final rta = ref.watch(readyToAssignProvider(account.id));
-
-    return Card(
-      margin: EdgeInsets.zero,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(_cardRadius),
-        onTap: () => context.push('/account/${account.id}'),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      account.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.labelLarge?.copyWith(
-                        color: cs.onSurfaceVariant,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    MoneyText(
-                      rta,
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        color: rta.isNegative ? AppColors.expense : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Icon(Icons.chevron_right_rounded, color: cs.onSurfaceVariant),
-            ],
+          InkWell(
+            borderRadius: BorderRadius.circular(_cardRadius),
+            onTap: () => context.push('/more/ready-to-assign'),
+            child: const ReadyToAssignCard(),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/features/dashboard/dashboard_screen.dart
+++ b/lib/features/dashboard/dashboard_screen.dart
@@ -970,17 +970,17 @@ class _AccountCard extends StatelessWidget {
   }
 }
 
-// ── 3¼. Ready to Assign (Envelope Mode) ──────────────────────────────────
+// ── 3¼. Ready to Assign ──────────────────────────────────────────────────
 
-/// The one shared Ready to Assign figure, pooled across every account with
-/// Envelope Mode on (GitHub #48 — one pool, not one per account). Hidden
-/// entirely when no account has Envelope Mode on.
+/// The one shared Ready to Assign figure, pooled across every on-budget
+/// account (GitHub #48 — one pool, not one per account). Hidden entirely
+/// while Ready to Assign is off globally, or no account is on-budget yet.
 class _ReadyToAssignSection extends ConsumerWidget {
   const _ReadyToAssignSection();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (ref.watch(budgetingModeProvider) != BudgetingMode.envelope) {
+    if (!ref.watch(rtaEnabledProvider)) {
       return const SizedBox.shrink();
     }
     final poolAccounts = ref.watch(envelopeModeAccountsProvider);
@@ -991,7 +991,7 @@ class _ReadyToAssignSection extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const _SectionHeader('Envelope'),
+          const _SectionHeader('Ready to Assign'),
           InkWell(
             borderRadius: BorderRadius.circular(_cardRadius),
             onTap: () => context.push('/more/ready-to-assign'),
@@ -1374,12 +1374,11 @@ class _BudgetsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (ref.watch(budgetingModeProvider) != BudgetingMode.budgets) {
-      return const SizedBox.shrink();
-    }
     final progress = ref.watch(budgetProgressProvider);
 
     if (progress.isEmpty) return const _SetBudgetCard();
+
+    final rtaOn = ref.watch(rtaEnabledProvider);
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 24),
@@ -1407,6 +1406,13 @@ class _BudgetsSection extends ConsumerWidget {
                         budget: p.budget.amount,
                         spent: p.spent,
                         color: Color(p.category.colorValue),
+                        fundingColor: rtaOn
+                            ? _fundingColor(
+                                ref.watch(
+                                  categoryFundingStateProvider(p.category.id),
+                                ),
+                              )
+                            : null,
                       ),
                   ],
                 ),
@@ -1417,6 +1423,13 @@ class _BudgetsSection extends ConsumerWidget {
       ),
     );
   }
+
+  static Color? _fundingColor(CategoryFundingState? state) => switch (state) {
+    CategoryFundingState.overspent => AppColors.expense,
+    CategoryFundingState.funded => AppColors.income,
+    CategoryFundingState.underfunded => Colors.amber,
+    null => null,
+  };
 }
 
 class _SetBudgetCard extends StatelessWidget {

--- a/lib/features/data_export/statement_pdf.dart
+++ b/lib/features/data_export/statement_pdf.dart
@@ -5,6 +5,7 @@ import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
 
 import '../../core/branding/app_info.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../data/database.dart';
 import '../../data/tables.dart';
@@ -27,6 +28,13 @@ Future<Uint8List> buildAccountStatementPdf({
   required DateTime end,
 }) async {
   final doc = pw.Document(title: '${account.name} statement');
+  // This account's own currency, not the app-wide parent one — a foreign-
+  // currency account's statement must state (and format) figures in the
+  // currency they actually happened in. Null means the parent currency,
+  // same convention as [Accounts.currencyCode] itself.
+  final currency = account.currencyCode == null
+      ? MoneyFormat.currency
+      : currencyForCode(account.currencyCode!);
 
   doc.addPage(
     pw.MultiPage(
@@ -38,9 +46,12 @@ Future<Uint8List> buildAccountStatementPdf({
         _kv('Type', _accountTypeLabel(account.type)),
         if (_bankLine(account) case final line?) _kv('Bank', line),
         _kv('Period', '${_dateLabel(start)} to ${_dateLabel(end)}'),
-        _kv('Currency', MoneyFormat.currency.code),
+        _kv('Currency', currency.code),
         pw.SizedBox(height: 12),
-        _kv('Opening balance', MoneyFormat.bare(statement.openingBalance)),
+        _kv(
+          'Opening balance',
+          MoneyFormat.bareIn(statement.openingBalance, currency),
+        ),
         pw.SizedBox(height: 12),
         if (statement.lines.isEmpty)
           pw.Text(
@@ -61,9 +72,13 @@ Future<Uint8List> buildAccountStatementPdf({
                 [
                   _dateLabel(line.date),
                   line.description,
-                  line.debit.isZero ? '' : MoneyFormat.bare(line.debit),
-                  line.credit.isZero ? '' : MoneyFormat.bare(line.credit),
-                  MoneyFormat.bare(line.balance),
+                  line.debit.isZero
+                      ? ''
+                      : MoneyFormat.bareIn(line.debit, currency),
+                  line.credit.isZero
+                      ? ''
+                      : MoneyFormat.bareIn(line.credit, currency),
+                  MoneyFormat.bareIn(line.balance, currency),
                 ],
             ],
             cellAlignments: const {
@@ -82,7 +97,10 @@ Future<Uint8List> buildAccountStatementPdf({
             headerDecoration: const pw.BoxDecoration(color: PdfColors.grey200),
           ),
         pw.SizedBox(height: 12),
-        _kv('Closing balance', MoneyFormat.bare(statement.closingBalance)),
+        _kv(
+          'Closing balance',
+          MoneyFormat.bareIn(statement.closingBalance, currency),
+        ),
       ],
     ),
   );

--- a/lib/features/more/more_screen.dart
+++ b/lib/features/more/more_screen.dart
@@ -29,7 +29,7 @@ class MoreScreen extends ConsumerWidget {
     final Color budgetSubtitleColor;
     if (budgetingMode == BudgetingMode.envelope) {
       final readyToAssign = ref.watch(readyToAssignProvider);
-      budgetTileLabel = 'Ready to Assign';
+      budgetTileLabel = 'Envelope';
       budgetTileRoute = '/more/ready-to-assign';
       budgetTileIcon = Icons.savings_outlined;
       budgetSubtitle = '${MoneyFormat.compact(readyToAssign)} unassigned';

--- a/lib/features/more/more_screen.dart
+++ b/lib/features/more/more_screen.dart
@@ -6,6 +6,7 @@ import '../../core/branding/app_info.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../data/providers.dart';
+import '../../data/tables.dart';
 
 /// Hub page. Grouped, not a flat dump. Every tile navigates to a real route.
 class MoreScreen extends ConsumerWidget {
@@ -167,6 +168,9 @@ class MoreScreen extends ConsumerWidget {
       ]),
     ];
 
+    final viewMode = ref.watch(moreScreenViewModeProvider);
+    final isCards = viewMode == MoreScreenViewMode.cards;
+
     return Scaffold(
       body: CustomScrollView(
         slivers: [
@@ -185,22 +189,40 @@ class MoreScreen extends ConsumerWidget {
                 ),
               ),
             ),
-            SliverToBoxAdapter(
-              child: Padding(
+            if (isCards)
+              SliverPadding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
-                child: Card(
-                  child: Column(
-                    children: [
-                      for (var i = 0; i < group.items.length; i++) ...[
-                        if (i > 0)
-                          Divider(height: 1, indent: 60, color: cs.outline),
-                        _MoreTile(item: group.items[i]),
+                sliver: SliverGrid(
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        mainAxisSpacing: 12,
+                        crossAxisSpacing: 12,
+                        childAspectRatio: 1.35,
+                      ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, i) => _MoreCard(item: group.items[i]),
+                    childCount: group.items.length,
+                  ),
+                ),
+              )
+            else
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Card(
+                    child: Column(
+                      children: [
+                        for (var i = 0; i < group.items.length; i++) ...[
+                          if (i > 0)
+                            Divider(height: 1, indent: 60, color: cs.outline),
+                          _MoreTile(item: group.items[i]),
+                        ],
                       ],
-                    ],
+                    ),
                   ),
                 ),
               ),
-            ),
           ],
           const SliverToBoxAdapter(child: SizedBox(height: 32)),
         ],
@@ -235,6 +257,55 @@ class _MoreTile extends StatelessWidget {
       ),
       trailing: const Icon(Icons.chevron_right_rounded),
       onTap: () => context.push(item.route),
+    );
+  }
+}
+
+/// A single hub card — two per row, see [MoreScreen]. Same destination and
+/// content as [_MoreTile], just laid out for a grid instead of a list row.
+class _MoreCard extends StatelessWidget {
+  const _MoreCard({required this.item});
+
+  final _Item item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: () => context.push(item.route),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(item.icon, color: cs.primary),
+              const Spacer(),
+              Text(
+                item.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                item.subtitle,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: item.subtitleColor ?? cs.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/more/more_screen.dart
+++ b/lib/features/more/more_screen.dart
@@ -18,14 +18,33 @@ class MoreScreen extends ConsumerWidget {
     final cs = theme.colorScheme;
 
     // ── Live badges ──────────────────────────────────────────────────────────
+    final budgetingMode = ref.watch(budgetingModeProvider);
     final progress = ref.watch(budgetProgressProvider);
     final overCount = progress.where((p) => p.overspent).length;
-    final budgetSubtitle = overCount > 0
-        ? '$overCount over budget'
-        : '${progress.length} active';
-    final budgetSubtitleColor = overCount > 0
-        ? AppColors.expense
-        : cs.onSurfaceVariant;
+
+    final String budgetTileLabel;
+    final String budgetTileRoute;
+    final IconData budgetTileIcon;
+    final String budgetSubtitle;
+    final Color budgetSubtitleColor;
+    if (budgetingMode == BudgetingMode.envelope) {
+      final readyToAssign = ref.watch(readyToAssignProvider);
+      budgetTileLabel = 'Ready to Assign';
+      budgetTileRoute = '/more/ready-to-assign';
+      budgetTileIcon = Icons.savings_outlined;
+      budgetSubtitle = '${MoneyFormat.compact(readyToAssign)} unassigned';
+      budgetSubtitleColor = cs.onSurfaceVariant;
+    } else {
+      budgetTileLabel = 'Budgets';
+      budgetTileRoute = '/more/budgets';
+      budgetTileIcon = Icons.donut_large_rounded;
+      budgetSubtitle = overCount > 0
+          ? '$overCount over budget'
+          : '${progress.length} active';
+      budgetSubtitleColor = overCount > 0
+          ? AppColors.expense
+          : cs.onSurfaceVariant;
+    }
 
     final netWorth =
         ref.watch(netWorthProvider).valueOrNull ?? const Money.zero();
@@ -57,9 +76,9 @@ class MoreScreen extends ConsumerWidget {
           subtitle: 'Who owes you, who you owe',
         ),
         _Item(
-          Icons.donut_large_rounded,
-          'Budgets',
-          route: '/more/budgets',
+          budgetTileIcon,
+          budgetTileLabel,
+          route: budgetTileRoute,
           subtitle: budgetSubtitle,
           subtitleColor: budgetSubtitleColor,
         ),

--- a/lib/features/more/more_screen.dart
+++ b/lib/features/more/more_screen.dart
@@ -6,7 +6,7 @@ import '../../core/branding/app_info.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../data/providers.dart';
-import '../../data/tables.dart';
+import '../../data/tables.dart' show MoreScreenViewMode;
 
 /// Hub page. Grouped, not a flat dump. Every tile navigates to a real route.
 class MoreScreen extends ConsumerWidget {
@@ -18,33 +18,15 @@ class MoreScreen extends ConsumerWidget {
     final cs = theme.colorScheme;
 
     // ── Live badges ──────────────────────────────────────────────────────────
-    final budgetingMode = ref.watch(budgetingModeProvider);
+    final rtaEnabled = ref.watch(rtaEnabledProvider);
     final progress = ref.watch(budgetProgressProvider);
     final overCount = progress.where((p) => p.overspent).length;
-
-    final String budgetTileLabel;
-    final String budgetTileRoute;
-    final IconData budgetTileIcon;
-    final String budgetSubtitle;
-    final Color budgetSubtitleColor;
-    if (budgetingMode == BudgetingMode.envelope) {
-      final readyToAssign = ref.watch(readyToAssignProvider);
-      budgetTileLabel = 'Envelope';
-      budgetTileRoute = '/more/ready-to-assign';
-      budgetTileIcon = Icons.savings_outlined;
-      budgetSubtitle = '${MoneyFormat.compact(readyToAssign)} unassigned';
-      budgetSubtitleColor = cs.onSurfaceVariant;
-    } else {
-      budgetTileLabel = 'Budgets';
-      budgetTileRoute = '/more/budgets';
-      budgetTileIcon = Icons.donut_large_rounded;
-      budgetSubtitle = overCount > 0
-          ? '$overCount over budget'
-          : '${progress.length} active';
-      budgetSubtitleColor = overCount > 0
-          ? AppColors.expense
-          : cs.onSurfaceVariant;
-    }
+    final budgetSubtitle = overCount > 0
+        ? '$overCount over budget'
+        : '${progress.length} active';
+    final budgetSubtitleColor = overCount > 0
+        ? AppColors.expense
+        : cs.onSurfaceVariant;
 
     final netWorth =
         ref.watch(netWorthProvider).valueOrNull ?? const Money.zero();
@@ -76,12 +58,21 @@ class MoreScreen extends ConsumerWidget {
           subtitle: 'Who owes you, who you owe',
         ),
         _Item(
-          budgetTileIcon,
-          budgetTileLabel,
-          route: budgetTileRoute,
+          Icons.donut_large_rounded,
+          'Budgets',
+          route: '/more/budgets',
           subtitle: budgetSubtitle,
           subtitleColor: budgetSubtitleColor,
         ),
+        if (rtaEnabled)
+          _Item(
+            Icons.savings_outlined,
+            'Ready to Assign',
+            route: '/more/ready-to-assign',
+            subtitle:
+                '${MoneyFormat.compact(ref.watch(readyToAssignProvider))} '
+                'unassigned',
+          ),
         _Item(
           Icons.autorenew_rounded,
           'Auto',

--- a/lib/features/reports/account_reports_screen.dart
+++ b/lib/features/reports/account_reports_screen.dart
@@ -173,6 +173,7 @@ class _BalanceSplitCard extends ConsumerWidget {
                   label: a.name,
                   value: a.currentBalance,
                   color: Color(a.colorValue),
+                  id: null,
                 ),
             ],
           )

--- a/lib/features/reports/chart_widgets.dart
+++ b/lib/features/reports/chart_widgets.dart
@@ -236,7 +236,14 @@ class _LegendChip extends StatelessWidget {
 class BudgetRadialChart extends StatefulWidget {
   const BudgetRadialChart({required this.slices, super.key});
 
-  final List<({String label, Money budget, Money spent, Color color})> slices;
+  /// [fundingColor], when set (GitHub #100 v2, only while Ready to Assign is
+  /// on), overrides [color] for this slice's fill — green/amber for
+  /// funded/underfunded. The overspent hazard-stripe + red ring stays
+  /// keyed off [spent]/[budget] regardless, so it still overlays either way.
+  final List<
+    ({String label, Money budget, Money spent, Color color, Color? fundingColor})
+  >
+  slices;
 
   @override
   State<BudgetRadialChart> createState() => _BudgetRadialChartState();
@@ -283,7 +290,9 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
     final data = <_BudgetSlice>[];
     if (positive.length > 6) {
       for (final s in positive.take(5)) {
-        data.add(_BudgetSlice(s.label, s.budget, s.spent, s.color));
+        data.add(
+          _BudgetSlice(s.label, s.budget, s.spent, s.color, s.fundingColor),
+        );
       }
       var restBudget = const Money.zero();
       var restSpent = const Money.zero();
@@ -291,10 +300,14 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
         restBudget += s.budget;
         restSpent += s.spent;
       }
+      // Folded into "Other": a single funding color can't represent several
+      // categories at once, so this tail always falls back to its own grey.
       data.add(_BudgetSlice('Other', restBudget, restSpent, Colors.grey));
     } else {
       for (final s in positive) {
-        data.add(_BudgetSlice(s.label, s.budget, s.spent, s.color));
+        data.add(
+          _BudgetSlice(s.label, s.budget, s.spent, s.color, s.fundingColor),
+        );
       }
     }
 
@@ -344,12 +357,23 @@ class _BudgetRadialChartState extends State<BudgetRadialChart> {
 }
 
 class _BudgetSlice {
-  const _BudgetSlice(this.label, this.budget, this.spent, this.color);
+  const _BudgetSlice(
+    this.label,
+    this.budget,
+    this.spent,
+    this.color, [
+    this.fundingColor,
+  ]);
 
   final String label;
   final Money budget;
   final Money spent;
   final Color color;
+  final Color? fundingColor;
+
+  /// The color actually painted for the wedge fill — [fundingColor] when
+  /// set, else the category's own [color].
+  Color get fillColor => fundingColor ?? color;
 
   bool get overspent => spent > budget;
 
@@ -386,7 +410,10 @@ class _BudgetSectorPainter extends CustomPainter {
       final sweep = share - gap;
       final wedge = _wedge(center, outerRect, start, sweep);
 
-      canvas.drawPath(wedge, Paint()..color = slice.color.withValues(alpha: 0.16));
+      canvas.drawPath(
+        wedge,
+        Paint()..color = slice.fillColor.withValues(alpha: 0.16),
+      );
 
       if (slice.fraction > 0) {
         final filledRadius = outerRadius * math.sqrt(slice.fraction);
@@ -397,7 +424,7 @@ class _BudgetSectorPainter extends CustomPainter {
             start,
             sweep,
           ),
-          Paint()..color = slice.color,
+          Paint()..color = slice.fillColor,
         );
       }
 

--- a/lib/features/reports/chart_widgets.dart
+++ b/lib/features/reports/chart_widgets.dart
@@ -46,10 +46,23 @@ class _NoData extends StatelessWidget {
 /// Account Reports want that at-a-glance list; the Dashboard's compact card
 /// doesn't).
 class CategoryPieChart extends StatefulWidget {
-  const CategoryPieChart({required this.slices, this.showLegend = true, super.key});
+  const CategoryPieChart({
+    required this.slices,
+    this.showLegend = true,
+    this.onSliceTap,
+    super.key,
+  });
 
-  final List<({String label, Money value, Color color})> slices;
+  /// [id] is whatever the caller wants back via [onSliceTap] — e.g. a
+  /// category id to drill into. Null for a slice nothing should navigate to
+  /// (the synthetic "Other" tail always gets null; a non-category chart like
+  /// the accounts-balance one can leave every slice's id null).
+  final List<({String label, Money value, Color color, int? id})> slices;
   final bool showLegend;
+
+  /// Tapping a legend chip whose slice carries a non-null id calls this with
+  /// that id. Left null (the default) makes the legend non-interactive.
+  final ValueChanged<int>? onSliceTap;
 
   @override
   State<CategoryPieChart> createState() => _CategoryPieChartState();
@@ -65,17 +78,18 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
 
     if (positive.isEmpty) return const _NoData(height: 220);
 
-    final data = <({String label, Money value, Color color})>[];
+    final data = <({String label, Money value, Color color, int? id})>[];
     if (positive.length > 6) {
       data.addAll(positive.take(5));
       var rest = const Money.zero();
       for (final s in positive.skip(5)) {
         rest += s.value;
       }
-      data.add((label: 'Other', value: rest, color: Colors.grey));
+      data.add((label: 'Other', value: rest, color: Colors.grey, id: null));
     } else {
       data.addAll(positive);
     }
+    final total = data.fold<int>(0, (sum, d) => sum + d.value.paise);
 
     final touched = _touchedIndex >= 0 && _touchedIndex < data.length
         ? data[_touchedIndex]
@@ -131,7 +145,16 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
               spacing: 16,
               runSpacing: 10,
               alignment: WrapAlignment.center,
-              children: [for (final s in data) _LegendChip(slice: s)],
+              children: [
+                for (final s in data)
+                  _LegendChip(
+                    slice: s,
+                    percentOfTotal: total == 0 ? null : s.value.paise / total * 100,
+                    onTap: (widget.onSliceTap == null || s.id == null)
+                        ? null
+                        : () => widget.onSliceTap!(s.id!),
+                  ),
+              ],
             ),
           ],
         ],
@@ -144,7 +167,7 @@ class _CategoryPieChartState extends State<CategoryPieChart> {
 class _CenterLabel extends StatelessWidget {
   const _CenterLabel({required this.slice});
 
-  final ({String label, Money value, Color color}) slice;
+  final ({String label, Money value, Color color, int? id}) slice;
 
   @override
   Widget build(BuildContext context) {
@@ -180,44 +203,67 @@ class _CenterLabel extends StatelessWidget {
 }
 
 class _LegendChip extends StatelessWidget {
-  const _LegendChip({required this.slice});
+  const _LegendChip({required this.slice, this.percentOfTotal, this.onTap});
 
-  final ({String label, Money value, Color color}) slice;
+  final ({String label, Money value, Color color, int? id}) slice;
+  final double? percentOfTotal;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return ConstrainedBox(
+    final valueLine = percentOfTotal == null
+        ? MoneyFormat.compact(slice.value)
+        : '${MoneyFormat.compact(slice.value)} (${percentOfTotal!.round()}%)';
+
+    final chip = ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 150),
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 10,
-            height: 10,
-            decoration: BoxDecoration(color: slice.color, shape: BoxShape.circle),
-          ),
-          const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              slice.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.bodySmall,
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(color: slice.color, shape: BoxShape.circle),
             ),
           ),
           const SizedBox(width: 6),
-          Text(
-            MoneyFormat.compact(slice.value),
-            maxLines: 1,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontFeatures: kTabularFigures,
+          // Label and value stack in one Flexible so a long percentage-
+          // annotated value wraps to a second line instead of overflowing
+          // the chip's width, the way it would fighting for space as a
+          // sibling of the label in a single Row.
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  slice.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall,
+                ),
+                Text(
+                  valueLine,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    fontFeatures: kTabularFigures,
+                  ),
+                ),
+              ],
             ),
           ),
         ],
       ),
     );
+
+    if (onTap == null) return chip;
+    return InkWell(borderRadius: BorderRadius.circular(8), onTap: onTap, child: chip);
   }
 }
 

--- a/lib/features/reports/stats_screen.dart
+++ b/lib/features/reports/stats_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../core/money.dart';
@@ -69,6 +70,23 @@ class StatsScreen extends ConsumerWidget {
         const SizedBox(height: 28),
         const _Caption('Highlights'),
         _HighlightsSection(month: month, showYear: showYear),
+        const SizedBox(height: 28),
+        const _Caption('Standings'),
+        _StandingsControls(
+          metric: ref.watch(statsStandingsMetricProvider),
+          ascending: ref.watch(statsStandingsAscendingProvider),
+          onMetricChanged: (v) =>
+              ref.read(statsStandingsMetricProvider.notifier).state = v,
+          onToggleAscending: () =>
+              ref.read(statsStandingsAscendingProvider.notifier).state =
+                  !ref.read(statsStandingsAscendingProvider),
+        ),
+        const SizedBox(height: 12),
+        _StandingsSection(
+          month: month,
+          showYear: showYear,
+          showSubcategories: ref.watch(statsShowSubcategoriesProvider),
+        ),
         const SizedBox(height: 24),
         Text(
           'Transfers between your own accounts are never counted as income '
@@ -626,5 +644,416 @@ class _HighlightRow extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+// ── 6. Standings ─────────────────────────────────────────────────────────────
+// Rankings in list form (GitHub #95) — the highest transactions, or the
+// most expensive categories, over the same period as Highlights above.
+// A single toggle reverses either ranking to lowest-first.
+
+/// How many rows a standings ranking shows before the rest is folded away —
+/// keeps the list a glanceable "top N" instead of the whole ledger.
+const _kStandingsLimit = 10;
+
+class _StandingsControls extends StatelessWidget {
+  const _StandingsControls({
+    required this.metric,
+    required this.ascending,
+    required this.onMetricChanged,
+    required this.onToggleAscending,
+  });
+
+  final StandingsMetric metric;
+  final bool ascending;
+  final ValueChanged<StandingsMetric> onMetricChanged;
+  final VoidCallback onToggleAscending;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: SegmentedButton<StandingsMetric>(
+            segments: const [
+              ButtonSegment(
+                value: StandingsMetric.transactions,
+                label: Text('Transactions'),
+              ),
+              ButtonSegment(
+                value: StandingsMetric.categories,
+                label: Text('Categories'),
+              ),
+            ],
+            selected: {metric},
+            showSelectedIcon: false,
+            onSelectionChanged: (s) => onMetricChanged(s.first),
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton.filledTonal(
+          icon: Icon(
+            ascending
+                ? Icons.arrow_upward_rounded
+                : Icons.arrow_downward_rounded,
+          ),
+          tooltip: ascending ? 'Lowest first' : 'Highest first',
+          onPressed: onToggleAscending,
+        ),
+      ],
+    );
+  }
+}
+
+class _StandingsSection extends ConsumerWidget {
+  const _StandingsSection({
+    required this.month,
+    required this.showYear,
+    required this.showSubcategories,
+  });
+
+  final DateTime month;
+  final bool showYear;
+  final bool showSubcategories;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final metric = ref.watch(statsStandingsMetricProvider);
+    final ascending = ref.watch(statsStandingsAscendingProvider);
+
+    return metric == StandingsMetric.transactions
+        ? _TransactionStandings(
+            month: month,
+            showYear: showYear,
+            ascending: ascending,
+          )
+        : _CategoryStandings(
+            showYear: showYear,
+            year: month.year,
+            showSubcategories: showSubcategories,
+            ascending: ascending,
+          );
+  }
+}
+
+class _TransactionStandings extends ConsumerWidget {
+  const _TransactionStandings({
+    required this.month,
+    required this.showYear,
+    required this.ascending,
+  });
+
+  final DateTime month;
+  final bool showYear;
+  final bool ascending;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final txsAsync = ref.watch(allTransactionsProvider);
+    final categories = ref.watch(categoryMapProvider);
+    final splitsByTx = ref.watch(transactionSplitsByTxProvider);
+
+    return txsAsync.when(
+      loading: () => const _SectionLoader(height: 120),
+      error: (_, _) => const InlineErrorView(),
+      data: (txs) {
+        // Only income and expense carry a "how much" that's meaningful to
+        // rank — transfers and person-to-person legs move money without
+        // being income or expense (see the footer note on this screen).
+        final ranked =
+            txs
+                .where(
+                  (t) =>
+                      t.type.isIncomeOrExpense &&
+                      t.date.year == month.year &&
+                      (showYear || t.date.month == month.month),
+                )
+                .toList()
+              ..sort(
+                (a, b) => ascending
+                    ? a.amount.compareTo(b.amount)
+                    : b.amount.compareTo(a.amount),
+              );
+
+        if (ranked.isEmpty) {
+          return _StandingsCard(children: [_notEnough(context)]);
+        }
+
+        String labelOf(TransactionRow t) {
+          if (t.categoryId != null) {
+            return categories[t.categoryId]?.name ?? 'Uncategorised';
+          }
+          return (splitsByTx[t.id]?.isNotEmpty ?? false)
+              ? 'Split'
+              : 'Uncategorised';
+        }
+
+        return _StandingsCard(
+          children: [
+            for (final (i, t) in ranked.take(_kStandingsLimit).indexed)
+              _StandingRow(
+                rank: i + 1,
+                title: t.payee?.isNotEmpty ?? false ? t.payee! : labelOf(t),
+                subtitle: DateFormat('d MMM yyyy').format(t.date),
+                value: t.type == TxType.income
+                    ? MoneyFormat.signed(t.amount)
+                    : MoneyFormat.signed(-t.amount),
+                valueColor: t.type == TxType.income
+                    ? AppColors.income
+                    : AppColors.expense,
+                onTap: () => context.push('/transaction/${t.id}'),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _notEnough(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      'Not enough data yet.',
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+}
+
+class _CategoryStandings extends ConsumerWidget {
+  const _CategoryStandings({
+    required this.showYear,
+    required this.year,
+    required this.showSubcategories,
+    required this.ascending,
+  });
+
+  final bool showYear;
+  final int year;
+  final bool showSubcategories;
+  final bool ascending;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categories = ref.watch(categoryMapProvider);
+
+    Widget rankingOf(Map<int, Money> rawSpend) {
+      // Same grouping rule as the pie above: subcategories stand alone
+      // (labelled "Parent · Child" to stay distinguishable), or roll up
+      // into their parent when the toggle is off.
+      final entries = <({String label, Money value, Color color})>[];
+      if (showSubcategories) {
+        rawSpend.forEach((id, amount) {
+          final cat = categories[id];
+          if (cat == null) return;
+          final parent = cat.parentId == null ? null : categories[cat.parentId];
+          entries.add((
+            label: parent == null ? cat.name : '${parent.name} · ${cat.name}',
+            value: amount,
+            color: Color(cat.colorValue),
+          ));
+        });
+      } else {
+        rollUpToParents(rawSpend, categories).forEach((id, amount) {
+          final cat = categories[id];
+          if (cat == null) return;
+          entries.add((label: cat.name, value: amount, color: Color(cat.colorValue)));
+        });
+      }
+
+      final positive = entries.where((e) => e.value.isPositive).toList()
+        ..sort(
+          (a, b) => ascending ? a.value.compareTo(b.value) : b.value.compareTo(a.value),
+        );
+
+      if (positive.isEmpty) {
+        return _StandingsCard(children: [_notEnough(context)]);
+      }
+
+      final maxValue = positive
+          .map((e) => e.value.paise)
+          .reduce((a, b) => a > b ? a : b);
+
+      return _StandingsCard(
+        children: [
+          for (final (i, e) in positive.take(_kStandingsLimit).indexed)
+            _StandingRow(
+              rank: i + 1,
+              title: e.label,
+              value: MoneyFormat.symbol(e.value),
+              dotColor: e.color,
+              barFraction: maxValue == 0 ? 0 : e.value.paise / maxValue,
+              barColor: e.color,
+            ),
+        ],
+      );
+    }
+
+    if (showYear) {
+      return rankingOf(ref.watch(yearSpendByCategoryProvider(year)));
+    }
+
+    final spendAsync = ref.watch(spendByCategoryProvider);
+    return spendAsync.when(
+      loading: () => const _SectionLoader(height: 220),
+      error: (_, _) => const InlineErrorView(),
+      data: rankingOf,
+    );
+  }
+
+  Widget _notEnough(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      'Not enough data yet.',
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+}
+
+class _StandingsCard extends StatelessWidget {
+  const _StandingsCard({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 6),
+        child: Column(children: children),
+      ),
+    );
+  }
+}
+
+/// One ranked row: a rank number, a title/subtitle pair, and a
+/// right-aligned value. [barFraction] (0–1) optionally draws a thin
+/// proportional bar under the row — used by the category ranking to show
+/// relative size at a glance; transactions skip it and are tappable instead.
+class _StandingRow extends StatelessWidget {
+  const _StandingRow({
+    required this.rank,
+    required this.title,
+    required this.value,
+    this.valueColor,
+    this.dotColor,
+    this.subtitle,
+    this.barFraction,
+    this.barColor,
+    this.onTap,
+  });
+
+  final int rank;
+  final String title;
+  final String? subtitle;
+  final String value;
+  // Colors the value text — for income/expense, where the color itself is
+  // meaningful. Category colors go on [dotColor] instead: a category's
+  // colorValue is picked to work as a swatch, not necessarily as readable
+  // text on a card.
+  final Color? valueColor;
+  final Color? dotColor;
+  final double? barFraction;
+  final Color? barColor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    final row = Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              SizedBox(
+                width: 22,
+                child: Text(
+                  '$rank',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: cs.onSurfaceVariant,
+                    fontWeight: FontWeight.w600,
+                    fontFeatures: kTabularFigures,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 6),
+              if (dotColor != null) ...[
+                Container(
+                  width: 10,
+                  height: 10,
+                  decoration: BoxDecoration(
+                    color: dotColor,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 8),
+              ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (subtitle != null)
+                      Text(
+                        subtitle!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                value,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: valueColor ?? cs.onSurface,
+                  fontFeatures: kTabularFigures,
+                ),
+              ),
+            ],
+          ),
+          if (barFraction != null) ...[
+            const SizedBox(height: 6),
+            Padding(
+              padding: const EdgeInsets.only(left: 28),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(3),
+                child: LinearProgressIndicator(
+                  value: barFraction!.clamp(0.0, 1.0),
+                  minHeight: 5,
+                  backgroundColor: (barColor ?? cs.primary).withValues(
+                    alpha: 0.14,
+                  ),
+                  valueColor: AlwaysStoppedAnimation(barColor ?? cs.primary),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    if (onTap == null) return row;
+    return InkWell(borderRadius: BorderRadius.circular(8), onTap: onTap, child: row);
   }
 }

--- a/lib/features/reports/stats_screen.dart
+++ b/lib/features/reports/stats_screen.dart
@@ -415,7 +415,7 @@ class _CategorySection extends ConsumerWidget {
     final categories = ref.watch(categoryMapProvider);
 
     Widget chartOf(Map<int, Money> rawSpend) {
-      final slices = <({String label, Money value, Color color})>[];
+      final slices = <({String label, Money value, Color color, int? id})>[];
       if (showSubcategories) {
         // Every leaf category gets its own slice — no roll-up. A
         // subcategory is labelled "Parent · Child" so two subcategories
@@ -429,6 +429,7 @@ class _CategorySection extends ConsumerWidget {
             label: parent == null ? cat.name : '${parent.name} · ${cat.name}',
             value: amount,
             color: Color(cat.colorValue),
+            id: id,
           ));
         });
       } else {
@@ -442,10 +443,14 @@ class _CategorySection extends ConsumerWidget {
             label: cat.name,
             value: amount,
             color: Color(cat.colorValue),
+            id: id,
           ));
         });
       }
-      return CategoryPieChart(slices: slices);
+      return CategoryPieChart(
+        slices: slices,
+        onSliceTap: (categoryId) => context.push('/more/budgets/$categoryId'),
+      );
     }
 
     if (showYear) {
@@ -841,13 +846,14 @@ class _CategoryStandings extends ConsumerWidget {
       // Same grouping rule as the pie above: subcategories stand alone
       // (labelled "Parent · Child" to stay distinguishable), or roll up
       // into their parent when the toggle is off.
-      final entries = <({String label, Money value, Color color})>[];
+      final entries = <({int id, String label, Money value, Color color})>[];
       if (showSubcategories) {
         rawSpend.forEach((id, amount) {
           final cat = categories[id];
           if (cat == null) return;
           final parent = cat.parentId == null ? null : categories[cat.parentId];
           entries.add((
+            id: id,
             label: parent == null ? cat.name : '${parent.name} · ${cat.name}',
             value: amount,
             color: Color(cat.colorValue),
@@ -857,7 +863,12 @@ class _CategoryStandings extends ConsumerWidget {
         rollUpToParents(rawSpend, categories).forEach((id, amount) {
           final cat = categories[id];
           if (cat == null) return;
-          entries.add((label: cat.name, value: amount, color: Color(cat.colorValue)));
+          entries.add((
+            id: id,
+            label: cat.name,
+            value: amount,
+            color: Color(cat.colorValue),
+          ));
         });
       }
 
@@ -873,6 +884,7 @@ class _CategoryStandings extends ConsumerWidget {
       final maxValue = positive
           .map((e) => e.value.paise)
           .reduce((a, b) => a > b ? a : b);
+      final total = positive.fold(const Money.zero(), (sum, e) => sum + e.value);
 
       return _StandingsCard(
         children: [
@@ -880,10 +892,14 @@ class _CategoryStandings extends ConsumerWidget {
             _StandingRow(
               rank: i + 1,
               title: e.label,
+              subtitle: total.paise == 0
+                  ? null
+                  : '${(e.value.paise / total.paise * 100).toStringAsFixed(1)}% of total',
               value: MoneyFormat.symbol(e.value),
               dotColor: e.color,
               barFraction: maxValue == 0 ? 0 : e.value.paise / maxValue,
               barColor: e.color,
+              onTap: () => context.push('/more/budgets/${e.id}'),
             ),
         ],
       );

--- a/lib/features/savings/loan_detail_screen.dart
+++ b/lib/features/savings/loan_detail_screen.dart
@@ -334,8 +334,9 @@ class LoanDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(loan.account.id);
+      rtaAutoDisabled = await ref.read(dbProvider).deleteAccount(loan.account.id);
     } on ArgumentError catch (e) {
       messenger
         ..hideCurrentSnackBar()
@@ -348,7 +349,16 @@ class LoanDetailScreen extends ConsumerWidget {
     navigator.pop();
     messenger
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Loan deleted')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Loan deleted. Ready to Assign turned off — no accounts '
+                      'left in the pool.'
+                : 'Loan deleted',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/savings/savings_goal_detail_screen.dart
+++ b/lib/features/savings/savings_goal_detail_screen.dart
@@ -448,8 +448,11 @@ class SavingsGoalDetailScreen extends ConsumerWidget {
     );
     if (confirmed != true) return;
 
+    bool rtaAutoDisabled;
     try {
-      await ref.read(dbProvider).deleteAccount(progress.account.id);
+      rtaAutoDisabled = await ref
+          .read(dbProvider)
+          .deleteAccount(progress.account.id);
     } on ArgumentError catch (e) {
       messenger
         ..hideCurrentSnackBar()
@@ -462,7 +465,16 @@ class SavingsGoalDetailScreen extends ConsumerWidget {
     navigator.pop();
     messenger
       ..hideCurrentSnackBar()
-      ..showSnackBar(const SnackBar(content: Text('Goal deleted')));
+      ..showSnackBar(
+        SnackBar(
+          content: Text(
+            rtaAutoDisabled
+                ? 'Goal deleted. Ready to Assign turned off — no accounts '
+                      'left in the pool.'
+                : 'Goal deleted',
+          ),
+        ),
+      );
   }
 }
 

--- a/lib/features/settings/currency_picker_sheet.dart
+++ b/lib/features/settings/currency_picker_sheet.dart
@@ -6,8 +6,15 @@ import '../../data/providers.dart';
 
 /// A searchable list of every currency the app knows. Picking one writes it to
 /// settings; the whole app reformats immediately (see [CurrencyScope]).
+///
+/// [initialCode]/[onSelected] let this same sheet be reused to pick an
+/// arbitrary currency that has nothing to do with the app-wide setting — see
+/// [pick] — without touching [Settings.currencyCode] at all.
 class CurrencyPickerSheet extends ConsumerStatefulWidget {
-  const CurrencyPickerSheet({super.key});
+  const CurrencyPickerSheet({this.initialCode, this.onSelected, super.key});
+
+  final String? initialCode;
+  final ValueChanged<Currency>? onSelected;
 
   static Future<void> show(BuildContext context, WidgetRef ref) {
     return showModalBottomSheet<void>(
@@ -19,6 +26,25 @@ class CurrencyPickerSheet extends ConsumerStatefulWidget {
         borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
       ),
       builder: (_) => const CurrencyPickerSheet(),
+    );
+  }
+
+  /// Picks a currency without touching the app's home-currency setting — for
+  /// a transaction or auto rule's own foreign-currency annotation (GitHub
+  /// #85). Returns `null` if the sheet is dismissed without a pick.
+  static Future<Currency?> pick(BuildContext context, {String? initialCode}) {
+    return showModalBottomSheet<Currency>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+      ),
+      builder: (context) => CurrencyPickerSheet(
+        initialCode: initialCode,
+        onSelected: (c) => Navigator.of(context).pop(c),
+      ),
     );
   }
 
@@ -53,7 +79,7 @@ class _CurrencyPickerSheetState extends ConsumerState<CurrencyPickerSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final selected = ref.watch(currencyProvider).code;
+    final selected = widget.initialCode ?? ref.watch(currencyProvider).code;
     final results = _filtered;
 
     return ConstrainedBox(
@@ -129,6 +155,10 @@ class _CurrencyPickerSheetState extends ConsumerState<CurrencyPickerSheet> {
                               : null,
                           selected: isSelected,
                           onTap: () async {
+                            if (widget.onSelected != null) {
+                              widget.onSelected!(c);
+                              return;
+                            }
                             await ref.read(dbProvider).setCurrencyCode(c.code);
                             if (context.mounted) Navigator.of(context).pop();
                           },

--- a/lib/features/settings/currency_settings_screen.dart
+++ b/lib/features/settings/currency_settings_screen.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../core/currency.dart';
+import '../../data/currency_conversion.dart';
+import '../../data/database.dart';
+import '../../data/providers.dart';
+import 'currency_picker_sheet.dart';
+
+final _dateFormat = DateFormat('d MMM yyyy');
+
+/// Settings > Currency. The parent currency (today's global
+/// `Settings.currencyCode`, unchanged — this screen just gives it a home
+/// alongside the rates that price every other currency against it) plus the
+/// manually-maintained exchange-rate history that lets an account carry its
+/// own currency (see `AppDatabase.latestRate`/`addCurrencyRate`).
+class CurrencySettingsScreen extends ConsumerWidget {
+  const CurrencySettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final parentCurrency = ref.watch(currencyProvider);
+    final ratesAsync = ref.watch(currencyRatesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Currency')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+        children: [
+          _sectionLabel(theme, 'Parent currency'),
+          Card(
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              leading: const Icon(Icons.payments_outlined),
+              title: Text('${parentCurrency.symbol} ${parentCurrency.code}'),
+              subtitle: Text(
+                'Every total — Net Worth, Reports, Budgets — is shown in '
+                'this currency.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () => CurrencyPickerSheet.show(context, ref),
+            ),
+          ),
+          const SizedBox(height: 20),
+          _sectionLabel(theme, 'Exchange rates'),
+          ratesAsync.when(
+            data: (rates) => Card(
+              child: Column(
+                children: [
+                  if (rates.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Text(
+                        'No exchange rates yet. Add a currency below to give '
+                        'an account its own currency — a bank account, '
+                        'wallet or card can then carry that currency and '
+                        'convert back to your parent currency using the '
+                        'rate you enter here.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                    )
+                  else
+                    for (var i = 0; i < rates.length; i++) ...[
+                      if (i > 0)
+                        Divider(height: 1, indent: 60, color: cs.outline),
+                      _RateTile(rate: rates[i], parentCurrency: parentCurrency),
+                    ],
+                  Divider(height: 1, indent: 60, color: cs.outline),
+                  ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                    leading: const Icon(Icons.add_circle_outline_rounded),
+                    title: const Text('Add a currency'),
+                    onTap: () => _addCurrency(context, ref),
+                  ),
+                ],
+              ),
+            ),
+            loading: () => const Padding(
+              padding: EdgeInsets.all(24),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (_, _) => Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'Could not load exchange rates.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _addCurrency(BuildContext context, WidgetRef ref) async {
+    final picked = await CurrencyPickerSheet.pick(context);
+    if (picked == null || !context.mounted) return;
+    await showAddRateDialog(context, ref, picked.code);
+  }
+
+  Widget _sectionLabel(ThemeData theme, String text) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 10),
+      child: Text(
+        text.toUpperCase(),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.1,
+        ),
+      ),
+    );
+  }
+}
+
+class _RateTile extends ConsumerWidget {
+  const _RateTile({required this.rate, required this.parentCurrency});
+
+  final CurrencyRateRow rate;
+  final Currency parentCurrency;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final currency = currencyForCode(rate.currencyCode);
+    final rateValue = rate.rateToBaseMicros / currencyRateScale;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+      leading: SizedBox(
+        width: 32,
+        child: Center(
+          child: Text(
+            currency.symbol,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ),
+      title: Text(
+        '1 ${currency.code} = ${rateValue.toStringAsFixed(4)} '
+        '${parentCurrency.code}',
+      ),
+      subtitle: Text(
+        'Updated ${_dateFormat.format(rate.effectiveAt)}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: cs.onSurfaceVariant,
+        ),
+      ),
+      trailing: const Icon(Icons.chevron_right_rounded),
+      onTap: () => showAddRateDialog(context, ref, rate.currencyCode),
+    );
+  }
+}
+
+/// Opens the "enter a rate" dialog for [currencyCode] and, if saved, records
+/// it via [AppDatabase.addCurrencyRate]. Shared by "Add a currency" (a brand
+/// new code) and tapping an existing rate row (a new historical entry for a
+/// code already in use) — both just need a value and an effective date.
+Future<void> showAddRateDialog(
+  BuildContext context,
+  WidgetRef ref,
+  String currencyCode,
+) async {
+  final result = await showDialog<({int rateToBaseMicros, DateTime effectiveAt})>(
+    context: context,
+    builder: (_) => _AddRateDialog(currencyCode: currencyCode),
+  );
+  if (result == null) return;
+  await ref
+      .read(dbProvider)
+      .addCurrencyRate(
+        currencyCode: currencyCode,
+        rateToBaseMicros: result.rateToBaseMicros,
+        effectiveAt: result.effectiveAt,
+      );
+}
+
+/// Same disposal-timing convention as `_MyIdDialog` in `settings_screen.dart`
+/// — a `StatefulWidget` owning its own controller, not one disposed right
+/// after `showDialog` resolves.
+class _AddRateDialog extends StatefulWidget {
+  const _AddRateDialog({required this.currencyCode});
+
+  final String currencyCode;
+
+  @override
+  State<_AddRateDialog> createState() => _AddRateDialogState();
+}
+
+class _AddRateDialogState extends State<_AddRateDialog> {
+  late final _rateController = TextEditingController();
+  DateTime _effectiveAt = DateTime.now();
+  String? _error;
+
+  @override
+  void dispose() {
+    _rateController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currency = currencyForCode(widget.currencyCode);
+    return AlertDialog(
+      title: Text('${currency.name} rate'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: _rateController,
+            autofocus: true,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: InputDecoration(
+              labelText: 'Rate',
+              hintText: 'e.g. 83.12',
+              prefixText: '1 ${currency.code} = ',
+              errorText: _error,
+            ),
+          ),
+          const SizedBox(height: 4),
+          ListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Effective date'),
+            subtitle: Text(_dateFormat.format(_effectiveAt)),
+            trailing: const Icon(Icons.calendar_today_outlined),
+            onTap: _pickDate,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(onPressed: _save, child: const Text('Save')),
+      ],
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _effectiveAt,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now(),
+    );
+    if (picked != null) setState(() => _effectiveAt = picked);
+  }
+
+  void _save() {
+    final rate = double.tryParse(_rateController.text.trim());
+    if (rate == null || rate <= 0) {
+      setState(() => _error = 'Enter a valid rate.');
+      return;
+    }
+    Navigator.of(context).pop((
+      rateToBaseMicros: (rate * currencyRateScale).round(),
+      effectiveAt: _effectiveAt,
+    ));
+  }
+}

--- a/lib/features/settings/more_screen_layout_sheet.dart
+++ b/lib/features/settings/more_screen_layout_sheet.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../data/providers.dart';
+import '../../data/tables.dart';
+
+/// How the More hub lays out its items — one column of rows, or two cards
+/// per row.
+class MoreScreenLayoutSheet extends ConsumerWidget {
+  const MoreScreenLayoutSheet({super.key});
+
+  static String label(MoreScreenViewMode mode) => switch (mode) {
+    MoreScreenViewMode.list => 'List',
+    MoreScreenViewMode.cards => 'Cards',
+  };
+
+  static String _description(MoreScreenViewMode mode) => switch (mode) {
+    MoreScreenViewMode.list => 'One row per item, with its subtitle — '
+        "XPENC's original look.",
+    MoreScreenViewMode.cards => 'Two cards per row, more compact and '
+        'visual.',
+  };
+
+  static IconData _icon(MoreScreenViewMode mode) => switch (mode) {
+    MoreScreenViewMode.list => Icons.view_list_rounded,
+    MoreScreenViewMode.cards => Icons.grid_view_rounded,
+  };
+
+  static Future<void> show(BuildContext context) => showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    showDragHandle: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    ),
+    builder: (_) => const MoreScreenLayoutSheet(),
+  );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final selected = ref.watch(moreScreenViewModeProvider);
+
+    return SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 4),
+            child: Text('More screen layout', style: theme.textTheme.titleLarge),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            child: Text(
+              'How the More hub shows Accounts, Budgets, Auto and the rest.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          ),
+          for (final mode in MoreScreenViewMode.values)
+            ListTile(
+              leading: Icon(_icon(mode)),
+              title: Text(label(mode)),
+              subtitle: Text(
+                _description(mode),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+              trailing: mode == selected
+                  ? Icon(Icons.check_rounded, color: cs.primary)
+                  : null,
+              selected: mode == selected,
+              onTap: () async {
+                await ref.read(dbProvider).setMoreScreenViewMode(mode);
+                if (context.mounted) Navigator.of(context).pop();
+              },
+            ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import '../../core/branding/app_info.dart';
 import '../../core/branding/brand_mark.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
+import '../../data/tables.dart' show BudgetingMode;
 import 'lock_screen_style_sheet.dart';
 import 'master_phrase_attempts_sheet.dart';
 import 'more_screen_layout_sheet.dart';
@@ -46,6 +47,7 @@ class SettingsScreen extends ConsumerWidget {
     final pinTimeoutMinutes = ref.watch(pinTimeoutMinutesProvider);
     final lockScreenStyle = ref.watch(lockScreenStyleProvider);
     final moreScreenViewMode = ref.watch(moreScreenViewModeProvider);
+    final budgetingMode = ref.watch(budgetingModeProvider);
     final hasMasterPhrase = ref.watch(hasMasterPhraseProvider);
     final masterPhraseAttemptThreshold = ref.watch(
       masterPhraseAttemptThresholdProvider,
@@ -187,6 +189,59 @@ class SettingsScreen extends ConsumerWidget {
               ),
               trailing: const Icon(Icons.chevron_right_rounded),
               onTap: () => context.push('/more/settings/dashboard'),
+            ),
+          ),
+
+          // ── Budgeting ──────────────────────────────────────────────────────
+          _sectionLabel(context, 'Budgeting'),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.donut_large_outlined),
+                      const SizedBox(width: 12),
+                      Text(
+                        'Budgeting mode',
+                        style: theme.textTheme.titleSmall,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Budgets sets a spending ceiling per category. Envelope '
+                    '(Ready to Assign) instead assigns money you actually '
+                    'have into categories first. Both keep working either '
+                    'way — this only picks which one the Dashboard and More '
+                    'hub show.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SegmentedButton<BudgetingMode>(
+                    segments: const [
+                      ButtonSegment(
+                        value: BudgetingMode.budgets,
+                        label: Text('Budgets'),
+                        icon: Icon(Icons.donut_large_outlined),
+                      ),
+                      ButtonSegment(
+                        value: BudgetingMode.envelope,
+                        label: Text('Envelope'),
+                        icon: Icon(Icons.savings_outlined),
+                      ),
+                    ],
+                    selected: {budgetingMode},
+                    onSelectionChanged: (selection) => ref
+                        .read(dbProvider)
+                        .setBudgetingMode(selection.first),
+                  ),
+                ],
+              ),
             ),
           ),
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,7 +6,6 @@ import '../../core/branding/app_info.dart';
 import '../../core/branding/brand_mark.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
-import 'currency_picker_sheet.dart';
 import 'lock_screen_style_sheet.dart';
 import 'master_phrase_attempts_sheet.dart';
 import 'more_screen_layout_sheet.dart';
@@ -93,7 +92,7 @@ class SettingsScreen extends ConsumerWidget {
                       ),
                     ],
                   ),
-                  onTap: () => CurrencyPickerSheet.show(context, ref),
+                  onTap: () => context.push('/more/settings/currency'),
                 ),
                 Divider(height: 1, indent: 60, color: cs.outline),
                 SwitchListTile(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import '../../data/providers.dart';
 import 'currency_picker_sheet.dart';
 import 'lock_screen_style_sheet.dart';
 import 'master_phrase_attempts_sheet.dart';
+import 'more_screen_layout_sheet.dart';
 import 'pin_timeout_sheet.dart';
 import 'theme_picker_sheet.dart';
 
@@ -45,6 +46,7 @@ class SettingsScreen extends ConsumerWidget {
     final biometricEnabled = ref.watch(biometricEnabledProvider);
     final pinTimeoutMinutes = ref.watch(pinTimeoutMinutesProvider);
     final lockScreenStyle = ref.watch(lockScreenStyleProvider);
+    final moreScreenViewMode = ref.watch(moreScreenViewModeProvider);
     final hasMasterPhrase = ref.watch(hasMasterPhraseProvider);
     final masterPhraseAttemptThreshold = ref.watch(
       masterPhraseAttemptThresholdProvider,
@@ -145,6 +147,27 @@ class SettingsScreen extends ConsumerWidget {
                     color: cs.onSurfaceVariant,
                   ),
                   onTap: () => context.push('/more/settings/font'),
+                ),
+                Divider(height: 1, indent: 60, color: cs.outline),
+                ListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  leading: const Icon(Icons.dashboard_outlined),
+                  title: const Text('More screen layout'),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        MoreScreenLayoutSheet.label(moreScreenViewMode),
+                        style: trailingStyle,
+                      ),
+                      const SizedBox(width: 4),
+                      Icon(
+                        Icons.chevron_right_rounded,
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ],
+                  ),
+                  onTap: () => MoreScreenLayoutSheet.show(context),
                 ),
               ],
             ),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,7 +6,6 @@ import '../../core/branding/app_info.dart';
 import '../../core/branding/brand_mark.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
-import '../../data/tables.dart' show BudgetingMode;
 import 'lock_screen_style_sheet.dart';
 import 'master_phrase_attempts_sheet.dart';
 import 'more_screen_layout_sheet.dart';
@@ -47,7 +46,7 @@ class SettingsScreen extends ConsumerWidget {
     final pinTimeoutMinutes = ref.watch(pinTimeoutMinutesProvider);
     final lockScreenStyle = ref.watch(lockScreenStyleProvider);
     final moreScreenViewMode = ref.watch(moreScreenViewModeProvider);
-    final budgetingMode = ref.watch(budgetingModeProvider);
+    final rtaEnabled = ref.watch(rtaEnabledProvider);
     final hasMasterPhrase = ref.watch(hasMasterPhraseProvider);
     final masterPhraseAttemptThreshold = ref.watch(
       masterPhraseAttemptThresholdProvider,
@@ -195,53 +194,23 @@ class SettingsScreen extends ConsumerWidget {
           // ── Budgeting ──────────────────────────────────────────────────────
           _sectionLabel(context, 'Budgeting'),
           Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      const Icon(Icons.donut_large_outlined),
-                      const SizedBox(width: 12),
-                      Text(
-                        'Budgeting mode',
-                        style: theme.textTheme.titleSmall,
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    'Budgets sets a spending ceiling per category. Envelope '
-                    '(Ready to Assign) instead assigns money you actually '
-                    'have into categories first. Both keep working either '
-                    'way — this only picks which one the Dashboard and More '
-                    'hub show.',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: cs.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  SegmentedButton<BudgetingMode>(
-                    segments: const [
-                      ButtonSegment(
-                        value: BudgetingMode.budgets,
-                        label: Text('Budgets'),
-                        icon: Icon(Icons.donut_large_outlined),
-                      ),
-                      ButtonSegment(
-                        value: BudgetingMode.envelope,
-                        label: Text('Envelope'),
-                        icon: Icon(Icons.savings_outlined),
-                      ),
-                    ],
-                    selected: {budgetingMode},
-                    onSelectionChanged: (selection) => ref
-                        .read(dbProvider)
-                        .setBudgetingMode(selection.first),
-                  ),
-                ],
+            child: SwitchListTile(
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+              secondary: const Icon(Icons.savings_outlined),
+              title: const Text('Ready to Assign'),
+              subtitle: Text(
+                'Budget (a spending ceiling per category) is always on. '
+                'Ready to Assign adds an optional layer on top: assign the '
+                'money you actually have into categories first, pooled '
+                'across every on-budget account. Turning this on enrolls '
+                'every account at once — opt individual ones out from '
+                'their own Account Detail screen.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: cs.onSurfaceVariant,
+                ),
               ),
+              value: rtaEnabled,
+              onChanged: (v) => _onRtaToggle(context, ref, v),
             ),
           ),
 
@@ -1044,6 +1013,42 @@ class SettingsScreen extends ConsumerWidget {
         ..hideCurrentSnackBar()
         ..showSnackBar(SnackBar(content: Text("Couldn't clear data: $e")));
     }
+  }
+
+  /// Turning Ready to Assign on is a bulk action — every account joins the
+  /// shared pool at once — so it gets the same confirm-on-enable treatment
+  /// as the per-account on-budget toggle; turning it off needs no
+  /// confirmation, same as there.
+  Future<void> _onRtaToggle(
+    BuildContext context,
+    WidgetRef ref,
+    bool enabled,
+  ) async {
+    if (enabled) {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Turn on Ready to Assign?'),
+          content: const Text(
+            'Every account joins the shared pool right away. You can opt '
+            'individual accounts back out afterward from their own Account '
+            'Detail screen.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Turn on'),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+    }
+    await ref.read(dbProvider).setRtaEnabled(enabled);
   }
 
   Future<void> _toggleNotifications(WidgetRef ref, bool value) async {

--- a/lib/features/tags/tag_groups_screen.dart
+++ b/lib/features/tags/tag_groups_screen.dart
@@ -1,0 +1,458 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/widgets/error_view.dart';
+import '../../data/database.dart';
+import '../../data/providers.dart';
+
+/// Preset colours for a group. Same palette as a plain tag's — this is
+/// decorative only, not a money-direction signal.
+const _presetColors = <int>[
+  0xFF16A34A,
+  0xFF2563EB,
+  0xFFDC2626,
+  0xFFA855F7,
+  0xFFF97316,
+  0xFF0EA5E9,
+  0xFF78716C,
+  0xFFEC4899,
+];
+
+/// Manage tag groups: named bundles of [Tags] (e.g. "Work trip" = Travel +
+/// Meals + Client) picked as one unit from [TagPickerSheet] instead of
+/// hunting each tag down individually every time. See GitHub #92.
+class TagGroupsScreen extends ConsumerWidget {
+  const TagGroupsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final groupsAsync = ref.watch(tagGroupsProvider);
+    final tagsByGroup = ref.watch(tagGroupTagsByGroupProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tag groups')),
+      body: groupsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => const Center(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: InlineErrorView(message: "Couldn't load tag groups"),
+          ),
+        ),
+        data: (groups) {
+          return ListView(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 96),
+            children: [
+              if (groups.isEmpty)
+                _EmptyGroups(theme: theme)
+              else
+                Card(
+                  clipBehavior: Clip.antiAlias,
+                  child: Column(
+                    children: [
+                      for (var i = 0; i < groups.length; i++) ...[
+                        if (i > 0)
+                          Divider(
+                            height: 1,
+                            indent: 60,
+                            color: theme.colorScheme.outline,
+                          ),
+                        _GroupTile(
+                          group: groups[i],
+                          tags: tagsByGroup[groups[i].id] ?? const [],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              const SizedBox(height: 20),
+              Text(
+                'Picking a group from the tag picker selects every tag in it '
+                'at once. Deleting a group never touches the tags themselves '
+                'or anything already tagged.',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        tooltip: 'New group',
+        onPressed: () => _openGroupEditor(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _EmptyGroups extends StatelessWidget {
+  const _EmptyGroups({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 48, 24, 24),
+      child: Column(
+        children: [
+          Icon(
+            Icons.workspaces_outline,
+            size: 48,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'No tag groups yet — tap + to bundle a few tags together.',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GroupTile extends ConsumerWidget {
+  const _GroupTile({required this.group, required this.tags});
+
+  final TagGroupRow group;
+  final List<TagRow> tags;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final color = Color(group.colorValue);
+    final subtitle = tags.isEmpty
+        ? 'No tags yet'
+        : tags.map((t) => t.name).join(', ');
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      leading: Container(
+        width: 40,
+        height: 40,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(Icons.workspaces_outline, color: color, size: 20),
+      ),
+      title: Text(
+        group.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      onTap: () => _openGroupEditor(context, existing: group),
+      trailing: IconButton(
+        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+        tooltip: 'Delete',
+        visualDensity: VisualDensity.compact,
+        onPressed: () => _confirmDelete(context, ref, group),
+      ),
+    );
+  }
+}
+
+Future<void> _confirmDelete(
+  BuildContext context,
+  WidgetRef ref,
+  TagGroupRow group,
+) async {
+  final messenger = ScaffoldMessenger.of(context);
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text('Delete "${group.name}"?'),
+      content: const Text(
+        'The tags in this group, and anything already tagged with them, '
+        'are left exactly as they are.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(dialogContext).colorScheme.error,
+          ),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+
+  await ref.read(dbProvider).deleteTagGroup(group.id);
+  messenger
+    ..hideCurrentSnackBar()
+    ..showSnackBar(const SnackBar(content: Text('Tag group deleted')));
+}
+
+Future<void> _openGroupEditor(BuildContext context, {TagGroupRow? existing}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    showDragHandle: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+    ),
+    builder: (_) => _GroupEditorSheet(existing: existing),
+  );
+}
+
+class _GroupEditorSheet extends ConsumerStatefulWidget {
+  const _GroupEditorSheet({this.existing});
+
+  final TagGroupRow? existing;
+
+  @override
+  ConsumerState<_GroupEditorSheet> createState() => _GroupEditorSheetState();
+}
+
+class _GroupEditorSheetState extends ConsumerState<_GroupEditorSheet> {
+  late final TextEditingController _nameController;
+  late int _colorValue;
+  final Set<int> _selectedTagIds = {};
+  bool _loadingTags = true;
+  bool _submitting = false;
+
+  bool get _isEdit => widget.existing != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.existing?.name ?? '');
+    _colorValue = widget.existing?.colorValue ?? _presetColors.first;
+    if (_isEdit) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _loadTags());
+    } else {
+      _loadingTags = false;
+    }
+  }
+
+  Future<void> _loadTags() async {
+    final ids = await ref.read(dbProvider).tagIdsForGroup(widget.existing!.id);
+    if (!mounted) return;
+    setState(() {
+      _selectedTagIds.addAll(ids);
+      _loadingTags = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<void> _save() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      _showError('Give the group a name.');
+      return;
+    }
+
+    setState(() => _submitting = true);
+    final db = ref.read(dbProvider);
+    try {
+      int groupId;
+      if (_isEdit) {
+        groupId = widget.existing!.id;
+        await db.updateTagGroup(
+          id: groupId,
+          name: name,
+          colorValue: _colorValue,
+        );
+      } else {
+        groupId = await db.addTagGroup(name: name, colorValue: _colorValue);
+      }
+      await db.setTagGroupTags(groupId, _selectedTagIds);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      _showError('Could not save the group — that name may already be used.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tagsAsync = ref.watch(tagsProvider);
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.85,
+      ),
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 20,
+          right: 20,
+          bottom:
+              MediaQuery.of(context).padding.bottom +
+              MediaQuery.of(context).viewInsets.bottom +
+              20,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                _isEdit ? 'Edit group' : 'New group',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 20),
+              TextField(
+                controller: _nameController,
+                autofocus: !_isEdit,
+                textCapitalization: TextCapitalization.words,
+                maxLength: 30,
+                decoration: const InputDecoration(
+                  labelText: 'Name',
+                  hintText: 'e.g. Work trip, Tax deductible',
+                  counterText: '',
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'COLOUR',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.1,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 14,
+                runSpacing: 14,
+                children: [for (final c in _presetColors) _colorDot(theme, c)],
+              ),
+              const SizedBox(height: 20),
+              Text(
+                'TAGS',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 1.1,
+                ),
+              ),
+              const SizedBox(height: 12),
+              if (_loadingTags)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Center(child: CircularProgressIndicator()),
+                )
+              else
+                tagsAsync.when(
+                  loading: () => const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 16),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (e, _) => Text(
+                    'Could not load tags.\n$e',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  data: (tags) {
+                    if (tags.isEmpty) {
+                      return Text(
+                        'No tags yet — add one from More → Tags first.',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      );
+                    }
+                    return Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        for (final tag in tags)
+                          FilterChip(
+                            label: Text(tag.name),
+                            selected: _selectedTagIds.contains(tag.id),
+                            selectedColor: Color(
+                              tag.colorValue,
+                            ).withValues(alpha: 0.22),
+                            checkmarkColor: Color(tag.colorValue),
+                            onSelected: (v) => setState(() {
+                              if (v) {
+                                _selectedTagIds.add(tag.id);
+                              } else {
+                                _selectedTagIds.remove(tag.id);
+                              }
+                            }),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+              const SizedBox(height: 28),
+              FilledButton(
+                onPressed: _submitting ? null : _save,
+                child: _submitting
+                    ? const SizedBox(
+                        height: 22,
+                        width: 22,
+                        child: CircularProgressIndicator(strokeWidth: 2.4),
+                      )
+                    : const Text('Save'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _colorDot(ThemeData theme, int value) {
+    final selected = _colorValue == value;
+    return GestureDetector(
+      onTap: () => setState(() => _colorValue = value),
+      child: Container(
+        width: 40,
+        height: 40,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: Color(value),
+          shape: BoxShape.circle,
+          border: selected
+              ? Border.all(color: theme.colorScheme.onSurface, width: 2.5)
+              : null,
+        ),
+        child: selected
+            ? const Icon(Icons.check_rounded, color: Colors.white, size: 20)
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/features/tags/tag_picker_sheet.dart
+++ b/lib/features/tags/tag_picker_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../data/database.dart';
 import '../../data/providers.dart';
 
 /// Bottom sheet: pick any number of tags as toggleable filter chips. New tags
@@ -28,6 +29,8 @@ class _TagPickerSheetState extends ConsumerState<TagPickerSheet> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final tagsAsync = ref.watch(tagsProvider);
+    final groups = ref.watch(tagGroupsProvider).valueOrNull ?? const [];
+    final tagsByGroup = ref.watch(tagGroupTagsByGroupProvider);
 
     return ConstrainedBox(
       constraints: BoxConstraints(
@@ -53,6 +56,29 @@ class _TagPickerSheetState extends ConsumerState<TagPickerSheet> {
                 ],
               ),
             ),
+            if (groups.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final group in groups)
+                      _GroupChip(
+                        group: group,
+                        tags: tagsByGroup[group.id] ?? const [],
+                        selected: _selected,
+                        onToggle: (ids) => setState(() {
+                          if (ids.every(_selected.contains)) {
+                            _selected.removeAll(ids);
+                          } else {
+                            _selected.addAll(ids);
+                          }
+                        }),
+                      ),
+                  ],
+                ),
+              ),
             Flexible(
               child: tagsAsync.when(
                 loading: () => const Padding(
@@ -109,6 +135,41 @@ class _TagPickerSheetState extends ConsumerState<TagPickerSheet> {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// One tag group, offered as a single toggle: applies (or removes) every one
+/// of its member tags at once. `selected` shows a filled state once every
+/// tag it names is already picked, exactly like a group of individual
+/// [FilterChip]s would if tapped together.
+class _GroupChip extends StatelessWidget {
+  const _GroupChip({
+    required this.group,
+    required this.tags,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  final TagGroupRow group;
+  final List<TagRow> tags;
+  final Set<int> selected;
+  final ValueChanged<List<int>> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    if (tags.isEmpty) return const SizedBox.shrink();
+    final ids = tags.map((t) => t.id).toList();
+    final allSelected = ids.every(selected.contains);
+    final color = Color(group.colorValue);
+
+    return FilterChip(
+      avatar: Icon(Icons.workspaces_outline, size: 16, color: color),
+      label: Text(group.name),
+      selected: allSelected,
+      selectedColor: color.withValues(alpha: 0.22),
+      checkmarkColor: color,
+      onSelected: (_) => onToggle(ids),
     );
   }
 }

--- a/lib/features/tags/tags_screen.dart
+++ b/lib/features/tags/tags_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../core/widgets/error_view.dart';
 import '../../data/database.dart';
@@ -30,7 +31,16 @@ class TagsScreen extends ConsumerWidget {
     final tagsAsync = ref.watch(tagsProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Tags')),
+      appBar: AppBar(
+        title: const Text('Tags'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.workspaces_outline),
+            tooltip: 'Tag groups',
+            onPressed: () => context.push('/more/tags/groups'),
+          ),
+        ],
+      ),
       body: tagsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (_, _) => const Center(

--- a/lib/features/transactions/transaction_detail_screen.dart
+++ b/lib/features/transactions/transaction_detail_screen.dart
@@ -340,6 +340,13 @@ class _Hero extends StatelessWidget {
         (t.type == TxType.expense || t.type == TxType.personOut)
         ? -t.amount
         : t.amount;
+    // The row's own snapshotted currency — authoritative regardless of
+    // whether the account it was posted from could somehow have a
+    // different currency today (it can't, once posted, but the
+    // transaction is self-describing either way).
+    final currency = t.currencyCode == null
+        ? null
+        : currencyForCode(t.currencyCode!);
 
     final (String label, IconData icon) = switch (t.type) {
       TxType.income => ('Income', Icons.arrow_downward_rounded),
@@ -358,6 +365,7 @@ class _Hero extends StatelessWidget {
             displayAmount,
             signed: !isTransfer,
             color: color,
+            currency: currency,
             style: theme.textTheme.displaySmall?.copyWith(
               fontWeight: FontWeight.w700,
             ),
@@ -628,6 +636,9 @@ class _LinkedTxRow extends StatelessWidget {
         (linked.type == TxType.expense || linked.type == TxType.personOut)
         ? -linked.amount
         : linked.amount;
+    final currency = linked.currencyCode == null
+        ? null
+        : currencyForCode(linked.currencyCode!);
 
     return Row(
       children: [
@@ -651,6 +662,7 @@ class _LinkedTxRow extends StatelessWidget {
                     displayAmount,
                     signed: !isTransfer,
                     color: colorForTxType(linked.type),
+                    currency: currency,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/lib/features/transactions/transaction_detail_screen.dart
+++ b/lib/features/transactions/transaction_detail_screen.dart
@@ -33,6 +33,11 @@ class TransactionDetailScreen extends ConsumerWidget {
         title: const Text('Transaction'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.content_copy_outlined),
+            tooltip: 'Duplicate',
+            onPressed: () => context.push('/add?duplicate=$transactionId'),
+          ),
+          IconButton(
             icon: const Icon(Icons.edit_outlined),
             tooltip: 'Edit',
             onPressed: () => context.push('/add?id=$transactionId'),

--- a/lib/features/transactions/transaction_detail_screen.dart
+++ b/lib/features/transactions/transaction_detail_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/widgets/error_view.dart';
 import '../../core/widgets/money_text.dart';
@@ -174,6 +175,15 @@ class _TransactionView extends ConsumerWidget {
                   'Account',
                   _accountValue(context, t, accountMap),
                 ),
+                if (t.foreignCurrencyCode != null &&
+                    t.foreignAmount != null) ...[
+                  _divider(theme),
+                  _detailRow(
+                    context,
+                    'Original amount',
+                    _valueText(context, _foreignAmountValue(t)),
+                  ),
+                ],
                 if (t.type == TxType.expense) ...[
                   _divider(theme),
                   _detailRow(
@@ -922,4 +932,16 @@ Widget _accountValue(
       ],
     ],
   );
+}
+
+/// "9.99 USD (1 USD ≈ ₹83.08)" — [t.foreignAmount]/[t.foreignCurrencyCode]
+/// must both be non-null; the implied rate is recomputed from [t.amount],
+/// never stored (GitHub #85).
+String _foreignAmountValue(TransactionRow t) {
+  final currency = currencyForCode(t.foreignCurrencyCode);
+  final foreignAmount = t.foreignAmount!;
+  final formatted = MoneyFormat.forCurrency(foreignAmount, currency);
+  if (!foreignAmount.isPositive) return formatted;
+  final rate = Money.fromRupees(t.amount.rupees / foreignAmount.rupees);
+  return '$formatted (1 ${currency.code} ≈ ${MoneyFormat.symbol(rate)})';
 }

--- a/lib/features/transactions/transactions_screen.dart
+++ b/lib/features/transactions/transactions_screen.dart
@@ -801,6 +801,62 @@ class _ClusterHeader extends StatelessWidget {
 
 // ── One transaction, one card ────────────────────────────────────────────────
 
+/// Long-press quick actions: Duplicate ("publish another one" of this
+/// transaction with today's date, GitHub #92), Edit, Delete — the same three
+/// destinations already reachable one at a time from the detail screen, just
+/// surfaced without leaving the list.
+Future<void> _openQuickActions(
+  BuildContext context,
+  TransactionRow tx,
+  String title,
+  Future<void> Function(TransactionRow tx, String title) onDelete,
+) async {
+  final theme = Theme.of(context);
+  await showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (sheetContext) => SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.content_copy_outlined),
+            title: const Text('Duplicate'),
+            subtitle: const Text('Add a new transaction with these details'),
+            onTap: () {
+              Navigator.of(sheetContext).pop();
+              context.push('/add?duplicate=${tx.id}');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.edit_outlined),
+            title: const Text('Edit'),
+            onTap: () {
+              Navigator.of(sheetContext).pop();
+              context.push('/add?id=${tx.id}');
+            },
+          ),
+          ListTile(
+            leading: Icon(
+              Icons.delete_outline_rounded,
+              color: theme.colorScheme.error,
+            ),
+            title: Text(
+              'Delete',
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+            onTap: () {
+              Navigator.of(sheetContext).pop();
+              onDelete(tx, title);
+            },
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 class _TxCard extends StatelessWidget {
   const _TxCard({
     required this.tx,
@@ -900,6 +956,7 @@ class _TxCard extends StatelessWidget {
             clipBehavior: Clip.antiAlias,
             child: InkWell(
               onTap: () => context.push('/transaction/${tx.id}'),
+              onLongPress: () => _openQuickActions(context, tx, title, onDelete),
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
                 child: Row(

--- a/lib/features/transactions/transactions_screen.dart
+++ b/lib/features/transactions/transactions_screen.dart
@@ -5,10 +5,12 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../core/app_icons.dart';
+import '../../core/currency.dart';
 import '../../core/money.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/widgets/money_text.dart';
 import '../../core/widgets/motion.dart';
+import '../../data/currency_conversion.dart';
 import '../../data/database.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart';
@@ -432,12 +434,14 @@ class _TransactionsScreenState extends ConsumerState<TransactionsScreen> {
     final entries = <_Entry>[];
     for (final day in days) {
       final rows = groups[day]!;
+      // Same reasoning as _SummaryStrip: fold baseAmount, since a day's
+      // rows can span accounts in different currencies.
       var net = const Money.zero();
       for (final tx in rows) {
         if (tx.type == TxType.income) {
-          net += tx.amount;
+          net += tx.baseAmount;
         } else if (tx.type == TxType.expense) {
-          net -= tx.amount;
+          net -= tx.baseAmount;
         }
       }
       entries.add(_HeaderEntry(day, net, rows.length));
@@ -545,11 +549,15 @@ class _SummaryStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     if (txns.isEmpty) return const SizedBox.shrink();
 
+    // Folds each transaction's parent-currency baseAmount, not its raw
+    // native amount — this strip mixes transactions from every account, so
+    // a foreign-currency one must be converted first or it silently
+    // corrupts the total (see TransactionBaseValue).
     var income = const Money.zero();
     var expense = const Money.zero();
     for (final tx in txns) {
-      if (tx.type == TxType.income) income += tx.amount;
-      if (tx.type == TxType.expense) expense += tx.amount;
+      if (tx.type == TxType.income) income += tx.baseAmount;
+      if (tx.type == TxType.expense) expense += tx.baseAmount;
     }
 
     return Padding(
@@ -925,6 +933,14 @@ class _TxCard extends StatelessWidget {
         (tx.type == TxType.expense || tx.type == TxType.personOut)
         ? -tx.amount
         : tx.amount;
+    // The source account's own currency — this row always shows tx.amount,
+    // which is native to accountId regardless of type (a transfer's amount
+    // is its source leg). Doesn't follow a debit card to its linked bank
+    // here, unlike account_detail_screen's fuller resolution — this list
+    // only has the single AccountRow, not the whole map, to check with.
+    final displayCurrency = account?.currencyCode == null
+        ? null
+        : currencyForCode(account!.currencyCode!);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
@@ -1043,6 +1059,7 @@ class _TxCard extends StatelessWidget {
                               displayAmount,
                               signed: !isTransfer,
                               color: colorForTxType(tx.type),
+                              currency: displayCurrency,
                               style: theme.textTheme.titleMedium?.copyWith(
                                 fontWeight: FontWeight.w700,
                               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -595,18 +595,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   media_store_plus:
     dependency: "direct main"
     description:
@@ -619,10 +619,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -944,10 +944,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.7"
   timezone:
     dependency: "direct main"
     description:
@@ -1040,10 +1040,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1117,5 +1117,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0-0 <4.0.0"
+  dart: ">=3.10.8 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -595,18 +595,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   media_store_plus:
     dependency: "direct main"
     description:
@@ -619,10 +619,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -944,10 +944,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.12"
   timezone:
     dependency: "direct main"
     description:
@@ -1040,10 +1040,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -1117,5 +1117,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.8 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # `AppInfo.version` / `AppInfo.buildNumber` mirror this line so the About screen
 # can show it without pulling in a platform plugin. `test/branding_test.dart`
 # parses this file and fails if the two ever disagree.
-version: 1.5.1+17
+version: 1.6.0+18
 
 environment:
   sdk: ^3.10.8

--- a/test/account_currency_test.dart
+++ b/test/account_currency_test.dart
@@ -1,0 +1,85 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<int> addBank({String? currencyCode}) => db.addAccount(
+        name: 'Bank',
+        type: AccountType.bank,
+        colorValue: 0xFF000000,
+        iconKey: 'bank',
+        openingBalance: const Money(10000),
+        currencyCode: currencyCode,
+      );
+
+  test('addAccount defaults to null (parent currency)', () async {
+    final id = await addBank();
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    expect(row.currencyCode, isNull);
+  });
+
+  test('addAccount stores an explicit foreign currency', () async {
+    final id = await addBank(currencyCode: 'USD');
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(id))).getSingle();
+    expect(row.currencyCode, 'USD');
+  });
+
+  test('a debit card never gets its own currency, even if one is passed', () async {
+    final bankId = await addBank(currencyCode: 'USD');
+    final cardId = await db.addAccount(
+      name: 'Debit card',
+      type: AccountType.card,
+      cardKind: CardKind.debit,
+      linkedAccountId: bankId,
+      colorValue: 0xFF000000,
+      iconKey: 'card',
+      openingBalance: const Money.zero(),
+      currencyCode: 'EUR',
+    );
+    final row = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(cardId))).getSingle();
+    expect(row.currencyCode, isNull);
+  });
+
+  group('setAccountCurrency', () {
+    test('changes the currency of an untouched account', () async {
+      final id = await addBank();
+      await db.setAccountCurrency(id, 'USD');
+      final row = await (db.select(
+        db.accounts,
+      )..where((a) => a.id.equals(id))).getSingle();
+      expect(row.currencyCode, 'USD');
+    });
+
+    test('locks once the account has a transaction', () async {
+      final id = await addBank();
+      await db.addTransaction(
+        type: TxType.income,
+        amount: const Money(5000),
+        accountId: id,
+        date: DateTime(2026, 1, 1),
+      );
+
+      expect(
+        () => db.setAccountCurrency(id, 'USD'),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an unknown currency code', () async {
+      final id = await addBank();
+      expect(() => db.setAccountCurrency(id, 'ZZZ'), throwsArgumentError);
+    });
+  });
+}

--- a/test/account_movement_test.dart
+++ b/test/account_movement_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+TransactionRow _transfer({
+  required int accountId,
+  required int toAccountId,
+  required Money amount,
+  Money? toAmount,
+}) => TransactionRow(
+  id: 1,
+  type: TxType.transfer,
+  amount: amount,
+  accountId: accountId,
+  toAccountId: toAccountId,
+  date: DateTime(2026, 1, 1),
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+  needsAmountReview: false,
+  toAmount: toAmount,
+);
+
+void main() {
+  group('accountMovement', () {
+    test('a same-currency transfer credits the destination with the full '
+        'amount (toAmount null)', () {
+      final tx = _transfer(accountId: 1, toAccountId: 2, amount: const Money(50000));
+      expect(accountMovement(tx, {1}), const Money(-50000));
+      expect(accountMovement(tx, {2}), const Money(50000));
+    });
+
+    test('a cross-currency transfer credits the destination with toAmount, '
+        'not the source-currency amount', () {
+      final tx = _transfer(
+        accountId: 1,
+        toAccountId: 2,
+        amount: const Money(830000), // ₹8300.00 left the source
+        toAmount: const Money(10000), // $100.00 landed in the destination
+      );
+      expect(accountMovement(tx, {1}), const Money(-830000));
+      expect(accountMovement(tx, {2}), const Money(10000));
+    });
+  });
+}

--- a/test/add_account_currency_test.dart
+++ b/test/add_account_currency_test.dart
@@ -1,0 +1,106 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/data/tables.dart';
+import 'package:xpenc/features/accounts/add_account_sheet.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> openSheet(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showAddAccountSheet(context),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump();
+    await tester.tap(find.text('open'));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets(
+    'picking a currency on the field updates its displayed value',
+    (tester) async {
+      await openSheet(tester);
+
+      // Bounded pumps throughout, never pumpAndSettle — CurrencyPickerSheet
+      // watches currencyProvider, which rides a live Drift stream (same
+      // rule as every other DB-backed screen test in this suite).
+      expect(find.textContaining('INR'), findsOneWidget);
+
+      await tester.tap(find.text('Currency'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      await tester.enterText(find.byType(TextField).last, 'USD');
+      await tester.pump();
+
+      await tester.tap(find.text('US Dollar').last);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.textContaining('USD'), findsOneWidget);
+      expect(find.textContaining('INR'), findsNothing);
+
+      await unmount(tester);
+    },
+  );
+
+  testWidgets('a debit card never shows a currency field', (tester) async {
+    await db.addAccount(
+      name: 'Bank',
+      type: AccountType.bank,
+      colorValue: 0xFF000000,
+      iconKey: 'bank',
+      openingBalance: const Money.zero(),
+    );
+
+    await openSheet(tester);
+
+    await tester.ensureVisible(find.text('Card'));
+    await tester.pump();
+    await tester.tap(find.text('Card'));
+    await tester.pump();
+    await tester.tap(find.text('Debit'));
+    await tester.pump();
+
+    expect(find.text('Currency'), findsNothing);
+
+    await unmount(tester);
+  });
+}

--- a/test/add_transaction_currency_test.dart
+++ b/test/add_transaction_currency_test.dart
@@ -1,0 +1,117 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/data/tables.dart';
+import 'package:xpenc/features/add_transaction/add_transaction_screen.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester, {TxType? initialType}) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: AddTransactionScreen(initialType: initialType),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  /// Opens the "Paid via"/account picker and taps the account named [name].
+  Future<void> pickAccount(WidgetTester tester, String name) async {
+    await tester.tap(find.text('Select account').first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text(name));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  testWidgets(
+    'the hero amount renders in the selected account\'s own currency',
+    (tester) async {
+      await db.addAccount(
+        name: 'Travel',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+        currencyCode: 'USD',
+      );
+
+      await pump(tester, initialType: TxType.expense);
+      await pickAccount(tester, 'Travel');
+
+      final amountText = tester.widget<Text>(
+        find.byKey(const Key('amountDisplay')),
+      );
+      expect(amountText.data, contains(r'$'));
+      expect(amountText.data, isNot(contains('₹')));
+
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    "the #85 'Foreign currency' toggle is hidden once the account has its "
+    'own currency',
+    (tester) async {
+      await db.addAccount(
+        name: 'Home wallet',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+      await db.addAccount(
+        name: 'Travel',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+        currencyCode: 'USD',
+      );
+
+      await pump(tester, initialType: TxType.expense);
+
+      await pickAccount(tester, 'Home wallet');
+      expect(find.text('Foreign currency'), findsOneWidget);
+
+      await tester.tap(find.text('Home wallet'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.tap(find.text('Travel'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('Foreign currency'), findsNothing);
+
+      await unmount(tester);
+    },
+  );
+}

--- a/test/add_transaction_default_account_test.dart
+++ b/test/add_transaction_default_account_test.dart
@@ -1,0 +1,104 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/data/tables.dart';
+import 'package:xpenc/features/add_transaction/add_transaction_screen.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester, {TxType? initialType}) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: AddTransactionScreen(initialType: initialType),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets(
+    'a brand-new transaction pre-selects the most recently used account',
+    (tester) async {
+      final walletId = await db.addAccount(
+        name: 'Wallet',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+      final bankId = await db.addAccount(
+        name: 'Bank',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+
+      // Oldest first, so "Bank" is the most recent by date.
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(500),
+        accountId: walletId,
+        date: DateTime(2026, 1, 1),
+      );
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(700),
+        accountId: bankId,
+        date: DateTime(2026, 1, 2),
+      );
+
+      await pump(tester, initialType: TxType.expense);
+
+      expect(find.text('Bank'), findsOneWidget);
+      expect(find.text('Select account'), findsNothing);
+
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'with no prior transactions, the account picker still asks the user to select one',
+    (tester) async {
+      await db.addAccount(
+        name: 'Wallet',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+      );
+
+      await pump(tester, initialType: TxType.expense);
+
+      expect(find.text('Select account'), findsWidgets);
+
+      await unmount(tester);
+    },
+  );
+}

--- a/test/auto_backup_test.dart
+++ b/test/auto_backup_test.dart
@@ -89,6 +89,7 @@ void main() {
       moreScreenViewMode: MoreScreenViewMode.list,
       frequentIconKeys: '',
       budgetingMode: BudgetingMode.budgets,
+      rtaEnabled: false,
     );
 
     final now = DateTime(2026, 8, 5, 12);

--- a/test/auto_backup_test.dart
+++ b/test/auto_backup_test.dart
@@ -87,6 +87,7 @@ void main() {
       lockScreenStyle: LockScreenStyle.classic,
       screenshotReminderEnabled: false,
       moreScreenViewMode: MoreScreenViewMode.list,
+      frequentIconKeys: '',
     );
 
     final now = DateTime(2026, 8, 5, 12);

--- a/test/auto_backup_test.dart
+++ b/test/auto_backup_test.dart
@@ -86,6 +86,7 @@ void main() {
       revolutEnabled: true,
       lockScreenStyle: LockScreenStyle.classic,
       screenshotReminderEnabled: false,
+      moreScreenViewMode: MoreScreenViewMode.list,
     );
 
     final now = DateTime(2026, 8, 5, 12);

--- a/test/auto_backup_test.dart
+++ b/test/auto_backup_test.dart
@@ -88,6 +88,7 @@ void main() {
       screenshotReminderEnabled: false,
       moreScreenViewMode: MoreScreenViewMode.list,
       frequentIconKeys: '',
+      budgetingMode: BudgetingMode.budgets,
     );
 
     final now = DateTime(2026, 8, 5, 12);

--- a/test/backup_currency_test.dart
+++ b/test/backup_currency_test.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+/// CurrencyRates is a brand-new table (not present when exportAll/importAll
+/// were first written) — this guards it actually rides along in a backup,
+/// same as every other table.
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<({int inrAccount, int usdAccount, int txId})> seedCurrencyData() async {
+    final inrAccount = (await db.watchAccounts().first).first.id;
+    final usdAccount = await db.addAccount(
+      name: 'Travel',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money.zero(),
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+    final txId = await db.addTransaction(
+      type: TxType.expense,
+      amount: const Money(1000),
+      accountId: usdAccount,
+      date: DateTime(2026, 2, 1),
+    );
+    return (inrAccount: inrAccount, usdAccount: usdAccount, txId: txId);
+  }
+
+  test('exportAll includes currencyRates and the new account/transaction '
+      'currency columns', () async {
+    await seedCurrencyData();
+
+    final dump = await db.exportAll();
+
+    expect(dump['currencyRates'], isA<List>());
+    expect((dump['currencyRates'] as List), hasLength(1));
+    final rateRow = (dump['currencyRates'] as List).first as Map;
+    expect(rateRow['currency_code'], 'USD');
+    expect(rateRow['rate_to_base_micros'], 83000000);
+
+    final accountRows = dump['accounts'] as List;
+    final usdAccountRow = accountRows
+        .cast<Map>()
+        .firstWhere((a) => a['currency_code'] == 'USD');
+    expect(usdAccountRow, isNotNull);
+
+    final txRows = dump['transactions'] as List;
+    final usdTxRow = txRows
+        .cast<Map>()
+        .firstWhere((t) => t['currency_code'] == 'USD');
+    expect(usdTxRow['fx_rate_to_base_micros'], 83000000);
+  });
+
+  test('a fresh database restores currencyRates and the currency columns '
+      'from a backup', () async {
+    final seeded = await seedCurrencyData();
+    final dump =
+        jsonDecode(jsonEncode(await db.exportAll())) as Map<String, dynamic>;
+
+    final fresh = AppDatabase(NativeDatabase.memory());
+    addTearDown(fresh.close);
+    await fresh.importAll(dump);
+
+    final rate = await fresh.latestRate('USD');
+    expect(rate, isNotNull);
+    expect(rate!.rateToBaseMicros, 83000000);
+
+    final usdAccount = await (fresh.select(
+      fresh.accounts,
+    )..where((a) => a.id.equals(seeded.usdAccount))).getSingle();
+    expect(usdAccount.currencyCode, 'USD');
+
+    final tx = await (fresh.select(
+      fresh.transactions,
+    )..where((t) => t.id.equals(seeded.txId))).getSingle();
+    expect(tx.currencyCode, 'USD');
+    expect(tx.fxRateToBaseMicros, 83000000);
+  });
+
+  test('clearAllData wipes currencyRates along with everything else', () async {
+    await seedCurrencyData();
+    await db.clearAllData();
+
+    final rates = await db.watchCurrentRates().first;
+    expect(rates, isEmpty);
+  });
+}

--- a/test/backup_test.dart
+++ b/test/backup_test.dart
@@ -257,6 +257,14 @@ void main() {
         tagIds: {tagId},
       );
 
+      // A tag group bundling that same tag (#92) — its own join table
+      // (`tagGroupTags`), separate from both tag joins above.
+      final tagGroupId = await db.addTagGroup(
+        name: 'Work trip',
+        colorValue: 0xFF0000FF,
+      );
+      await db.setTagGroupTags(tagGroupId, {tagId});
+
       // A manual link between two transactions (#64).
       final incomeTx = (await db.watchTransactions().first)
           .firstWhere((t) => t.type == TxType.income);
@@ -388,6 +396,15 @@ void main() {
         await fresh.tagIdsForRecurringRule(freshSpotify.id),
         hasLength(1),
         reason: 'the preset tag on a recurring rule must survive too',
+      );
+
+      // Tag group bundling that tag (tagGroupTags, #92).
+      final freshGroup = (await fresh.watchTagGroups().first)
+          .firstWhere((g) => g.name == 'Work trip');
+      expect(
+        await fresh.tagIdsForGroup(freshGroup.id),
+        hasLength(1),
+        reason: 'the tag link on the group must survive too',
       );
 
       // Manual link between two transactions (transactionLinks, #64).

--- a/test/backup_test.dart
+++ b/test/backup_test.dart
@@ -480,8 +480,11 @@ void main() {
       final csv = await db.transactionsCsv();
       final lines = csv.trim().split('\n');
 
-      expect(lines.first,
-          'Date,Type,Amount,Account,To Account,Category,Person,Note');
+      expect(
+        lines.first,
+        'Date,Type,Amount,Account,To Account,Category,Person,Note,'
+        'Foreign Amount,Foreign Currency',
+      );
       // header + 3 manual transactions + the personOut row for lending Ram 500
       expect(lines, hasLength(5));
 

--- a/test/budget_radial_chart_test.dart
+++ b/test/budget_radial_chart_test.dart
@@ -63,6 +63,7 @@ void main() {
                       budget: budget,
                       spent: spent,
                       color: categoryColor,
+                      fundingColor: null,
                     ),
                   ],
                 ),

--- a/test/category_templates_test.dart
+++ b/test/category_templates_test.dart
@@ -1,0 +1,167 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+/// Category templates (GitHub #101): save the current category structure as
+/// a named snapshot, then switch between saved structures. Switching must
+/// never touch a transaction — only which `Categories` rows are archived vs.
+/// active, exactly like a manual archive.
+void main() {
+  late AppDatabase db;
+
+  // Fresh databases start pre-seeded with default categories (Salary, Rent,
+  // …). Archive them so each test's active set is exactly what it creates —
+  // template save/apply is about set membership, and asserting against a mix
+  // of test data and seed data would make every expectation unreadable.
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    for (final c in await db.watchAllCategories().first) {
+      await db.archiveCategory(c.id);
+    }
+  });
+  tearDown(() => db.close());
+
+  Future<int> addExpense(String name, {int? parentId}) => db.addCategory(
+    name: name,
+    kind: CategoryKind.expense,
+    colorValue: 0xFF000000,
+    iconKey: 'other',
+    parentId: parentId,
+  );
+
+  Future<List<CategoryRow>> activeCategories() async =>
+      (await db.watchAllCategories().first)
+        ..sort((a, b) => a.id.compareTo(b.id));
+
+  group('saveCategoriesAsTemplate', () {
+    test('snapshots active parents and children', () async {
+      final food = await addExpense('Food');
+      await addExpense('Groceries', parentId: food);
+      await addExpense('Transport');
+
+      final templateId = await db.saveCategoriesAsTemplate('My structure');
+      final items = await db.watchCategoryTemplateItems(templateId).first;
+
+      expect(items.length, 3);
+      final groceriesItem = items.firstWhere((i) => i.name == 'Groceries');
+      final foodItem = items.firstWhere((i) => i.name == 'Food');
+      expect(groceriesItem.parentItemId, foodItem.id);
+      expect(
+        items.firstWhere((i) => i.name == 'Transport').parentItemId,
+        isNull,
+      );
+    });
+
+    test('skips archived categories', () async {
+      final food = await addExpense('Food');
+      await db.archiveCategory(food);
+      await addExpense('Transport');
+
+      final templateId = await db.saveCategoriesAsTemplate('Partial');
+      final items = await db.watchCategoryTemplateItems(templateId).first;
+      expect(items.map((i) => i.name), ['Transport']);
+    });
+  });
+
+  group('applyCategoryTemplate', () {
+    test('creates categories the template has but the app does not', () async {
+      final templateId = await db.saveCategoriesAsTemplate('Empty baseline');
+      // Hand-craft a template with two categories, one nested, since the
+      // live DB starts out empty of custom categories in this test.
+      await db.deleteCategoryTemplate(templateId);
+      final food = await addExpense('Food');
+      await addExpense('Groceries', parentId: food);
+      final richId = await db.saveCategoriesAsTemplate('Rich');
+      await db.archiveCategory(food); // back to empty active set
+
+      await db.applyCategoryTemplate(richId);
+      final active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food', 'Groceries'});
+      final newFood = active.firstWhere((c) => c.name == 'Food');
+      final newGroceries = active.firstWhere((c) => c.name == 'Groceries');
+      expect(newGroceries.parentId, newFood.id);
+    });
+
+    test('archives a live category the target template does not have, '
+        'keeping every transaction that used it', () async {
+      // A template with just "Food" — snapshotted, then archived away
+      // again so the live app doesn't have it yet.
+      await addExpense('Food');
+      final foodTemplateId = await db.saveCategoriesAsTemplate('Food only');
+      await db.archiveCategory((await activeCategories()).single.id);
+
+      // The live app actually uses "Transport", with a real transaction.
+      final transport = await addExpense('Transport');
+      final cashId = (await db.watchAccounts().first)
+          .firstWhere((a) => a.type == AccountType.cash)
+          .id;
+      final txId = await db.addTransaction(
+        type: TxType.expense,
+        accountId: cashId,
+        amount: const Money(500),
+        date: DateTime(2026, 9, 1),
+        categoryId: transport,
+      );
+
+      await db.applyCategoryTemplate(foodTemplateId);
+
+      final active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+
+      final tx = (await db.watchTransactions().first).firstWhere(
+        (t) => t.id == txId,
+      );
+      expect(tx.categoryId, transport);
+      final archivedTransport = await db.categoryById(transport);
+      expect(archivedTransport!.isArchived, isTrue);
+    });
+
+    test('switching back and forth never duplicates categories', () async {
+      final food = await addExpense('Food');
+      final templateA = await db.saveCategoriesAsTemplate('A');
+      await db.archiveCategory(food);
+      await addExpense('Transport');
+      final templateB = await db.saveCategoriesAsTemplate('B');
+
+      await db.applyCategoryTemplate(templateA);
+      var active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+
+      await db.applyCategoryTemplate(templateB);
+      active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Transport'});
+
+      // Switch back to A: Food should be the *same row*, reactivated, not a
+      // freshly created duplicate.
+      await db.applyCategoryTemplate(templateA);
+      active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+      expect(active.single.id, food);
+    });
+
+    test('refuses to apply an empty template', () async {
+      final templateId = await db.saveCategoriesAsTemplate('Empty');
+      expect(() => db.applyCategoryTemplate(templateId), throwsArgumentError);
+    });
+  });
+
+  group('template management', () {
+    test('renameCategoryTemplate updates the name', () async {
+      final id = await db.saveCategoriesAsTemplate('Old name');
+      await db.renameCategoryTemplate(id, 'New name');
+      final templates = await db.watchCategoryTemplates().first;
+      expect(templates.single.name, 'New name');
+    });
+
+    test('deleteCategoryTemplate removes the template and its items', () async {
+      await addExpense('Food');
+      final id = await db.saveCategoriesAsTemplate('Doomed');
+      await db.deleteCategoryTemplate(id);
+
+      expect(await db.watchCategoryTemplates().first, isEmpty);
+      expect(await db.watchCategoryTemplateItems(id).first, isEmpty);
+    });
+  });
+}

--- a/test/cross_currency_balance_test.dart
+++ b/test/cross_currency_balance_test.dart
@@ -1,0 +1,91 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('a cross-currency transfer credits the destination in its own currency',
+      () async {
+    final inrAcct = await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000), // ₹10,000.00
+    );
+    final usdAcct = await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money.zero(),
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000, // 1 USD = 83 INR
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+
+    await db.addTransaction(
+      type: TxType.transfer,
+      amount: const Money(830000), // ₹8300.00 leaves the INR wallet
+      accountId: inrAcct,
+      toAccountId: usdAcct,
+      date: DateTime(2026, 2, 1),
+    );
+
+    final inrRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(inrAcct))).getSingle();
+    final usdRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(usdAcct))).getSingle();
+
+    expect(inrRow.currentBalance, const Money(170000)); // ₹1700.00 left
+    expect(usdRow.currentBalance, const Money(10000)); // $100.00 credited
+  });
+
+  test('recalculateBalances rebuilds a cross-currency transfer identically',
+      () async {
+    final inrAcct = await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000),
+    );
+    final usdAcct = await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money.zero(),
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+    await db.addTransaction(
+      type: TxType.transfer,
+      amount: const Money(830000),
+      accountId: inrAcct,
+      toAccountId: usdAcct,
+      date: DateTime(2026, 2, 1),
+    );
+
+    await db.recalculateBalances();
+
+    final usdRow = await (db.select(
+      db.accounts,
+    )..where((a) => a.id.equals(usdAcct))).getSingle();
+    expect(usdRow.currentBalance, const Money(10000));
+  });
+}

--- a/test/currency_conversion_test.dart
+++ b/test/currency_conversion_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/currency_conversion.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+void main() {
+  group('convertUsingRate', () {
+    test('1 USD = 83.12 INR converts \$10.00 to ₹831.20', () {
+      final converted = convertUsingRate(
+        const Money(1000), // $10.00
+        83120000, // 83.12 scaled by currencyRateScale
+      );
+      expect(converted, const Money(83120)); // ₹831.20
+    });
+
+    test('a 1:1 rate is a no-op', () {
+      final converted = convertUsingRate(const Money(50000), 1000000);
+      expect(converted, const Money(50000));
+    });
+  });
+
+  group('TransactionBaseValue.baseAmount', () {
+    test('a parent-currency transaction (null currencyCode) is unconverted', () {
+      final row = TransactionRow(
+        id: 1,
+        type: TxType.expense,
+        amount: const Money(50000),
+        accountId: 1,
+        date: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+        needsAmountReview: false,
+      );
+      expect(row.baseAmount, const Money(50000));
+    });
+
+    test('a foreign-currency transaction converts using its snapshotted rate', () {
+      final row = TransactionRow(
+        id: 1,
+        type: TxType.expense,
+        amount: const Money(1000), // $10.00
+        accountId: 1,
+        date: DateTime(2026, 1, 1),
+        createdAt: DateTime(2026, 1, 1),
+        updatedAt: DateTime(2026, 1, 1),
+        needsAmountReview: false,
+        currencyCode: 'USD',
+        fxRateToBaseMicros: 83120000,
+      );
+      expect(row.baseAmount, const Money(83120)); // ₹831.20
+    });
+  });
+}

--- a/test/currency_rates_db_test.dart
+++ b/test/currency_rates_db_test.dart
@@ -1,0 +1,102 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/data/database.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  group('addCurrencyRate', () {
+    test('rejects an unknown currency code', () {
+      expect(
+        () => db.addCurrencyRate(
+          currencyCode: 'ZZZ',
+          rateToBaseMicros: 83000000,
+          effectiveAt: DateTime(2026, 1, 1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a non-positive rate', () {
+      expect(
+        () => db.addCurrencyRate(
+          currencyCode: 'USD',
+          rateToBaseMicros: 0,
+          effectiveAt: DateTime(2026, 1, 1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts a valid rate', () async {
+      final id = await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 83000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      expect(id, greaterThan(0));
+    });
+  });
+
+  group('latestRate', () {
+    test('returns null when the currency has no rate yet', () async {
+      final rate = await db.latestRate('USD');
+      expect(rate, isNull);
+    });
+
+    test('resolves the most recent rate at or before "asOf"', () async {
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 80000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 85000000,
+        effectiveAt: DateTime(2026, 6, 1),
+      );
+
+      final beforeBoth = await db.latestRate(
+        'USD',
+        asOf: DateTime(2025, 12, 1),
+      );
+      expect(beforeBoth, isNull);
+
+      final betweenThem = await db.latestRate(
+        'USD',
+        asOf: DateTime(2026, 3, 1),
+      );
+      expect(betweenThem!.rateToBaseMicros, 80000000);
+
+      final afterBoth = await db.latestRate('USD', asOf: DateTime(2026, 12, 1));
+      expect(afterBoth!.rateToBaseMicros, 85000000);
+    });
+  });
+
+  group('watchCurrentRates', () {
+    test('emits one row per currency, the newest rate for each', () async {
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 80000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 85000000,
+        effectiveAt: DateTime(2026, 6, 1),
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'EUR',
+        rateToBaseMicros: 90000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+
+      final rows = await db.watchCurrentRates().first;
+      expect(rows, hasLength(2));
+      final usd = rows.firstWhere((r) => r.currencyCode == 'USD');
+      expect(usd.rateToBaseMicros, 85000000);
+    });
+  });
+}

--- a/test/currency_settings_screen_test.dart
+++ b/test/currency_settings_screen_test.dart
@@ -1,0 +1,97 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/features/settings/currency_settings_screen.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: const CurrencySettingsScreen(),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 200)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets('renders the parent currency and an empty rate list', (
+    tester,
+  ) async {
+    await pump(tester);
+
+    expect(find.text('Currency'), findsWidgets);
+    expect(find.text('PARENT CURRENCY'), findsOneWidget);
+    expect(find.textContaining('INR'), findsWidgets);
+    expect(
+      find.textContaining("No exchange rates yet"),
+      findsOneWidget,
+    );
+
+    await unmount(tester);
+  });
+
+  testWidgets('shows an existing rate in the list', (tester) async {
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+
+    await pump(tester);
+
+    expect(find.textContaining('USD'), findsWidgets);
+    expect(find.textContaining('83'), findsWidgets);
+
+    await unmount(tester);
+  });
+
+  testWidgets('adding a currency and its first rate shows up in the list', (
+    tester,
+  ) async {
+    await pump(tester);
+
+    await tester.tap(find.text('Add a currency'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, 'USD');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('US Dollar').last);
+    await tester.pumpAndSettle();
+
+    final rateField = find.widgetWithText(TextField, 'Rate');
+    expect(rateField, findsOneWidget);
+    await tester.enterText(rateField, '83');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('USD'), findsWidgets);
+
+    await unmount(tester);
+  });
+}

--- a/test/currency_test.dart
+++ b/test/currency_test.dart
@@ -81,6 +81,27 @@ void main() {
       expect(MoneyFormat.signed(const Money(50000)), startsWith('+'));
       expect(MoneyFormat.signed(const Money(50000)), isNot(contains(r'$')));
     });
+
+    test('symbolIn formats against an explicit currency, ignoring the '
+        'globally configured one', () {
+      MoneyFormat.configure(
+        currency: currencyForCode('INR'),
+        showSymbol: true,
+      );
+      final out = MoneyFormat.symbolIn(const Money(125050), currencyForCode('USD'));
+      expect(out, contains(r'$'));
+      expect(out, contains('1,250.50'));
+      expect(out, isNot(contains('₹')));
+    });
+
+    test('symbolIn respects a zero-decimal currency', () {
+      final out = MoneyFormat.symbolIn(
+        const Money(125000),
+        currencyForCode('JPY'),
+      );
+      expect(out, contains('¥'));
+      expect(out, isNot(contains('.00')));
+    });
   });
 
   group('settings persistence', () {

--- a/test/database_test.dart
+++ b/test/database_test.dart
@@ -1661,6 +1661,140 @@ void main() {
       );
     });
 
+    group('G&L — funding a goal or paying a loan', () {
+      test(
+        'posts a transfer, not an expense, and moves both balances',
+        () async {
+          final cash = await cashId();
+          final goal = await db.addGoal(
+            name: 'Emergency Fund',
+            targetAmount: Money.fromRupees(50000),
+            colorValue: 0,
+            iconKey: 'savings',
+          );
+          final today = DateTime(2026, 7, 1);
+
+          final ruleId = await db.addRecurringRule(
+            name: 'Fund emergency savings',
+            kind: CategoryKind.expense,
+            amount: Money.fromRupees(5000),
+            accountId: cash,
+            toAccountId: goal,
+            frequency: RecurringFrequency.monthly,
+            startsOn: today,
+          );
+
+          final posted = await db.runDueRecurringRules(now: today);
+          expect(posted, 1);
+          expect(await balanceOf(cash), Money.fromRupees(-5000));
+          expect(await balanceOf(goal), Money.fromRupees(5000));
+
+          final tx = (await db.watchTransactions().first).single;
+          expect(tx.type, TxType.transfer);
+          expect(tx.toAccountId, goal);
+          expect(tx.recurringRuleId, ruleId);
+          expect(tx.payee, isNull);
+        },
+      );
+
+      test('a category is optional — omitting one leaves it null', () async {
+        final cash = await cashId();
+        final goal = await db.addGoal(
+          name: 'Emergency Fund',
+          targetAmount: Money.fromRupees(50000),
+          colorValue: 0,
+          iconKey: 'savings',
+        );
+
+        await db.addRecurringRule(
+          name: 'Fund emergency savings',
+          kind: CategoryKind.expense,
+          amount: Money.fromRupees(5000),
+          accountId: cash,
+          toAccountId: goal,
+          frequency: RecurringFrequency.monthly,
+          startsOn: DateTime(2026, 7, 1),
+        );
+
+        final rule = (await db.watchRecurringRules().first).single;
+        expect(rule.categoryId, isNull);
+      });
+
+      test('pays down a loan the same way', () async {
+        final cash = await cashId();
+        final loan = await db.addLoan(
+          name: 'Car Loan',
+          principal: Money.fromRupees(200000),
+          colorValue: 0,
+          iconKey: 'loan',
+        );
+        final today = DateTime(2026, 7, 5);
+
+        await db.addRecurringRule(
+          name: 'Car EMI',
+          kind: CategoryKind.expense,
+          amount: Money.fromRupees(8000),
+          accountId: cash,
+          toAccountId: loan,
+          frequency: RecurringFrequency.monthly,
+          startsOn: today,
+        );
+
+        await db.runDueRecurringRules(now: today);
+        expect(await balanceOf(loan), Money.fromRupees(-192000));
+      });
+
+      test('rejects a destination that is not a goal or loan', () async {
+        final cash = await cashId();
+        final bank = await db.addAccount(
+          name: 'Bank',
+          type: AccountType.bank,
+          colorValue: 0,
+          iconKey: 'bank',
+          openingBalance: const Money.zero(),
+        );
+        expect(
+          () => db.addRecurringRule(
+            name: 'Broken',
+            kind: CategoryKind.expense,
+            amount: Money.fromRupees(500),
+            accountId: cash,
+            toAccountId: bank,
+            frequency: RecurringFrequency.monthly,
+            startsOn: DateTime(2026, 7, 1),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('rejects a source that is itself a goal', () async {
+        final goal = await db.addGoal(
+          name: 'Emergency Fund',
+          targetAmount: Money.fromRupees(50000),
+          colorValue: 0,
+          iconKey: 'savings',
+        );
+        final otherGoal = await db.addGoal(
+          name: 'New Bike',
+          targetAmount: Money.fromRupees(50000),
+          colorValue: 0,
+          iconKey: 'savings',
+        );
+        expect(
+          () => db.addRecurringRule(
+            name: 'Broken',
+            kind: CategoryKind.expense,
+            amount: Money.fromRupees(500),
+            accountId: goal,
+            toAccountId: otherGoal,
+            frequency: RecurringFrequency.monthly,
+            startsOn: DateTime(2026, 7, 1),
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+
     test(
       'deleting a rule keeps its posted transactions but clears the link',
       () async {
@@ -1916,6 +2050,51 @@ void main() {
           reason: 'advances one step from its own due date, not to today',
         );
       });
+    });
+  });
+
+  group('tag groups — a picker shortcut (GitHub #92)', () {
+    test('addTagGroup + setTagGroupTags round-trips', () async {
+      final work = await db.addTag(name: 'Work', colorValue: 0);
+      final travel = await db.addTag(name: 'Travel', colorValue: 0);
+      final groupId = await db.addTagGroup(name: 'Work trip', colorValue: 0);
+
+      await db.setTagGroupTags(groupId, {work, travel});
+
+      expect((await db.tagIdsForGroup(groupId)).toSet(), {work, travel});
+      expect((await db.watchTagGroups().first).single.name, 'Work trip');
+    });
+
+    test('setTagGroupTags replaces the whole set', () async {
+      final a = await db.addTag(name: 'A', colorValue: 0);
+      final b = await db.addTag(name: 'B', colorValue: 0);
+      final groupId = await db.addTagGroup(name: 'Group', colorValue: 0);
+      await db.setTagGroupTags(groupId, {a});
+
+      await db.setTagGroupTags(groupId, {b});
+
+      expect(await db.tagIdsForGroup(groupId), [b]);
+    });
+
+    test('updateTagGroup renames and recolours in place', () async {
+      final groupId = await db.addTagGroup(name: 'Old', colorValue: 1);
+
+      await db.updateTagGroup(id: groupId, name: 'New', colorValue: 2);
+
+      final group = (await db.watchTagGroups().first).single;
+      expect(group.name, 'New');
+      expect(group.colorValue, 2);
+    });
+
+    test('deleteTagGroup drops its tag links but leaves the tags alone', () async {
+      final tag = await db.addTag(name: 'Work', colorValue: 0);
+      final groupId = await db.addTagGroup(name: 'Group', colorValue: 0);
+      await db.setTagGroupTags(groupId, {tag});
+
+      await db.deleteTagGroup(groupId);
+
+      expect(await db.watchTagGroups().first, isEmpty);
+      expect((await db.watchTags().first).map((t) => t.id), [tag]);
     });
   });
 

--- a/test/envelope_mode_test.dart
+++ b/test/envelope_mode_test.dart
@@ -56,10 +56,10 @@ void main() {
           .firstWhere((c) => c.name == name)
           .id;
 
-  group('setBudgetingMode — GitHub #100', () {
+  group('setRtaEnabled — GitHub #100 v2', () {
     test(
-      'switching to envelope enrolls every existing account, including one '
-      'never touched before',
+      'turning RTA on enrolls every existing account, including one never '
+      'touched before',
       () async {
         final cash = await cashId();
         final bank = await db.addAccount(
@@ -70,7 +70,7 @@ void main() {
           openingBalance: Money.fromRupees(5000),
         );
 
-        await db.setBudgetingMode(BudgetingMode.envelope);
+        await db.setRtaEnabled(true);
 
         final accounts = await db.watchAccounts().first;
         expect(
@@ -85,22 +85,22 @@ void main() {
     );
 
     test(
-      'switching back to budgets leaves every account\'s flag untouched',
+      'turning RTA off leaves every account\'s flag untouched',
       () async {
         final cash = await cashId();
-        await db.setBudgetingMode(BudgetingMode.envelope);
-        await db.setBudgetingMode(BudgetingMode.budgets);
+        await db.setRtaEnabled(true);
+        await db.setRtaEnabled(false);
 
         final after = await db.watchAccounts().first;
         expect(after.firstWhere((a) => a.id == cash).envelopeMode, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
       },
     );
 
     test(
-      'a new account created while Envelope is the active mode joins the '
-      'pool automatically',
+      'a new account created while RTA is on joins the pool automatically',
       () async {
-        await db.setBudgetingMode(BudgetingMode.envelope);
+        await db.setRtaEnabled(true);
 
         final newAccount = await db.addAccount(
           name: 'New Wallet',
@@ -118,8 +118,7 @@ void main() {
     );
 
     test(
-      'a new account created while Budgets is the active mode does not '
-      'join the pool',
+      'a new account created while RTA is off does not join the pool',
       () async {
         final newAccount = await db.addAccount(
           name: 'New Wallet',
@@ -135,6 +134,76 @@ void main() {
         expect(row.envelopeMode, isFalse);
       },
     );
+  });
+
+  group('auto-disable RTA — GitHub #100 v2', () {
+    test(
+      'turning off the last pool account via setEnvelopeMode while RTA is '
+      'on also turns RTA off, and reports it',
+      () async {
+        final cash = await cashId();
+        await db.setRtaEnabled(true);
+
+        final autoDisabled = await db.setEnvelopeMode(cash, false);
+
+        expect(autoDisabled, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
+      },
+    );
+
+    test(
+      'turning off a non-last pool account leaves RTA on, and reports '
+      'nothing happened',
+      () async {
+        final cash = await cashId();
+        final bank = await db.addAccount(
+          name: 'IPPB',
+          type: AccountType.bank,
+          colorValue: 0,
+          iconKey: 'bank',
+          openingBalance: Money.fromRupees(5000),
+        );
+        await db.setRtaEnabled(true);
+
+        final autoDisabled = await db.setEnvelopeMode(cash, false);
+
+        expect(autoDisabled, isFalse);
+        expect((await db.getSettings()).rtaEnabled, isTrue);
+        final bankRow = await (db.select(
+          db.accounts,
+        )..where((a) => a.id.equals(bank))).getSingle();
+        expect(bankRow.envelopeMode, isTrue);
+      },
+    );
+
+    test(
+      'deleting the last pool account also turns RTA off, and reports it',
+      () async {
+        final newAccount = await db.addAccount(
+          name: 'New Wallet',
+          type: AccountType.cash,
+          colorValue: 0,
+          iconKey: 'wallet',
+          openingBalance: const Money.zero(),
+        );
+        await db.setRtaEnabled(true);
+        // Every other pool account has to stop being on-budget first, or
+        // deleting this one wouldn't actually empty the pool.
+        final cash = await cashId();
+        await db.setEnvelopeMode(cash, false);
+
+        final autoDisabled = await db.deleteAccount(newAccount);
+
+        expect(autoDisabled, isTrue);
+        expect((await db.getSettings()).rtaEnabled, isFalse);
+      },
+    );
+
+    test('is a no-op while RTA is already off', () async {
+      final cash = await cashId();
+      final autoDisabled = await db.setEnvelopeMode(cash, false);
+      expect(autoDisabled, isFalse);
+    });
   });
 
   group('addAllocation', () {

--- a/test/envelope_mode_test.dart
+++ b/test/envelope_mode_test.dart
@@ -243,7 +243,7 @@ void main() {
       await settle();
 
       final balance = container.read(
-        categoryBalanceProvider((accountId: cash, categoryId: food)),
+        categoryBalanceProvider(food),
       );
       expect(balance, Money.fromRupees(1400));
     });
@@ -269,13 +269,14 @@ void main() {
       await settle();
 
       final balance = container.read(
-        categoryBalanceProvider((accountId: cash, categoryId: food)),
+        categoryBalanceProvider(food),
       );
       expect(balance, Money.fromRupees(-300));
     });
 
-    test('the same category in two different envelope accounts never mixes',
-        () async {
+    test(
+        'the same category pools across every Envelope-Mode account '
+        '(GitHub #48 — one shared balance, not one per account)', () async {
       await warmUp();
       final cash = await cashId();
       final bank = await db.addAccount(
@@ -302,16 +303,45 @@ void main() {
       await settle();
 
       expect(
-        container.read(
-          categoryBalanceProvider((accountId: cash, categoryId: food)),
-        ),
-        Money.fromRupees(1000),
+        container.read(categoryBalanceProvider(food)),
+        Money.fromRupees(3500),
       );
+    });
+
+    test(
+        "an account that isn't in Envelope Mode never contributes to the "
+        'shared pool, even sharing a category with one that is', () async {
+      await warmUp();
+      final cash = await cashId();
+      final bank = await db.addAccount(
+        name: 'IPPB',
+        type: AccountType.bank,
+        colorValue: 0,
+        iconKey: 'bank',
+        openingBalance: Money.fromRupees(5000),
+      );
+      final food = await expenseCategory('Food');
+      await db.setEnvelopeMode(cash, true);
+      // bank is never put in Envelope Mode.
+
+      await db.addAllocation(
+        accountId: cash,
+        categoryId: food,
+        amount: Money.fromRupees(1000),
+      );
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: Money.fromRupees(400),
+        accountId: bank,
+        categoryId: food,
+        date: DateTime.now(),
+      );
+      await settle();
+
       expect(
-        container.read(
-          categoryBalanceProvider((accountId: bank, categoryId: food)),
-        ),
-        Money.fromRupees(2500),
+        container.read(categoryBalanceProvider(food)),
+        Money.fromRupees(1000),
+        reason: "bank's ordinary spending must not drain the shared pool",
       );
     });
   });
@@ -333,7 +363,7 @@ void main() {
       await settle();
 
       expect(
-        container.read(readyToAssignProvider(cash)),
+        container.read(readyToAssignProvider),
         Money.fromRupees(5000),
       );
     });
@@ -362,7 +392,7 @@ void main() {
       await settle();
 
       expect(
-        container.read(readyToAssignProvider(cash)),
+        container.read(readyToAssignProvider),
         Money.fromRupees(3800),
       );
     });
@@ -406,13 +436,54 @@ void main() {
       final balance = (await db.watchAccounts().first).single.currentBalance;
       expect(balance, Money.fromRupees(750));
       expect(
-        container.read(readyToAssignProvider(cash)),
+        container.read(readyToAssignProvider),
         Money.fromRupees(750),
       );
       expect(
-        container.read(readyToAssignProvider(cash)).paise <= balance.paise,
+        container.read(readyToAssignProvider).paise <= balance.paise,
         isTrue,
         reason: 'ready-to-assign must never exceed the real account balance',
+      );
+    });
+
+    test(
+        'pools across every Envelope-Mode account (GitHub #48 — one shared '
+        'figure, not one per account)', () async {
+      await warmUp();
+      final cash = await cashId();
+      final bank = await db.addAccount(
+        name: 'IPPB',
+        type: AccountType.bank,
+        colorValue: 0,
+        iconKey: 'bank',
+        openingBalance: Money.fromRupees(2000),
+      );
+      final food = await expenseCategory('Food');
+      await db.setEnvelopeMode(cash, true);
+      await db.setEnvelopeMode(bank, true);
+      final salary = await (db.watchCategories(CategoryKind.income).first)
+          .then((c) => c.firstWhere((c) => c.name == 'Salary').id);
+      await db.addTransaction(
+        type: TxType.income,
+        amount: Money.fromRupees(1000),
+        accountId: cash,
+        categoryId: salary,
+        date: DateTime.now(),
+      );
+      await settle();
+
+      await db.addAllocation(
+        accountId: cash,
+        categoryId: food,
+        amount: Money.fromRupees(600),
+      );
+      await settle();
+
+      // cash: 1000 balance, 600 claimed by Food. bank: 2000 balance,
+      // nothing claimed. Pool RTA = (1000 + 2000) − 600 = 2400.
+      expect(
+        container.read(readyToAssignProvider),
+        Money.fromRupees(2400),
       );
     });
   });

--- a/test/envelope_mode_test.dart
+++ b/test/envelope_mode_test.dart
@@ -56,6 +56,87 @@ void main() {
           .firstWhere((c) => c.name == name)
           .id;
 
+  group('setBudgetingMode — GitHub #100', () {
+    test(
+      'switching to envelope enrolls every existing account, including one '
+      'never touched before',
+      () async {
+        final cash = await cashId();
+        final bank = await db.addAccount(
+          name: 'IPPB',
+          type: AccountType.bank,
+          colorValue: 0,
+          iconKey: 'bank',
+          openingBalance: Money.fromRupees(5000),
+        );
+
+        await db.setBudgetingMode(BudgetingMode.envelope);
+
+        final accounts = await db.watchAccounts().first;
+        expect(
+          accounts.firstWhere((a) => a.id == cash).envelopeMode,
+          isTrue,
+        );
+        expect(
+          accounts.firstWhere((a) => a.id == bank).envelopeMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'switching back to budgets leaves every account\'s flag untouched',
+      () async {
+        final cash = await cashId();
+        await db.setBudgetingMode(BudgetingMode.envelope);
+        await db.setBudgetingMode(BudgetingMode.budgets);
+
+        final after = await db.watchAccounts().first;
+        expect(after.firstWhere((a) => a.id == cash).envelopeMode, isTrue);
+      },
+    );
+
+    test(
+      'a new account created while Envelope is the active mode joins the '
+      'pool automatically',
+      () async {
+        await db.setBudgetingMode(BudgetingMode.envelope);
+
+        final newAccount = await db.addAccount(
+          name: 'New Wallet',
+          type: AccountType.cash,
+          colorValue: 0,
+          iconKey: 'wallet',
+          openingBalance: const Money.zero(),
+        );
+
+        final row = await (db.select(
+          db.accounts,
+        )..where((a) => a.id.equals(newAccount))).getSingle();
+        expect(row.envelopeMode, isTrue);
+      },
+    );
+
+    test(
+      'a new account created while Budgets is the active mode does not '
+      'join the pool',
+      () async {
+        final newAccount = await db.addAccount(
+          name: 'New Wallet',
+          type: AccountType.cash,
+          colorValue: 0,
+          iconKey: 'wallet',
+          openingBalance: const Money.zero(),
+        );
+
+        final row = await (db.select(
+          db.accounts,
+        )..where((a) => a.id.equals(newAccount))).getSingle();
+        expect(row.envelopeMode, isFalse);
+      },
+    );
+  });
+
   group('addAllocation', () {
     test('rejects an account with Envelope Mode off', () async {
       final cash = await cashId();

--- a/test/icon_picker_sheet_test.dart
+++ b/test/icon_picker_sheet_test.dart
@@ -1,0 +1,143 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/features/accounts/add_account_sheet.dart';
+import 'package:xpenc/features/categories/categories_screen.dart';
+
+/// GitHub #102: Categories (and anywhere else an icon is chosen) should offer
+/// every icon in `AppIcons`, filterable by search, with recently-picked icons
+/// surfaced up top. Covers the shared `showIconPickerSheet` sheet through
+/// both callers that wire it up.
+///
+/// Follows the three rules from test/smoke_test.dart: DB work inside
+/// `runAsync`, never `pumpAndSettle`, unmount before the test ends.
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester, Widget screen) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(theme: AppTheme.light, home: screen),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 200)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> settleSheet(WidgetTester tester) async {
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets(
+    'Add Account sheet: the icon field searches, picks, and remembers '
+    'frequently used icons',
+    (tester) async {
+      await pump(
+        tester,
+        Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => showAddAccountSheet(context),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+
+      // Open the icon picker from the account sheet's own "Icon" field.
+      await tester.tap(find.text('Tap to change'));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Search icons'), findsOneWidget);
+
+      // No icon has ever been picked yet, so there's nothing to surface.
+      expect(find.text('Frequently used'), findsNothing);
+
+      await tester.enterText(
+        find.byKey(const Key('iconPickerSearch')),
+        'coffee',
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+      expect(find.text('Results'), findsOneWidget);
+      expect(find.byIcon(Icons.coffee_outlined), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.coffee_outlined));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+
+      // Back on the account sheet, the field now previews the chosen icon.
+      expect(find.text('Search icons'), findsNothing);
+      expect(find.byIcon(Icons.coffee_outlined), findsOneWidget);
+
+      await tester.runAsync(() async {
+        final settings = await db.getSettings();
+        expect(settings.frequentIconKeys, 'coffee');
+      });
+
+      // Reopening the picker now surfaces coffee under "Frequently used".
+      await tester.tap(find.text('Tap to change'));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Frequently used'), findsOneWidget);
+      // 3, not 2: the "Frequently used" row, the "All icons" row, and the
+      // account sheet's own field preview underneath — still mounted below
+      // this stacked modal sheet.
+      expect(find.byIcon(Icons.coffee_outlined), findsNWidgets(3));
+
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'Category editor: the icon field opens the same searchable picker',
+    (tester) async {
+      await pump(tester, const CategoriesScreen());
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.byTooltip('New category'));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+      expect(find.text('New category'), findsOneWidget);
+
+      await tester.tap(find.text('Tap to change'));
+      await settleSheet(tester);
+      expect(tester.takeException(), isNull);
+      expect(find.text('Search icons'), findsOneWidget);
+      expect(find.text('All icons'), findsOneWidget);
+
+      await unmount(tester);
+    },
+  );
+}

--- a/test/migration_version_drift_test.dart
+++ b/test/migration_version_drift_test.dart
@@ -127,4 +127,18 @@ void main() {
       await reopened.close();
     },
   );
+
+  test(
+    'the v60 CurrencyRates table and account/transaction currency columns '
+    'survive a rolled-back re-open',
+    () async {
+      final file = await buildRolledBackDatabase(59);
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      await expectLater(reopened.select(reopened.currencyRates).get(), completes);
+      await expectLater(reopened.select(reopened.accounts).get(), completes);
+      await expectLater(reopened.select(reopened.transactions).get(), completes);
+      await reopened.close();
+    },
+  );
 }

--- a/test/money_text_currency_test.dart
+++ b/test/money_text_currency_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/currency.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/widgets/money_text.dart';
+
+void main() {
+  tearDown(() => MoneyFormat.configure(
+        currency: kDefaultCurrency,
+        showSymbol: true,
+      ));
+
+  testWidgets('an explicit currency overrides the globally configured one',
+      (tester) async {
+    MoneyFormat.configure(currency: currencyForCode('INR'), showSymbol: true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MoneyText(
+            const Money(125050),
+            currency: currencyForCode('USD'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining(r'$'), findsOneWidget);
+    expect(find.textContaining('₹'), findsNothing);
+  });
+
+  testWidgets('omitting currency keeps using the global MoneyFormat, unchanged',
+      (tester) async {
+    MoneyFormat.configure(currency: currencyForCode('INR'), showSymbol: true);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: MoneyText(Money(125050))),
+      ),
+    );
+
+    expect(find.textContaining('₹'), findsOneWidget);
+  });
+}

--- a/test/net_worth_currency_test.dart
+++ b/test/net_worth_currency_test.dart
@@ -1,0 +1,53 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('sums a mixed-currency set of accounts using the live rate', () async {
+    await db.addAccount(
+      name: 'INR wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(1000000), // ₹10,000.00
+    );
+    await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(10000), // $100.00
+      currencyCode: 'USD',
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 83000000, // 1 USD = 83 INR
+      effectiveAt: DateTime(2020, 1, 1),
+    );
+
+    final netWorth = await db.watchNetWorth().first;
+    // ₹10,000.00 + ($100.00 -> ₹8,300.00) = ₹18,300.00
+    expect(netWorth, const Money(1830000));
+  });
+
+  test('a foreign account with no rate yet contributes its raw balance '
+      'unconverted, rather than breaking the stream', () async {
+    await db.addAccount(
+      name: 'USD wallet',
+      type: AccountType.cash,
+      colorValue: 0xFF000000,
+      iconKey: 'cash',
+      openingBalance: const Money(10000),
+      currencyCode: 'USD',
+    );
+
+    final netWorth = await db.watchNetWorth().first;
+    expect(netWorth, const Money(10000));
+  });
+}

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -26,8 +26,10 @@ import 'package:xpenc/features/reports/account_reports_screen.dart';
 import 'package:xpenc/features/reports/stats_screen.dart';
 import 'package:xpenc/features/savings/savings_goal_detail_screen.dart';
 import 'package:xpenc/features/savings/savings_goals_screen.dart';
+import 'package:xpenc/features/settings/more_screen_layout_sheet.dart';
 import 'package:xpenc/features/settings/settings_screen.dart';
 import 'package:xpenc/features/settings/widgets_screen.dart';
+import 'package:xpenc/features/tags/tag_groups_screen.dart';
 import 'package:xpenc/features/transactions/transaction_detail_screen.dart';
 import 'package:xpenc/features/more/whats_new_data.dart';
 import 'package:xpenc/features/more/whats_new_screen.dart';
@@ -183,6 +185,26 @@ void main() {
     await pump(tester, const CategoriesScreen());
     expect(tester.takeException(), isNull);
     expect(find.text('Categories'), findsWidgets);
+    await unmount(tester);
+  });
+
+  testWidgets('Tag groups screen renders empty, then with a group', (
+    tester,
+  ) async {
+    await pump(tester, const TagGroupsScreen());
+    expect(tester.takeException(), isNull);
+    expect(find.text('Tag groups'), findsOneWidget);
+    expect(find.textContaining('No tag groups yet'), findsOneWidget);
+    await unmount(tester);
+
+    final tagId = await db.addTag(name: 'Travel', colorValue: 0xFF16A34A);
+    final groupId = await db.addTagGroup(name: 'Work trip', colorValue: 0);
+    await db.setTagGroupTags(groupId, {tagId});
+
+    await pump(tester, const TagGroupsScreen());
+    expect(tester.takeException(), isNull);
+    expect(find.text('Work trip'), findsOneWidget);
+    expect(find.text('Travel'), findsOneWidget);
     await unmount(tester);
   });
 
@@ -585,6 +607,47 @@ void main() {
     // Sits below the fold at phone size — bring it into the viewport first.
     await tester.scrollUntilVisible(find.text('Backup & Restore'), 240);
     expect(find.text('Backup & Restore'), findsOneWidget);
+    await unmount(tester);
+  });
+
+  testWidgets('More hub renders every tile in cards layout', (tester) async {
+    await db.setMoreScreenViewMode(MoreScreenViewMode.cards);
+    await pump(tester, const MoreScreen());
+    expect(tester.takeException(), isNull);
+    expect(find.text('Stats'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('Backup & Restore'), 240);
+    expect(find.text('Backup & Restore'), findsOneWidget);
+    await unmount(tester);
+  });
+
+  testWidgets(
+    'Settings: More screen layout row shows the stored mode',
+    (tester) async {
+      await pump(tester, const SettingsScreen());
+      expect(tester.takeException(), isNull);
+
+      await tester.scrollUntilVisible(find.text('More screen layout'), 300);
+      expect(find.text('List'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets('picking Cards on the More screen layout sheet writes it to '
+      'the database', (tester) async {
+    await pump(tester, const Scaffold(body: MoreScreenLayoutSheet()));
+
+    await tester.tap(find.text('Cards'));
+    await tester.pump();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 200)),
+    );
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+
+    await tester.runAsync(() async {
+      final settings = await db.getSettings();
+      expect(settings.moreScreenViewMode, MoreScreenViewMode.cards);
+    });
     await unmount(tester);
   });
 

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -350,6 +350,107 @@ void main() {
     await unmount(tester);
   });
 
+  testWidgets(
+    'Stats: category standings show each category\'s share of total spend',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        final seeded = await seed(); // Food: 320 + 1234.56 = 1554.56
+        cash = seeded.cash;
+        final transport = (await db.watchCategories(CategoryKind.expense).first)
+            .firstWhere((c) => c.name == 'Transport')
+            .id;
+        // Total spend: 1554.56 + 500 = 2054.56 -> Transport is ~24.3%.
+        await db.addTransaction(
+          type: TxType.expense,
+          amount: Money.fromRupees(500),
+          accountId: cash,
+          categoryId: transport,
+          date: DateTime.now(),
+        );
+      });
+      // A tall viewport so the whole ListView (charts included) lays out
+      // without needing a scroll — the Stats screen has more than one
+      // Scrollable (the charts included), which makes scrollUntilVisible
+      // unreliable here.
+      tester.view.physicalSize = const Size(1080, 9000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [dbProvider.overrideWithValue(db)],
+          child: const MaterialApp(home: StatsScreen()),
+        ),
+      );
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      // The Standings section defaults to ranking transactions — switch it
+      // to categories to reach the ranking this test targets (GitHub #95).
+      await tester.tap(find.text('Categories'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      expect(find.textContaining('% of total'), findsWidgets);
+      expect(find.textContaining('24.3% of total'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    "Stats: the Spending by category donut's legend shows each slice's "
+    'share of total',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        final seeded = await seed(); // Food: 320 + 1234.56 = 1554.56
+        cash = seeded.cash;
+        final transport = (await db.watchCategories(CategoryKind.expense).first)
+            .firstWhere((c) => c.name == 'Transport')
+            .id;
+        // Total spend: 1554.56 + 500 = 2054.56 -> Transport is ~24%.
+        await db.addTransaction(
+          type: TxType.expense,
+          amount: Money.fromRupees(500),
+          accountId: cash,
+          categoryId: transport,
+          date: DateTime.now(),
+        );
+      });
+      // A tall viewport so the donut's legend lays out without needing a
+      // scroll — see the note on the Standings test above.
+      tester.view.physicalSize = const Size(1080, 9000);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [dbProvider.overrideWithValue(db)],
+          child: const MaterialApp(home: StatsScreen()),
+        ),
+      );
+      // spendByCategoryProvider is a drift stream query — give it one more
+      // round trip to emit before asserting on its data.
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(tester.takeException(), isNull);
+
+      expect(find.textContaining('(24%)'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
   testWidgets('Account Reports renders with a negative credit-card balance', (
     tester,
   ) async {

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -14,6 +14,7 @@ import 'package:xpenc/features/accounts/accounts_screen.dart';
 import 'package:xpenc/features/auto/archived_auto_rules_screen.dart';
 import 'package:xpenc/features/auto/auto_screen.dart';
 import 'package:xpenc/features/budgets/budget_detail_screen.dart';
+import 'package:xpenc/features/budgets/ready_to_assign_screen.dart';
 import 'package:xpenc/features/calendar/calendar_screen.dart';
 import 'package:xpenc/features/categories/categories_screen.dart';
 import 'package:xpenc/features/data_export/backup_screen.dart';
@@ -422,8 +423,8 @@ void main() {
   });
 
   testWidgets(
-    'Account detail: Envelope Mode shows Ready to Assign and category '
-    'balances once turned on',
+    'Account detail: Envelope Mode links to the shared Ready to Assign '
+    'screen once turned on',
     (tester) async {
       late int cash;
       await tester.runAsync(() async {
@@ -439,7 +440,29 @@ void main() {
       await pump(tester, AccountDetailScreen(accountId: cash));
       expect(tester.takeException(), isNull);
       expect(find.text('Envelope Mode'), findsOneWidget);
-      expect(find.text('Ready to Assign'), findsOneWidget);
+      expect(find.text('View shared budget'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'Ready to Assign screen shows the shared pool total and category '
+    'balances',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        cash = (await seed()).cash;
+        await db.setEnvelopeMode(cash, true);
+        await db.addAllocation(
+          accountId: cash,
+          categoryId: await (db.watchCategories(CategoryKind.expense).first)
+              .then((c) => c.firstWhere((c) => c.name == 'Food').id),
+          amount: Money.fromRupees(500),
+        );
+      });
+      await pump(tester, const ReadyToAssignScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Ready to Assign'), findsWidgets);
       expect(find.text('Food'), findsWidgets);
       await unmount(tester);
     },

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -446,6 +446,46 @@ void main() {
   );
 
   testWidgets(
+    'Assign sheet offers an account picker once more than one account is '
+    'in the pool (GitHub #100)',
+    (tester) async {
+      late int cash;
+      await tester.runAsync(() async {
+        final seeded = await seed();
+        cash = seeded.cash;
+        await db.setEnvelopeMode(cash, true);
+      });
+      await pump(tester, const ReadyToAssignScreen());
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.text('Food').first);
+      await tester.pumpAndSettle();
+      // Only one pool account so far — no need to ask which one.
+      expect(find.text('Account'), findsNothing);
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+
+      await tester.runAsync(() async {
+        final bank = await db.addAccount(
+          name: 'IPPB',
+          type: AccountType.bank,
+          colorValue: 0,
+          iconKey: 'bank',
+          openingBalance: Money.fromRupees(5000),
+        );
+        await db.setEnvelopeMode(bank, true);
+      });
+      await pump(tester, const ReadyToAssignScreen());
+      expect(tester.takeException(), isNull);
+
+      await tester.tap(find.text('Food').first);
+      await tester.pumpAndSettle();
+      expect(find.text('Account'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
     'Ready to Assign screen shows the shared pool total and category '
     'balances',
     (tester) async {
@@ -707,17 +747,18 @@ void main() {
   );
 
   testWidgets(
-    'More hub: the Budgets tile becomes Ready to Assign in Envelope mode '
+    'More hub: the Budgets tile becomes Envelope in Envelope mode '
     '(GitHub #100)',
     (tester) async {
       await db.setBudgetingMode(BudgetingMode.envelope);
       await pump(tester, const MoreScreen());
       expect(tester.takeException(), isNull);
-      expect(find.text('Ready to Assign'), findsOneWidget);
+      expect(find.text('Envelope'), findsOneWidget);
       expect(find.text('Budgets'), findsNothing);
       await unmount(tester);
     },
   );
+
 
   testWidgets('Settings renders', (tester) async {
     await pump(tester, const SettingsScreen());

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -423,13 +423,13 @@ void main() {
   });
 
   testWidgets(
-    'Account detail: Envelope Mode links to the shared Ready to Assign '
-    'screen once turned on',
+    'Account detail: On-budget links to the shared Ready to Assign screen '
+    'once turned on',
     (tester) async {
       late int cash;
       await tester.runAsync(() async {
         cash = (await seed()).cash;
-        await db.setEnvelopeMode(cash, true);
+        await db.setRtaEnabled(true);
         await db.addAllocation(
           accountId: cash,
           categoryId: await (db.watchCategories(CategoryKind.expense).first)
@@ -439,7 +439,7 @@ void main() {
       });
       await pump(tester, AccountDetailScreen(accountId: cash));
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope Mode'), findsOneWidget);
+      expect(find.text('On-budget'), findsOneWidget);
       expect(find.text('View shared budget'), findsOneWidget);
       await unmount(tester);
     },
@@ -509,16 +509,22 @@ void main() {
   );
 
   testWidgets(
-    'Account detail: turning Envelope Mode on asks for confirmation first',
+    'Account detail: turning On-budget on asks for confirmation first',
     (tester) async {
       late int cash;
-      await tester.runAsync(() async => cash = (await seed()).cash);
+      await tester.runAsync(() async {
+        cash = (await seed()).cash;
+        // RTA has to be on for the On-budget toggle to render at all — then
+        // opt this one account back out so there's something to turn on.
+        await db.setRtaEnabled(true);
+        await db.setEnvelopeMode(cash, false);
+      });
       await pump(tester, AccountDetailScreen(accountId: cash));
       expect(tester.takeException(), isNull);
 
-      await tester.tap(find.text('Envelope Mode'));
+      await tester.tap(find.text('On-budget'));
       await tester.pump();
-      expect(find.text('Turn on Envelope Mode?'), findsOneWidget);
+      expect(find.text('Mark this account on-budget?'), findsOneWidget);
 
       late List<AccountRow> account;
       await tester.runAsync(
@@ -715,22 +721,24 @@ void main() {
   });
 
   testWidgets(
-    'Settings: Budgeting mode defaults to Budgets and switching to '
-    'Envelope persists (GitHub #100)',
+    'Settings: Ready to Assign defaults off and turning it on persists '
+    '(GitHub #100 v2)',
     (tester) async {
       await pump(tester, const SettingsScreen());
       expect(tester.takeException(), isNull);
 
-      await tester.scrollUntilVisible(find.text('Envelope'), 300);
-      await tester.ensureVisible(find.text('Envelope'));
+      await tester.scrollUntilVisible(find.text('Ready to Assign'), 300);
+      await tester.ensureVisible(find.text('Ready to Assign'));
       await tester.pumpAndSettle();
-      expect(find.text('Budgets'), findsWidgets);
-      expect(find.text('Envelope'), findsOneWidget);
+      expect(find.text('Ready to Assign'), findsOneWidget);
 
       final initial = await db.getSettings();
-      expect(initial.budgetingMode, BudgetingMode.budgets);
+      expect(initial.rtaEnabled, isFalse);
 
-      await tester.tap(find.text('Envelope'));
+      await tester.tap(find.text('Ready to Assign'));
+      await tester.pump();
+      expect(find.text('Turn on Ready to Assign?'), findsOneWidget);
+      await tester.tap(find.text('Turn on'));
       await tester.pump();
       await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 200)),
@@ -740,21 +748,32 @@ void main() {
 
       await tester.runAsync(() async {
         final updated = await db.getSettings();
-        expect(updated.budgetingMode, BudgetingMode.envelope);
+        expect(updated.rtaEnabled, isTrue);
       });
       await unmount(tester);
     },
   );
 
   testWidgets(
-    'More hub: the Budgets tile becomes Envelope in Envelope mode '
-    '(GitHub #100)',
+    'More hub: a Ready to Assign tile appears alongside Budgets once RTA '
+    'is on (GitHub #100 v2)',
     (tester) async {
-      await db.setBudgetingMode(BudgetingMode.envelope);
+      await db.setRtaEnabled(true);
       await pump(tester, const MoreScreen());
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope'), findsOneWidget);
-      expect(find.text('Budgets'), findsNothing);
+      expect(find.text('Ready to Assign'), findsOneWidget);
+      expect(find.text('Budgets'), findsOneWidget);
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'More hub: only the Budgets tile shows while RTA is off',
+    (tester) async {
+      await pump(tester, const MoreScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Budgets'), findsOneWidget);
+      expect(find.text('Ready to Assign'), findsNothing);
       await unmount(tester);
     },
   );

--- a/test/screens_smoke_test.dart
+++ b/test/screens_smoke_test.dart
@@ -674,6 +674,51 @@ void main() {
     await unmount(tester);
   });
 
+  testWidgets(
+    'Settings: Budgeting mode defaults to Budgets and switching to '
+    'Envelope persists (GitHub #100)',
+    (tester) async {
+      await pump(tester, const SettingsScreen());
+      expect(tester.takeException(), isNull);
+
+      await tester.scrollUntilVisible(find.text('Envelope'), 300);
+      await tester.ensureVisible(find.text('Envelope'));
+      await tester.pumpAndSettle();
+      expect(find.text('Budgets'), findsWidgets);
+      expect(find.text('Envelope'), findsOneWidget);
+
+      final initial = await db.getSettings();
+      expect(initial.budgetingMode, BudgetingMode.budgets);
+
+      await tester.tap(find.text('Envelope'));
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 200)),
+      );
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+
+      await tester.runAsync(() async {
+        final updated = await db.getSettings();
+        expect(updated.budgetingMode, BudgetingMode.envelope);
+      });
+      await unmount(tester);
+    },
+  );
+
+  testWidgets(
+    'More hub: the Budgets tile becomes Ready to Assign in Envelope mode '
+    '(GitHub #100)',
+    (tester) async {
+      await db.setBudgetingMode(BudgetingMode.envelope);
+      await pump(tester, const MoreScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Ready to Assign'), findsOneWidget);
+      expect(find.text('Budgets'), findsNothing);
+      await unmount(tester);
+    },
+  );
+
   testWidgets('Settings renders', (tester) async {
     await pump(tester, const SettingsScreen());
     expect(tester.takeException(), isNull);

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -135,10 +135,11 @@ void main() {
 
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
-      // Appears twice: the section header and the pooled RTA card's own
-      // label (GitHub #48 — one shared card, not one per account, so the
-      // account name itself is no longer shown here).
-      expect(find.text('Ready to Assign'), findsNWidgets(2));
+      expect(find.text('Envelope'), findsOneWidget);
+      // The pooled RTA card's own label (GitHub #48 — one shared card, not
+      // one per account, so the account name itself is no longer shown
+      // here).
+      expect(find.text('Ready to Assign'), findsOneWidget);
       await unmount(tester);
     },
   );

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -108,8 +108,8 @@ void main() {
   });
 
   testWidgets(
-    'Dashboard shows the shared Ready to Assign pool only in Envelope '
-    'budgeting mode, once an account is in Envelope Mode (GitHub #100)',
+    'Dashboard shows the shared Ready to Assign pool only once RTA is on '
+    'globally and an account is on-budget (GitHub #100 v2)',
     (tester) async {
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
@@ -121,25 +121,21 @@ void main() {
         await db.setEnvelopeMode(cash, true);
       });
 
-      // Still hidden under the default Budgets mode, even with a pool
-      // account — the Settings switch decides which system the Dashboard
-      // surfaces.
+      // Still hidden while RTA is off globally, even with an on-budget
+      // account — the Settings switch is what surfaces this section.
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
       expect(find.text('Ready to Assign'), findsNothing);
       await unmount(tester);
 
-      await tester.runAsync(
-        () => db.setBudgetingMode(BudgetingMode.envelope),
-      );
+      await tester.runAsync(() => db.setRtaEnabled(true));
 
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
-      expect(find.text('Envelope'), findsOneWidget);
-      // The pooled RTA card's own label (GitHub #48 — one shared card, not
-      // one per account, so the account name itself is no longer shown
-      // here).
-      expect(find.text('Ready to Assign'), findsOneWidget);
+      // The section header and the pooled RTA card's own label (GitHub
+      // #48 — one shared card, not one per account, so the account name
+      // itself is no longer shown here).
+      expect(find.text('Ready to Assign'), findsNWidgets(2));
       await unmount(tester);
     },
   );

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -108,8 +108,8 @@ void main() {
   });
 
   testWidgets(
-    'Dashboard shows the shared Ready to Assign pool only once an account '
-    'is in Envelope Mode',
+    'Dashboard shows the shared Ready to Assign pool only in Envelope '
+    'budgeting mode, once an account is in Envelope Mode (GitHub #100)',
     (tester) async {
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);
@@ -120,6 +120,18 @@ void main() {
         final cash = await cashId();
         await db.setEnvelopeMode(cash, true);
       });
+
+      // Still hidden under the default Budgets mode, even with a pool
+      // account — the Settings switch decides which system the Dashboard
+      // surfaces.
+      await pump(tester, const DashboardScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Ready to Assign'), findsNothing);
+      await unmount(tester);
+
+      await tester.runAsync(
+        () => db.setBudgetingMode(BudgetingMode.envelope),
+      );
 
       await pump(tester, const DashboardScreen());
       expect(tester.takeException(), isNull);

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -107,25 +107,29 @@ void main() {
     await unmount(tester);
   });
 
-  testWidgets('Dashboard shows Ready to Assign only for an envelope account', (
-    tester,
-  ) async {
-    await pump(tester, const DashboardScreen());
-    expect(tester.takeException(), isNull);
-    expect(find.text('Ready to Assign'), findsNothing);
-    await unmount(tester);
+  testWidgets(
+    'Dashboard shows the shared Ready to Assign pool only once an account '
+    'is in Envelope Mode',
+    (tester) async {
+      await pump(tester, const DashboardScreen());
+      expect(tester.takeException(), isNull);
+      expect(find.text('Ready to Assign'), findsNothing);
+      await unmount(tester);
 
-    await tester.runAsync(() async {
-      final cash = await cashId();
-      await db.setEnvelopeMode(cash, true);
-    });
+      await tester.runAsync(() async {
+        final cash = await cashId();
+        await db.setEnvelopeMode(cash, true);
+      });
 
-    await pump(tester, const DashboardScreen());
-    expect(tester.takeException(), isNull);
-    expect(find.text('Ready to Assign'), findsOneWidget);
-    expect(find.text('Cash'), findsWidgets);
-    await unmount(tester);
-  });
+      await pump(tester, const DashboardScreen());
+      expect(tester.takeException(), isNull);
+      // Appears twice: the section header and the pooled RTA card's own
+      // label (GitHub #48 — one shared card, not one per account, so the
+      // account name itself is no longer shown here).
+      expect(find.text('Ready to Assign'), findsNWidgets(2));
+      await unmount(tester);
+    },
+  );
 
   testWidgets('Accounts renders and shows the seeded Cash account', (
     tester,

--- a/test/statement_pdf_test.dart
+++ b/test/statement_pdf_test.dart
@@ -63,6 +63,49 @@ void main() {
     expect(looksLikePdf(bytes), isTrue);
   });
 
+  test(
+    "a foreign-currency account's statement PDF renders in its own "
+    'currency, not the parent one',
+    () async {
+      final usdAccount = await db.addAccount(
+        name: 'Travel',
+        type: AccountType.cash,
+        colorValue: 0xFF000000,
+        iconKey: 'cash',
+        openingBalance: const Money.zero(),
+        currencyCode: 'USD',
+      );
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 83000000,
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+      await db.addTransaction(
+        type: TxType.expense,
+        amount: Money.fromRupees(10), // $10.00
+        accountId: usdAccount,
+        date: DateTime(2026, 7, 5),
+        payee: 'Test Store',
+      );
+
+      final statement = await db.accountStatement(
+        accountId: usdAccount,
+        start: DateTime(2026, 7, 1),
+        end: DateTime(2026, 7, 31),
+      );
+      final account = await (db.select(
+        db.accounts,
+      )..where((a) => a.id.equals(usdAccount))).getSingle();
+      final bytes = await buildAccountStatementPdf(
+        account: account,
+        statement: statement,
+        start: DateTime(2026, 7, 1),
+        end: DateTime(2026, 7, 31),
+      );
+      expect(looksLikePdf(bytes), isTrue);
+    },
+  );
+
   test('budget statement PDF renders with rows', () async {
     final cash = (await db.watchAccounts().first)
         .firstWhere((a) => a.type == AccountType.cash);

--- a/test/transaction_currency_snapshot_test.dart
+++ b/test/transaction_currency_snapshot_test.dart
@@ -1,0 +1,117 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+void main() {
+  late AppDatabase db;
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<int> addAccountWithCurrency(String? code) => db.addAccount(
+        name: 'Acct $code',
+        type: AccountType.bank,
+        colorValue: 0xFF000000,
+        iconKey: 'bank',
+        openingBalance: const Money.zero(),
+        currencyCode: code,
+      );
+
+  test('a parent-currency account posts with null currency/rate', () async {
+    final id = await addAccountWithCurrency(null);
+    final txId = await db.addTransaction(
+      type: TxType.expense,
+      amount: const Money(50000),
+      accountId: id,
+      date: DateTime(2026, 1, 1),
+    );
+    final row = await (db.select(
+      db.transactions,
+    )..where((t) => t.id.equals(txId))).getSingle();
+    expect(row.currencyCode, isNull);
+    expect(row.fxRateToBaseMicros, isNull);
+  });
+
+  test('a foreign-currency account with no rate yet throws', () async {
+    final id = await addAccountWithCurrency('USD');
+    expect(
+      () => db.addTransaction(
+        type: TxType.expense,
+        amount: const Money(1000),
+        accountId: id,
+        date: DateTime(2026, 1, 1),
+      ),
+      throwsArgumentError,
+    );
+  });
+
+  test('a foreign-currency account snapshots the rate as of the tx date', () async {
+    final id = await addAccountWithCurrency('USD');
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 80000000,
+      effectiveAt: DateTime(2026, 1, 1),
+    );
+    await db.addCurrencyRate(
+      currencyCode: 'USD',
+      rateToBaseMicros: 85000000,
+      effectiveAt: DateTime(2026, 6, 1),
+    );
+
+    final txId = await db.addTransaction(
+      type: TxType.expense,
+      amount: const Money(1000),
+      accountId: id,
+      date: DateTime(2026, 3, 1), // between the two rates
+    );
+    final row = await (db.select(
+      db.transactions,
+    )..where((t) => t.id.equals(txId))).getSingle();
+    expect(row.currencyCode, 'USD');
+    expect(row.fxRateToBaseMicros, 80000000);
+  });
+
+  group('cross-currency transfer', () {
+    test('same-currency transfer leaves toAmount/toCurrencyCode null', () async {
+      final a = await addAccountWithCurrency(null);
+      final b = await addAccountWithCurrency(null);
+      final txId = await db.addTransaction(
+        type: TxType.transfer,
+        amount: const Money(50000),
+        accountId: a,
+        toAccountId: b,
+        date: DateTime(2026, 1, 1),
+      );
+      final row = await (db.select(
+        db.transactions,
+      )..where((t) => t.id.equals(txId))).getSingle();
+      expect(row.toAmount, isNull);
+      expect(row.toCurrencyCode, isNull);
+    });
+
+    test('parent to foreign transfer computes toAmount via the current rate', () async {
+      final inrAcct = await addAccountWithCurrency(null);
+      final usdAcct = await addAccountWithCurrency('USD');
+      await db.addCurrencyRate(
+        currencyCode: 'USD',
+        rateToBaseMicros: 83000000, // 1 USD = 83 INR
+        effectiveAt: DateTime(2026, 1, 1),
+      );
+
+      final txId = await db.addTransaction(
+        type: TxType.transfer,
+        amount: const Money(830000), // ₹8300.00
+        accountId: inrAcct,
+        toAccountId: usdAcct,
+        date: DateTime(2026, 2, 1),
+      );
+      final row = await (db.select(
+        db.transactions,
+      )..where((t) => t.id.equals(txId))).getSingle();
+      expect(row.toCurrencyCode, 'USD');
+      // ₹8300.00 / 83 = $100.00
+      expect(row.toAmount, const Money(10000));
+    });
+  });
+}

--- a/test/transactions_screen_currency_test.dart
+++ b/test/transactions_screen_currency_test.dart
@@ -1,0 +1,99 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/core/theme/app_theme.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/providers.dart';
+import 'package:xpenc/data/tables.dart';
+import 'package:xpenc/features/transactions/transactions_screen.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  Future<void> pump(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dbProvider.overrideWithValue(db)],
+        child: MaterialApp(
+          theme: AppTheme.light,
+          home: const TransactionsScreen(),
+        ),
+      ),
+    );
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 150)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> unmount(WidgetTester tester) async {
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(Duration.zero);
+  }
+
+  testWidgets(
+    "the day/summary income total converts a foreign-currency account's "
+    'income into the parent currency instead of adding its raw amount',
+    (tester) async {
+      await tester.runAsync(() async {
+        final inrAccount = (await db.watchAccounts().first).first;
+        final usdAccount = await db.addAccount(
+          name: 'Travel',
+          type: AccountType.cash,
+          colorValue: 0xFF000000,
+          iconKey: 'cash',
+          openingBalance: const Money.zero(),
+          currencyCode: 'USD',
+        );
+        await db.addCurrencyRate(
+          currencyCode: 'USD',
+          rateToBaseMicros: 83000000, // 1 USD = 83 INR
+          effectiveAt: DateTime(2020, 1, 1),
+        );
+        final salaryCategory = await db.addCategory(
+          name: 'Salary',
+          kind: CategoryKind.income,
+          colorValue: 0xFF000000,
+          iconKey: 'salary',
+        );
+
+        // ₹17.00 (native) + $1.00 (-> ₹83.00 at the rate above) = ₹100.00.
+        await db.addTransaction(
+          type: TxType.income,
+          amount: const Money(1700),
+          accountId: inrAccount.id,
+          categoryId: salaryCategory,
+          date: DateTime.now(),
+        );
+        await db.addTransaction(
+          type: TxType.income,
+          amount: const Money(100),
+          accountId: usdAccount,
+          categoryId: salaryCategory,
+          date: DateTime.now(),
+        );
+      });
+
+      await pump(tester);
+
+      // MoneyFormat.compact renders ₹100.00 at this size without abbreviating.
+      expect(find.textContaining('100'), findsWidgets);
+      // The pre-fix bug summed 1700 + 100 = 1800 raw paise (₹18.00) — make
+      // sure that wrong figure isn't what's on screen.
+      expect(find.textContaining('18.00'), findsNothing);
+
+      await unmount(tester);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Closes #101 — save the current category/sub-category structure as a named template (Categories → the new templates icon), and switch between saved templates any time.
- Switching never touches a transaction: categories the target template doesn't have are archived (exactly like a manual archive — their transactions keep them), categories it does have are created or relabelled in place, and switching back later reactivates the same categories instead of duplicating them.
- New Drift tables `CategoryTemplates` / `CategoryTemplateItems` (schema v62 → v63), DB methods (`saveCategoriesAsTemplate`, `applyCategoryTemplate`, `renameCategoryTemplate`, `deleteCategoryTemplate`), a new `CategoryTemplatesScreen`, and 8 new tests in `test/category_templates_test.dart`.
- Design notes in `docs/superpowers/specs/2026-09-06-category-templates-design.md`.

**Note:** this branch (renamed from `feat/remember-account-and-category-insights`) already carried a series of prior, unmerged commits (multi-currency accounts, the Ready to Assign toggle redesign, etc.) pushed to origin before this session started — this diff includes those too, not just the category-templates work above.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test test/category_templates_test.dart` — 8/8 passing
- [x] `flutter test` (full suite) — 673/673 passing

Generated with: CODEAI
