### PR TITLE
feat: category templates — save and switch category structures (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Release process: see [docs/RELEASING.md](docs/RELEASING.md).
 ## [Unreleased]
 
 ### Added
+- **Category templates** (#101) — save your current category/sub-category
+  structure as a named template from Categories → the new templates icon,
+  and switch between saved templates any time. Switching never touches a
+  transaction: categories the target template doesn't have are archived
+  (same as a manual archive — their transactions keep them), categories it
+  does have are created or relabelled in place, and switching back later
+  reactivates the same categories rather than duplicating them.
 - **Auto rules: Goals & Loans (G&L)** — a recurring rule's Expense/Income
   toggle now has a third option, G&L: on schedule, it posts a transfer into
   a goal or a payment toward a loan instead of a category-tagged

--- a/docs/superpowers/specs/2026-09-06-category-templates-design.md
+++ b/docs/superpowers/specs/2026-09-06-category-templates-design.md
@@ -1,0 +1,75 @@
+# Category templates — design spec
+
+Date: 2026-09-06
+Status: implemented
+GitHub: #101
+
+## Background
+
+serrq's ask (#101): save the current category/sub-category structure as a
+reusable template, and switch between templates without losing the history of
+already-categorized transactions. Explicitly orthogonal to Ready to Assign —
+this is about which categories exist, not how money is allocated to them.
+
+## Why the existing archive rule makes this easy
+
+`Categories` already never hard-deletes — `AppDatabase.archiveCategory`'s own
+doc comment says why: "deleting a category orphans every past transaction
+that referenced it." Every transaction stores a `categoryId` pointing at a
+live `Categories` row, archived or not.
+
+That means "switch template" doesn't need to touch a single `Transactions`
+row. It only needs to change which `Categories` rows are archived vs. active:
+
+- A category in the *target* template but not currently active → created (or
+  unarchived + relabelled, if a same-named one already exists).
+- A category currently active but not in the *target* template → archived.
+  Every transaction that used it keeps pointing at the same (now-archived)
+  row, so reports and statements are untouched.
+
+Switching back later re-activates the old set the same way — nothing was
+ever deleted, so it's a free "revert."
+
+## Data model
+
+Two new tables, independent of `Categories`:
+
+- `CategoryTemplates` (id, name, createdAt) — one row per saved template.
+- `CategoryTemplateItems` (id, templateId, name, kind, colorValue, iconKey,
+  sortOrder, parentItemId) — a template's own category tree, exactly two
+  levels deep like `Categories.parentId`, but `parentItemId` resolves against
+  *other rows in the same template*, not live category ids. A template must
+  be applicable on a fresh install that has never seen these categories.
+
+## Matching: how "switch" maps template items onto live categories
+
+Live categories and template items are matched by
+`(kind, name.trim().toLowerCase(), parentName.trim().toLowerCase())` — not by
+id, since a template's ids are meaningless outside the template that made
+them. Two categories are "the same" if they have the same kind, name, and
+parent name.
+
+`applyCategoryTemplate`:
+1. Load the target template's items, parents before children.
+2. For each parent item: if a live top-level category matches, relabel it
+   (name/colour/icon) in place and record the match; otherwise create one.
+3. For each child item: same, nested under the (matched-or-created) live
+   parent from step 2.
+4. Any currently-active category (parent or child) that wasn't matched gets
+   archived — its transactions keep it, just hidden from new entries, same
+   as a manual archive.
+
+Re-nesting a live category that itself still has children (the two-level
+cap in `updateCategory`) can throw; `applyCategoryTemplate` catches that one
+case and keeps the category's existing parent rather than aborting the whole
+switch, so one awkward re-nest never blocks everything else in the template.
+
+## Non-goals (v1)
+
+- No community/shared template gallery — save/switch only, all local.
+- Templates aren't part of `exportAll`/`importAll` in this pass; they are a
+  local convenience over `Categories`, not part of the ledger itself, so a
+  ledger backup doesn't need to carry them for now. Revisit if requested.
+- No automatic re-run of budgets when a template switch archives a budgeted
+  category — `Budgets` already handles an archived category's row the same
+  way manual archiving does today.

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -15,6 +15,7 @@ import '../../features/budgets/budgets_screen.dart';
 import '../../features/budgets/ready_to_assign_screen.dart';
 import '../../features/calendar/calendar_screen.dart';
 import '../../features/categories/categories_screen.dart';
+import '../../features/categories/category_templates_screen.dart';
 import '../../features/dashboard/dashboard_screen.dart';
 import '../../features/data_export/backup_screen.dart';
 import '../../features/data_export/csv_import_screen.dart';
@@ -246,6 +247,13 @@ final appRouter = GoRouter(
                   path: 'categories',
                   parentNavigatorKey: _rootKey,
                   builder: (_, _) => const CategoriesScreen(),
+                  routes: [
+                    GoRoute(
+                      path: 'templates',
+                      parentNavigatorKey: _rootKey,
+                      builder: (_, _) => const CategoryTemplatesScreen(),
+                    ),
+                  ],
                 ),
                 GoRoute(
                   path: 'tags',

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -27,9 +27,8 @@ part 'database.g.dart';
 Money accountMovement(TransactionRow tx, Set<int> ownIds) => switch (tx.type) {
   TxType.income || TxType.personIn => tx.amount,
   TxType.expense || TxType.personOut => -tx.amount,
-  TxType.transfer => ownIds.contains(tx.accountId)
-      ? -tx.amount
-      : (tx.toAmount ?? tx.amount),
+  TxType.transfer =>
+    ownIds.contains(tx.accountId) ? -tx.amount : (tx.toAmount ?? tx.amount),
 };
 
 /// The gap between automatic backups for a given schedule. `monthly` is
@@ -152,6 +151,8 @@ typedef CombinedStatementLine = ({
     OcrCorrections,
     CreditCardDetails,
     CurrencyRates,
+    CategoryTemplates,
+    CategoryTemplateItems,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -177,7 +178,7 @@ class AppDatabase extends _$AppDatabase {
       );
 
   @override
-  int get schemaVersion => 62;
+  int get schemaVersion => 63;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -374,11 +375,7 @@ class AppDatabase extends _$AppDatabase {
           settings,
           settings.masterPhraseAttemptThreshold,
         );
-        await _addColumnIfMissing(
-          m,
-          settings,
-          settings.failedPasscodeAttempts,
-        );
+        await _addColumnIfMissing(m, settings, settings.failedPasscodeAttempts);
       }
       if (from < 42) {
         await _addColumnIfMissing(m, settings, settings.showBottomNavLabels);
@@ -407,7 +404,11 @@ class AppDatabase extends _$AppDatabase {
         await _addColumnIfMissing(m, recurringRules, recurringRules.note);
       }
       if (from < 48) {
-        await _addColumnIfMissing(m, recurringRules, recurringRules.promoAmount);
+        await _addColumnIfMissing(
+          m,
+          recurringRules,
+          recurringRules.promoAmount,
+        );
         await _addColumnIfMissing(
           m,
           recurringRules,
@@ -501,11 +502,7 @@ class AppDatabase extends _$AppDatabase {
           transactions.fxRateToBaseMicros,
         );
         await _addColumnIfMissing(m, transactions, transactions.toAmount);
-        await _addColumnIfMissing(
-          m,
-          transactions,
-          transactions.toCurrencyCode,
-        );
+        await _addColumnIfMissing(m, transactions, transactions.toCurrencyCode);
         await _addColumnIfMissing(
           m,
           transactions,
@@ -526,11 +523,17 @@ class AppDatabase extends _$AppDatabase {
         // Envelope-mode user's accounts don't silently fall out of the pool.
         await _addColumnIfMissing(m, settings, settings.rtaEnabled);
         final current = await select(settings).getSingleOrNull();
-        if (current != null && current.budgetingMode == BudgetingMode.envelope) {
+        if (current != null &&
+            current.budgetingMode == BudgetingMode.envelope) {
           await update(
             settings,
           ).write(const SettingsCompanion(rtaEnabled: Value(true)));
         }
+      }
+      if (from < 63) {
+        // GitHub #101 — saveable, switchable category templates.
+        await m.createTable(categoryTemplates);
+        await m.createTable(categoryTemplateItems);
       }
     },
     beforeOpen: (details) async {
@@ -894,8 +897,9 @@ class AppDatabase extends _$AppDatabase {
         await _adjust(t.accountId, -amt);
       case TxType.transfer:
         await _adjust(t.accountId, -amt);
-        final creditAmt =
-            t.toAmount == null ? amt : Money(t.toAmount!.paise * sign);
+        final creditAmt = t.toAmount == null
+            ? amt
+            : Money(t.toAmount!.paise * sign);
         await _adjust(t.toAccountId!, creditAmt);
     }
   }
@@ -1040,7 +1044,10 @@ class AppDatabase extends _$AppDatabase {
   /// downstream total, so this fails loudly instead and the UI is
   /// responsible for steering the user to the Currency settings screen
   /// first.
-  Future<(String?, int?)> _resolveTxCurrency(int accountId, DateTime date) async {
+  Future<(String?, int?)> _resolveTxCurrency(
+    int accountId,
+    DateTime date,
+  ) async {
     final account = await (select(
       accounts,
     )..where((a) => a.id.equals(accountId))).getSingle();
@@ -1552,9 +1559,9 @@ class AppDatabase extends _$AppDatabase {
   )..orderBy([(g) => OrderingTerm(expression: g.name)])).watch();
 
   Future<int> addTagGroup({required String name, required int colorValue}) =>
-      into(tagGroups).insert(
-        TagGroupsCompanion.insert(name: name, colorValue: colorValue),
-      );
+      into(
+        tagGroups,
+      ).insert(TagGroupsCompanion.insert(name: name, colorValue: colorValue));
 
   Future<void> updateTagGroup({
     required int id,
@@ -1592,9 +1599,9 @@ class AppDatabase extends _$AppDatabase {
         tagGroupTags,
       )..where((t) => t.groupId.equals(groupId))).go();
       for (final tagId in tagIds) {
-        await into(tagGroupTags).insert(
-          TagGroupTagsCompanion.insert(groupId: groupId, tagId: tagId),
-        );
+        await into(
+          tagGroupTags,
+        ).insert(TagGroupTagsCompanion.insert(groupId: groupId, tagId: tagId));
       }
     });
   }
@@ -1757,15 +1764,13 @@ class AppDatabase extends _$AppDatabase {
 
   // ── Credit card statements (GitHub #91) ─────────────────────────────────
 
-  Future<CreditCardDetailRow?> getCreditCardDetails(int accountId) =>
-      (select(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).getSingleOrNull();
+  Future<CreditCardDetailRow?> getCreditCardDetails(int accountId) => (select(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).getSingleOrNull();
 
-  Stream<CreditCardDetailRow?> watchCreditCardDetails(int accountId) =>
-      (select(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).watchSingleOrNull();
+  Stream<CreditCardDetailRow?> watchCreditCardDetails(int accountId) => (select(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).watchSingleOrNull();
 
   /// Every credit card currently tracking a statement cycle — what
   /// [NotificationService.syncCreditCardReminders] schedules a due-date
@@ -1805,10 +1810,9 @@ class AppDatabase extends _$AppDatabase {
 
   /// Turns tracking back off — the card itself is untouched, only the
   /// cycle it was reporting against.
-  Future<void> deleteCreditCardDetails(int accountId) =>
-      (delete(
-        creditCardDetails,
-      )..where((c) => c.accountId.equals(accountId))).go();
+  Future<void> deleteCreditCardDetails(int accountId) => (delete(
+    creditCardDetails,
+  )..where((c) => c.accountId.equals(accountId))).go();
 
   /// The last real day of [year]/[month] if [day] overshoots it (e.g. the
   /// 31st in a 30-day month) — the same snapping [_nextOccurrence] applies
@@ -2257,10 +2261,7 @@ class AppDatabase extends _$AppDatabase {
   /// to now) — `null` if none has been entered yet as of that date. This is
   /// what a transaction snapshots at post time, and what a live figure
   /// (Net Worth) resolves with `asOf` left at its default.
-  Future<CurrencyRateRow?> latestRate(
-    String currencyCode, {
-    DateTime? asOf,
-  }) {
+  Future<CurrencyRateRow?> latestRate(String currencyCode, {DateTime? asOf}) {
     final cutoff = asOf ?? DateTime.now();
     return (select(currencyRates)
           ..where(
@@ -2269,8 +2270,10 @@ class AppDatabase extends _$AppDatabase {
                 r.effectiveAt.isSmallerOrEqualValue(cutoff),
           )
           ..orderBy([
-            (r) =>
-                OrderingTerm(expression: r.effectiveAt, mode: OrderingMode.desc),
+            (r) => OrderingTerm(
+              expression: r.effectiveAt,
+              mode: OrderingMode.desc,
+            ),
           ])
           ..limit(1))
         .getSingleOrNull();
@@ -2343,23 +2346,22 @@ class AppDatabase extends _$AppDatabase {
   /// has been entered for its currency yet, its raw balance is added
   /// unconverted rather than dropping it or throwing, so an incomplete
   /// Currency setup never breaks the dashboard.
-  Stream<Money> watchNetWorth() => watchBalanceHoldingAccounts().asyncMap((
-    rows,
-  ) async {
-    var total = const Money.zero();
-    for (final a in rows) {
-      if (!a.includeInNetWorth) continue;
-      if (a.currencyCode == null) {
-        total += a.currentBalance;
-        continue;
-      }
-      final rate = await latestRate(a.currencyCode!);
-      total += rate == null
-          ? a.currentBalance
-          : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
-    }
-    return total;
-  });
+  Stream<Money> watchNetWorth() =>
+      watchBalanceHoldingAccounts().asyncMap((rows) async {
+        var total = const Money.zero();
+        for (final a in rows) {
+          if (!a.includeInNetWorth) continue;
+          if (a.currencyCode == null) {
+            total += a.currentBalance;
+            continue;
+          }
+          final rate = await latestRate(a.currencyCode!);
+          total += rate == null
+              ? a.currentBalance
+              : convertUsingRate(a.currentBalance, rate.rateToBaseMicros);
+        }
+        return total;
+      });
 
   /// Flips whether [id]'s balance counts toward [watchNetWorth] — the toggle
   /// behind Settings > Customize Dashboard.
@@ -3034,9 +3036,9 @@ class AppDatabase extends _$AppDatabase {
 
   // ── Groups CRUD ───────────────────────────────────────────────────────────
 
-  Future<int> addGroup(String name, {String? note}) => into(groups).insert(
-    GroupsCompanion.insert(name: name, note: Value(note)),
-  );
+  Future<int> addGroup(String name, {String? note}) => into(
+    groups,
+  ).insert(GroupsCompanion.insert(name: name, note: Value(note)));
 
   Future<void> updateGroup({
     required int id,
@@ -3073,7 +3075,9 @@ class AppDatabase extends _$AppDatabase {
   /// history. Anything used must be archived instead.
   Future<void> deleteGroup(int id) async {
     if (await countExpensesForGroup(id) > 0) {
-      throw ArgumentError('This group has expense history — archive it instead.');
+      throw ArgumentError(
+        'This group has expense history — archive it instead.',
+      );
     }
     await transaction(() async {
       await (delete(groupMembers)..where((m) => m.groupId.equals(id))).go();
@@ -3101,11 +3105,12 @@ class AppDatabase extends _$AppDatabase {
   /// [addGroupExpense] distributes a rounding remainder in, so which member
   /// gets an extra paisa is stable, not arbitrary.
   Stream<List<PersonRow>> watchGroupMembers(int groupId) {
-    final query = select(groupMembers).join([
-      innerJoin(persons, persons.id.equalsExp(groupMembers.personId)),
-    ])
-      ..where(groupMembers.groupId.equals(groupId))
-      ..orderBy([OrderingTerm.asc(groupMembers.id)]);
+    final query =
+        select(groupMembers).join([
+            innerJoin(persons, persons.id.equalsExp(groupMembers.personId)),
+          ])
+          ..where(groupMembers.groupId.equals(groupId))
+          ..orderBy([OrderingTerm.asc(groupMembers.id)]);
     return query.watch().map(
       (rows) => rows.map((r) => r.readTable(persons)).toList(),
     );
@@ -3759,14 +3764,15 @@ class AppDatabase extends _$AppDatabase {
               dayOfMonth: rule.dayOfMonth,
             );
           }
-          await (update(recurringRules)..where((r) => r.id.equals(rule.id)))
-              .write(
-                RecurringRulesCompanion(
-                  nextDueDate: Value(next),
-                  promoAmount: Value(promoAmount),
-                  promoOccurrencesLeft: Value(promoLeft),
-                ),
-              );
+          await (update(
+            recurringRules,
+          )..where((r) => r.id.equals(rule.id))).write(
+            RecurringRulesCompanion(
+              nextDueDate: Value(next),
+              promoAmount: Value(promoAmount),
+              promoOccurrencesLeft: Value(promoLeft),
+            ),
+          );
         });
       } catch (_) {
         // One rule that can no longer post (its account stopped being
@@ -4268,9 +4274,8 @@ class AppDatabase extends _$AppDatabase {
   Future<void> setRevolutEnabled(bool value) =>
       update(settings).write(SettingsCompanion(revolutEnabled: Value(value)));
 
-  Future<void> setLockScreenStyle(LockScreenStyle style) => update(
-    settings,
-  ).write(SettingsCompanion(lockScreenStyle: Value(style)));
+  Future<void> setLockScreenStyle(LockScreenStyle style) =>
+      update(settings).write(SettingsCompanion(lockScreenStyle: Value(style)));
 
   Future<void> setMoreScreenViewMode(MoreScreenViewMode mode) => update(
     settings,
@@ -4284,9 +4289,7 @@ class AppDatabase extends _$AppDatabase {
   /// reads it while RTA is off), so turning it back on re-enrolls everyone
   /// anyway per the branch below — no data is lost either direction.
   Future<void> setRtaEnabled(bool enabled) => transaction(() async {
-    await update(
-      settings,
-    ).write(SettingsCompanion(rtaEnabled: Value(enabled)));
+    await update(settings).write(SettingsCompanion(rtaEnabled: Value(enabled)));
     if (enabled) {
       await update(
         accounts,
@@ -4391,9 +4394,9 @@ class AppDatabase extends _$AppDatabase {
   /// fall back to.
   Future<void> setMasterPhraseAttemptThreshold(int attempts) async {
     if ((await getSettings()).masterPhraseHash == null) return;
-    await update(settings).write(
-      SettingsCompanion(masterPhraseAttemptThreshold: Value(attempts)),
-    );
+    await update(
+      settings,
+    ).write(SettingsCompanion(masterPhraseAttemptThreshold: Value(attempts)));
   }
 
   /// Increments the persisted wrong-PIN counter and returns the new count —
@@ -4468,9 +4471,8 @@ class AppDatabase extends _$AppDatabase {
     settings,
   ).write(SettingsCompanion(showBottomNavLabels: Value(value)));
 
-  Future<void> setHoldMenuEnabled(bool value) => update(
-    settings,
-  ).write(SettingsCompanion(holdMenuEnabled: Value(value)));
+  Future<void> setHoldMenuEnabled(bool value) =>
+      update(settings).write(SettingsCompanion(holdMenuEnabled: Value(value)));
 
   Future<void> setHoldMenuSlots(List<String> ids) async {
     if (ids.length != 3 || ids.toSet().length != 3) {
@@ -4487,9 +4489,9 @@ class AppDatabase extends _$AppDatabase {
   /// Clamped to a sane range here, not just in the settings slider — this is
   /// the only path a stray value (a bad restore, a future scripted call)
   /// could take to reach the column.
-  Future<void> setExtraBottomInset(int px) => update(settings).write(
-    SettingsCompanion(extraBottomInset: Value(px.clamp(0, 40))),
-  );
+  Future<void> setExtraBottomInset(int px) => update(
+    settings,
+  ).write(SettingsCompanion(extraBottomInset: Value(px.clamp(0, 40))));
 
   /// Bumps [key] to the front of `Settings.frequentIconKeys` — the icon sheet
   /// calls this whenever an icon is picked. Capped at 12 so the "Frequently
@@ -4804,6 +4806,220 @@ class AppDatabase extends _$AppDatabase {
     )..where((t) => t.categoryId.equals(categoryId))).get();
     return rows.length;
   }
+
+  // ── Category templates (GitHub #101) ────────────────────────────────────
+  //
+  // A template is a named snapshot of a category/sub-category structure.
+  // Switching to one never touches `Transactions` — it only changes which
+  // `Categories` rows are archived vs. active, the same as a manual archive.
+  // See docs/superpowers/specs/2026-09-06-category-templates-design.md.
+
+  /// Matches a live category or template item to "the same" one elsewhere —
+  /// by kind, name and parent *name*, never by id (a template's own ids are
+  /// meaningless once applied on a different device/dataset).
+  String _categoryMatchKey(CategoryKind kind, String name, String? parentName) {
+    final normalizedParent = parentName?.trim().toLowerCase() ?? '';
+    return '${kind.name}|$normalizedParent|${name.trim().toLowerCase()}';
+  }
+
+  Stream<List<CategoryTemplateRow>> watchCategoryTemplates() =>
+      (select(categoryTemplates)..orderBy([
+            (t) =>
+                OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+          ]))
+          .watch();
+
+  Stream<List<CategoryTemplateItemRow>> watchCategoryTemplateItems(
+    int templateId,
+  ) =>
+      (select(categoryTemplateItems)
+            ..where((i) => i.templateId.equals(templateId))
+            ..orderBy([(i) => OrderingTerm(expression: i.sortOrder)]))
+          .watch();
+
+  /// Snapshots every currently-active category (both kinds) into a brand new
+  /// template. A child whose parent isn't itself active (a dangling
+  /// `parentId`, same edge case `_flatten` in the Categories screen guards)
+  /// is skipped rather than saved half-nested.
+  Future<int> saveCategoriesAsTemplate(String name) => transaction(() async {
+    final templateId = await into(
+      categoryTemplates,
+    ).insert(CategoryTemplatesCompanion.insert(name: name));
+
+    final active = await (select(
+      categories,
+    )..where((c) => c.isArchived.equals(false))).get();
+    final parents = active.where((c) => c.parentId == null).toList();
+    final itemIdByCategoryId = <int, int>{};
+
+    for (final p in parents) {
+      final itemId = await into(categoryTemplateItems).insert(
+        CategoryTemplateItemsCompanion.insert(
+          templateId: templateId,
+          name: p.name,
+          kind: p.kind,
+          colorValue: p.colorValue,
+          iconKey: p.iconKey,
+          sortOrder: Value(p.sortOrder),
+        ),
+      );
+      itemIdByCategoryId[p.id] = itemId;
+    }
+    for (final c in active.where((c) => c.parentId != null)) {
+      final parentItemId = itemIdByCategoryId[c.parentId];
+      if (parentItemId == null) continue;
+      await into(categoryTemplateItems).insert(
+        CategoryTemplateItemsCompanion.insert(
+          templateId: templateId,
+          name: c.name,
+          kind: c.kind,
+          colorValue: c.colorValue,
+          iconKey: c.iconKey,
+          sortOrder: Value(c.sortOrder),
+          parentItemId: Value(parentItemId),
+        ),
+      );
+    }
+    return templateId;
+  });
+
+  Future<void> renameCategoryTemplate(int id, String name) =>
+      (update(categoryTemplates)..where((t) => t.id.equals(id))).write(
+        CategoryTemplatesCompanion(name: Value(name)),
+      );
+
+  Future<void> deleteCategoryTemplate(int id) => transaction(() async {
+    await (delete(
+      categoryTemplateItems,
+    )..where((i) => i.templateId.equals(id))).go();
+    await (delete(categoryTemplates)..where((t) => t.id.equals(id))).go();
+  });
+
+  /// Switches the live category set to match [templateId]'s structure,
+  /// without ever touching a transaction:
+  ///
+  /// - A template item that matches an existing category (by
+  ///   [_categoryMatchKey], active **or** archived) relabels that category
+  ///   in place (name, colour, icon) and unarchives it if needed, instead of
+  ///   making a duplicate — this is what makes switching back to a template
+  ///   used before a free "revert" rather than a fresh rebuild.
+  /// - A template item with no match gets created fresh.
+  /// - A live active category that no template item matches gets archived —
+  ///   exactly like a manual archive, so its transactions keep it and only
+  ///   disappear from new-entry pickers.
+  Future<void> applyCategoryTemplate(int templateId) => transaction(() async {
+    final items = await (select(
+      categoryTemplateItems,
+    )..where((i) => i.templateId.equals(templateId))).get();
+    if (items.isEmpty) {
+      throw ArgumentError('This template has no categories to switch to.');
+    }
+    final itemsById = {for (final i in items) i.id: i};
+    String keyOf(CategoryTemplateItemRow i) {
+      final parentName = i.parentItemId == null
+          ? null
+          : itemsById[i.parentItemId]?.name;
+      return _categoryMatchKey(i.kind, i.name, parentName);
+    }
+
+    final all = await select(categories).get();
+    final byId = {for (final c in all) c.id: c};
+    String keyOfCategory(CategoryRow c) {
+      final parentName = c.parentId == null ? null : byId[c.parentId]?.name;
+      return _categoryMatchKey(c.kind, c.name, parentName);
+    }
+
+    // Archived rows first, active rows second — if a key somehow matches
+    // both (a stray duplicate), the map ends up pointing at the active one,
+    // so an already-live category is never displaced by reactivating a
+    // stale archived duplicate of itself.
+    final byKey = <String, CategoryRow>{};
+    for (final c in all.where((c) => c.isArchived)) {
+      byKey[keyOfCategory(c)] = c;
+    }
+    for (final c in all.where((c) => !c.isArchived)) {
+      byKey[keyOfCategory(c)] = c;
+    }
+    final active = all.where((c) => !c.isArchived).toList();
+
+    final matchedIds = <int>{};
+    final liveIdByItemId = <int, int>{};
+
+    Future<void> reuse(
+      CategoryRow existing,
+      CategoryTemplateItemRow item,
+      Value<int?> parentId,
+    ) async {
+      matchedIds.add(existing.id);
+      if (existing.isArchived) {
+        await (update(categories)..where((cc) => cc.id.equals(existing.id)))
+            .write(const CategoriesCompanion(isArchived: Value(false)));
+      }
+      try {
+        await updateCategory(
+          id: existing.id,
+          name: item.name,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+          parentId: parentId,
+        );
+      } on ArgumentError {
+        // Most likely: `existing` still has children of its own, so the
+        // two-level cap in `updateCategory` refuses to nest it under
+        // someone else. Keep its current placement rather than aborting the
+        // whole switch over one awkward re-nest.
+        if (parentId.present && parentId.value != null) {
+          await updateCategory(
+            id: existing.id,
+            name: item.name,
+            colorValue: item.colorValue,
+            iconKey: item.iconKey,
+          );
+        } else {
+          rethrow;
+        }
+      }
+    }
+
+    // Parents first, so children below can resolve their live parent id.
+    for (final item in items.where((i) => i.parentItemId == null)) {
+      final existing = byKey[keyOf(item)];
+      if (existing != null) {
+        liveIdByItemId[item.id] = existing.id;
+        await reuse(existing, item, const Value(null));
+      } else {
+        liveIdByItemId[item.id] = await addCategory(
+          name: item.name,
+          kind: item.kind,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+        );
+      }
+    }
+    for (final item in items.where((i) => i.parentItemId != null)) {
+      final existing = byKey[keyOf(item)];
+      final liveParentId = liveIdByItemId[item.parentItemId];
+      if (existing != null) {
+        await reuse(existing, item, Value(liveParentId));
+      } else if (liveParentId != null) {
+        await addCategory(
+          name: item.name,
+          kind: item.kind,
+          colorValue: item.colorValue,
+          iconKey: item.iconKey,
+          parentId: liveParentId,
+        );
+      }
+    }
+
+    for (final c in active) {
+      if (!matchedIds.contains(c.id)) {
+        await (update(categories)..where((cc) => cc.id.equals(c.id))).write(
+          const CategoriesCompanion(isArchived: Value(true)),
+        );
+      }
+    }
+  });
 
   // ── Per-account history ───────────────────────────────────────────────────
 

--- a/lib/data/database.g.dart
+++ b/lib/data/database.g.dart
@@ -20087,6 +20087,791 @@ class CurrencyRatesCompanion extends UpdateCompanion<CurrencyRateRow> {
   }
 }
 
+class $CategoryTemplatesTable extends CategoryTemplates
+    with TableInfo<$CategoryTemplatesTable, CategoryTemplateRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoryTemplatesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 60,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+    defaultValue: currentDateAndTime,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, name, createdAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'category_templates';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CategoryTemplateRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CategoryTemplateRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CategoryTemplateRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+    );
+  }
+
+  @override
+  $CategoryTemplatesTable createAlias(String alias) {
+    return $CategoryTemplatesTable(attachedDatabase, alias);
+  }
+}
+
+class CategoryTemplateRow extends DataClass
+    implements Insertable<CategoryTemplateRow> {
+  final int id;
+  final String name;
+  final DateTime createdAt;
+  const CategoryTemplateRow({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    return map;
+  }
+
+  CategoryTemplatesCompanion toCompanion(bool nullToAbsent) {
+    return CategoryTemplatesCompanion(
+      id: Value(id),
+      name: Value(name),
+      createdAt: Value(createdAt),
+    );
+  }
+
+  factory CategoryTemplateRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CategoryTemplateRow(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+    };
+  }
+
+  CategoryTemplateRow copyWith({int? id, String? name, DateTime? createdAt}) =>
+      CategoryTemplateRow(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        createdAt: createdAt ?? this.createdAt,
+      );
+  CategoryTemplateRow copyWithCompanion(CategoryTemplatesCompanion data) {
+    return CategoryTemplateRow(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateRow(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, createdAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CategoryTemplateRow &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.createdAt == this.createdAt);
+}
+
+class CategoryTemplatesCompanion extends UpdateCompanion<CategoryTemplateRow> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<DateTime> createdAt;
+  const CategoryTemplatesCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.createdAt = const Value.absent(),
+  });
+  CategoryTemplatesCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    this.createdAt = const Value.absent(),
+  }) : name = Value(name);
+  static Insertable<CategoryTemplateRow> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<DateTime>? createdAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (createdAt != null) 'created_at': createdAt,
+    });
+  }
+
+  CategoryTemplatesCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<DateTime>? createdAt,
+  }) {
+    return CategoryTemplatesCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplatesCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('createdAt: $createdAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $CategoryTemplateItemsTable extends CategoryTemplateItems
+    with TableInfo<$CategoryTemplateItemsTable, CategoryTemplateItemRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CategoryTemplateItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _templateIdMeta = const VerificationMeta(
+    'templateId',
+  );
+  @override
+  late final GeneratedColumn<int> templateId = GeneratedColumn<int>(
+    'template_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES category_templates (id)',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 40,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  late final GeneratedColumnWithTypeConverter<CategoryKind, String> kind =
+      GeneratedColumn<String>(
+        'kind',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      ).withConverter<CategoryKind>($CategoryTemplateItemsTable.$converterkind);
+  static const VerificationMeta _colorValueMeta = const VerificationMeta(
+    'colorValue',
+  );
+  @override
+  late final GeneratedColumn<int> colorValue = GeneratedColumn<int>(
+    'color_value',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _iconKeyMeta = const VerificationMeta(
+    'iconKey',
+  );
+  @override
+  late final GeneratedColumn<String> iconKey = GeneratedColumn<String>(
+    'icon_key',
+    aliasedName,
+    false,
+    additionalChecks: GeneratedColumn.checkTextLength(
+      minTextLength: 1,
+      maxTextLength: 40,
+    ),
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sortOrderMeta = const VerificationMeta(
+    'sortOrder',
+  );
+  @override
+  late final GeneratedColumn<int> sortOrder = GeneratedColumn<int>(
+    'sort_order',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _parentItemIdMeta = const VerificationMeta(
+    'parentItemId',
+  );
+  @override
+  late final GeneratedColumn<int> parentItemId = GeneratedColumn<int>(
+    'parent_item_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    templateId,
+    name,
+    kind,
+    colorValue,
+    iconKey,
+    sortOrder,
+    parentItemId,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'category_template_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CategoryTemplateItemRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('template_id')) {
+      context.handle(
+        _templateIdMeta,
+        templateId.isAcceptableOrUnknown(data['template_id']!, _templateIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_templateIdMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('color_value')) {
+      context.handle(
+        _colorValueMeta,
+        colorValue.isAcceptableOrUnknown(data['color_value']!, _colorValueMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_colorValueMeta);
+    }
+    if (data.containsKey('icon_key')) {
+      context.handle(
+        _iconKeyMeta,
+        iconKey.isAcceptableOrUnknown(data['icon_key']!, _iconKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_iconKeyMeta);
+    }
+    if (data.containsKey('sort_order')) {
+      context.handle(
+        _sortOrderMeta,
+        sortOrder.isAcceptableOrUnknown(data['sort_order']!, _sortOrderMeta),
+      );
+    }
+    if (data.containsKey('parent_item_id')) {
+      context.handle(
+        _parentItemIdMeta,
+        parentItemId.isAcceptableOrUnknown(
+          data['parent_item_id']!,
+          _parentItemIdMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CategoryTemplateItemRow map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CategoryTemplateItemRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      templateId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}template_id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      kind: $CategoryTemplateItemsTable.$converterkind.fromSql(
+        attachedDatabase.typeMapping.read(
+          DriftSqlType.string,
+          data['${effectivePrefix}kind'],
+        )!,
+      ),
+      colorValue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}color_value'],
+      )!,
+      iconKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}icon_key'],
+      )!,
+      sortOrder: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}sort_order'],
+      )!,
+      parentItemId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}parent_item_id'],
+      ),
+    );
+  }
+
+  @override
+  $CategoryTemplateItemsTable createAlias(String alias) {
+    return $CategoryTemplateItemsTable(attachedDatabase, alias);
+  }
+
+  static JsonTypeConverter2<CategoryKind, String, String> $converterkind =
+      const EnumNameConverter<CategoryKind>(CategoryKind.values);
+}
+
+class CategoryTemplateItemRow extends DataClass
+    implements Insertable<CategoryTemplateItemRow> {
+  final int id;
+  final int templateId;
+  final String name;
+  final CategoryKind kind;
+  final int colorValue;
+  final String iconKey;
+  final int sortOrder;
+  final int? parentItemId;
+  const CategoryTemplateItemRow({
+    required this.id,
+    required this.templateId,
+    required this.name,
+    required this.kind,
+    required this.colorValue,
+    required this.iconKey,
+    required this.sortOrder,
+    this.parentItemId,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['template_id'] = Variable<int>(templateId);
+    map['name'] = Variable<String>(name);
+    {
+      map['kind'] = Variable<String>(
+        $CategoryTemplateItemsTable.$converterkind.toSql(kind),
+      );
+    }
+    map['color_value'] = Variable<int>(colorValue);
+    map['icon_key'] = Variable<String>(iconKey);
+    map['sort_order'] = Variable<int>(sortOrder);
+    if (!nullToAbsent || parentItemId != null) {
+      map['parent_item_id'] = Variable<int>(parentItemId);
+    }
+    return map;
+  }
+
+  CategoryTemplateItemsCompanion toCompanion(bool nullToAbsent) {
+    return CategoryTemplateItemsCompanion(
+      id: Value(id),
+      templateId: Value(templateId),
+      name: Value(name),
+      kind: Value(kind),
+      colorValue: Value(colorValue),
+      iconKey: Value(iconKey),
+      sortOrder: Value(sortOrder),
+      parentItemId: parentItemId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentItemId),
+    );
+  }
+
+  factory CategoryTemplateItemRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CategoryTemplateItemRow(
+      id: serializer.fromJson<int>(json['id']),
+      templateId: serializer.fromJson<int>(json['templateId']),
+      name: serializer.fromJson<String>(json['name']),
+      kind: $CategoryTemplateItemsTable.$converterkind.fromJson(
+        serializer.fromJson<String>(json['kind']),
+      ),
+      colorValue: serializer.fromJson<int>(json['colorValue']),
+      iconKey: serializer.fromJson<String>(json['iconKey']),
+      sortOrder: serializer.fromJson<int>(json['sortOrder']),
+      parentItemId: serializer.fromJson<int?>(json['parentItemId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'templateId': serializer.toJson<int>(templateId),
+      'name': serializer.toJson<String>(name),
+      'kind': serializer.toJson<String>(
+        $CategoryTemplateItemsTable.$converterkind.toJson(kind),
+      ),
+      'colorValue': serializer.toJson<int>(colorValue),
+      'iconKey': serializer.toJson<String>(iconKey),
+      'sortOrder': serializer.toJson<int>(sortOrder),
+      'parentItemId': serializer.toJson<int?>(parentItemId),
+    };
+  }
+
+  CategoryTemplateItemRow copyWith({
+    int? id,
+    int? templateId,
+    String? name,
+    CategoryKind? kind,
+    int? colorValue,
+    String? iconKey,
+    int? sortOrder,
+    Value<int?> parentItemId = const Value.absent(),
+  }) => CategoryTemplateItemRow(
+    id: id ?? this.id,
+    templateId: templateId ?? this.templateId,
+    name: name ?? this.name,
+    kind: kind ?? this.kind,
+    colorValue: colorValue ?? this.colorValue,
+    iconKey: iconKey ?? this.iconKey,
+    sortOrder: sortOrder ?? this.sortOrder,
+    parentItemId: parentItemId.present
+        ? parentItemId.value
+        : this.parentItemId,
+  );
+  CategoryTemplateItemRow copyWithCompanion(
+    CategoryTemplateItemsCompanion data,
+  ) {
+    return CategoryTemplateItemRow(
+      id: data.id.present ? data.id.value : this.id,
+      templateId: data.templateId.present
+          ? data.templateId.value
+          : this.templateId,
+      name: data.name.present ? data.name.value : this.name,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      colorValue: data.colorValue.present
+          ? data.colorValue.value
+          : this.colorValue,
+      iconKey: data.iconKey.present ? data.iconKey.value : this.iconKey,
+      sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
+      parentItemId: data.parentItemId.present
+          ? data.parentItemId.value
+          : this.parentItemId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateItemRow(')
+          ..write('id: $id, ')
+          ..write('templateId: $templateId, ')
+          ..write('name: $name, ')
+          ..write('kind: $kind, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('iconKey: $iconKey, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('parentItemId: $parentItemId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    templateId,
+    name,
+    kind,
+    colorValue,
+    iconKey,
+    sortOrder,
+    parentItemId,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CategoryTemplateItemRow &&
+          other.id == this.id &&
+          other.templateId == this.templateId &&
+          other.name == this.name &&
+          other.kind == this.kind &&
+          other.colorValue == this.colorValue &&
+          other.iconKey == this.iconKey &&
+          other.sortOrder == this.sortOrder &&
+          other.parentItemId == this.parentItemId);
+}
+
+class CategoryTemplateItemsCompanion
+    extends UpdateCompanion<CategoryTemplateItemRow> {
+  final Value<int> id;
+  final Value<int> templateId;
+  final Value<String> name;
+  final Value<CategoryKind> kind;
+  final Value<int> colorValue;
+  final Value<String> iconKey;
+  final Value<int> sortOrder;
+  final Value<int?> parentItemId;
+  const CategoryTemplateItemsCompanion({
+    this.id = const Value.absent(),
+    this.templateId = const Value.absent(),
+    this.name = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.colorValue = const Value.absent(),
+    this.iconKey = const Value.absent(),
+    this.sortOrder = const Value.absent(),
+    this.parentItemId = const Value.absent(),
+  });
+  CategoryTemplateItemsCompanion.insert({
+    this.id = const Value.absent(),
+    required int templateId,
+    required String name,
+    required CategoryKind kind,
+    required int colorValue,
+    required String iconKey,
+    this.sortOrder = const Value.absent(),
+    this.parentItemId = const Value.absent(),
+  }) : templateId = Value(templateId),
+       name = Value(name),
+       kind = Value(kind),
+       colorValue = Value(colorValue),
+       iconKey = Value(iconKey);
+  static Insertable<CategoryTemplateItemRow> custom({
+    Expression<int>? id,
+    Expression<int>? templateId,
+    Expression<String>? name,
+    Expression<String>? kind,
+    Expression<int>? colorValue,
+    Expression<String>? iconKey,
+    Expression<int>? sortOrder,
+    Expression<int>? parentItemId,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (templateId != null) 'template_id': templateId,
+      if (name != null) 'name': name,
+      if (kind != null) 'kind': kind,
+      if (colorValue != null) 'color_value': colorValue,
+      if (iconKey != null) 'icon_key': iconKey,
+      if (sortOrder != null) 'sort_order': sortOrder,
+      if (parentItemId != null) 'parent_item_id': parentItemId,
+    });
+  }
+
+  CategoryTemplateItemsCompanion copyWith({
+    Value<int>? id,
+    Value<int>? templateId,
+    Value<String>? name,
+    Value<CategoryKind>? kind,
+    Value<int>? colorValue,
+    Value<String>? iconKey,
+    Value<int>? sortOrder,
+    Value<int?>? parentItemId,
+  }) {
+    return CategoryTemplateItemsCompanion(
+      id: id ?? this.id,
+      templateId: templateId ?? this.templateId,
+      name: name ?? this.name,
+      kind: kind ?? this.kind,
+      colorValue: colorValue ?? this.colorValue,
+      iconKey: iconKey ?? this.iconKey,
+      sortOrder: sortOrder ?? this.sortOrder,
+      parentItemId: parentItemId ?? this.parentItemId,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (templateId.present) {
+      map['template_id'] = Variable<int>(templateId.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(
+        $CategoryTemplateItemsTable.$converterkind.toSql(kind.value),
+      );
+    }
+    if (colorValue.present) {
+      map['color_value'] = Variable<int>(colorValue.value);
+    }
+    if (iconKey.present) {
+      map['icon_key'] = Variable<String>(iconKey.value);
+    }
+    if (sortOrder.present) {
+      map['sort_order'] = Variable<int>(sortOrder.value);
+    }
+    if (parentItemId.present) {
+      map['parent_item_id'] = Variable<int>(parentItemId.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CategoryTemplateItemsCompanion(')
+          ..write('id: $id, ')
+          ..write('templateId: $templateId, ')
+          ..write('name: $name, ')
+          ..write('kind: $kind, ')
+          ..write('colorValue: $colorValue, ')
+          ..write('iconKey: $iconKey, ')
+          ..write('sortOrder: $sortOrder, ')
+          ..write('parentItemId: $parentItemId')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -20131,6 +20916,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $CreditCardDetailsTable creditCardDetails =
       $CreditCardDetailsTable(this);
   late final $CurrencyRatesTable currencyRates = $CurrencyRatesTable(this);
+  late final $CategoryTemplatesTable categoryTemplates =
+      $CategoryTemplatesTable(this);
+  late final $CategoryTemplateItemsTable categoryTemplateItems =
+      $CategoryTemplateItemsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -20169,6 +20958,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     ocrCorrections,
     creditCardDetails,
     currencyRates,
+    categoryTemplates,
+    categoryTemplateItems,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([

--- a/lib/data/providers.dart
+++ b/lib/data/providers.dart
@@ -67,6 +67,18 @@ final categoryMapProvider = Provider<Map<int, CategoryRow>>((ref) {
   };
 });
 
+/// Saved category templates (GitHub #101), newest first.
+final categoryTemplatesProvider = StreamProvider<List<CategoryTemplateRow>>(
+  (ref) => ref.watch(dbProvider).watchCategoryTemplates(),
+);
+
+/// One template's own category items, for previewing before applying it.
+final categoryTemplateItemsProvider =
+    StreamProvider.family<List<CategoryTemplateItemRow>, int>(
+      (ref, templateId) =>
+          ref.watch(dbProvider).watchCategoryTemplateItems(templateId),
+    );
+
 /// A category's top-level ancestor. The tree is two deep, so a child resolves
 /// to its parent and a parent (or an unknown id) resolves to itself. Used to
 /// roll subcategory spend up into the parent it belongs to.
@@ -430,10 +442,7 @@ final defaultEnvelopeAccountIdProvider = Provider<int?>((ref) {
 /// everyday spending would silently drain the shared pool. Never touches
 /// [Accounts.currentBalance] or `net worth` — Envelope Mode only re-labels
 /// money already correctly tracked by the ledger, it never moves any.
-final categoryBalanceProvider = Provider.family<Money, int>((
-  ref,
-  categoryId,
-) {
+final categoryBalanceProvider = Provider.family<Money, int>((ref, categoryId) {
   final poolAccountIds = {
     for (final a in ref.watch(envelopeModeAccountsProvider)) a.id,
   };
@@ -462,21 +471,19 @@ enum CategoryFundingState { overspent, funded, underfunded }
 
 /// Returns null when [categoryId] has no [Budgets] row — there's nothing to
 /// color either way, in RTA on or off.
-final categoryFundingStateProvider = Provider.family<CategoryFundingState?, int>((
-  ref,
-  categoryId,
-) {
-  final p = ref
-      .watch(budgetProgressProvider)
-      .where((p) => p.budget.categoryId == categoryId)
-      .firstOrNull;
-  if (p == null) return null;
-  if (p.overspent) return CategoryFundingState.overspent;
-  final balance = ref.watch(categoryBalanceProvider(categoryId));
-  return balance >= p.budget.amount
-      ? CategoryFundingState.funded
-      : CategoryFundingState.underfunded;
-});
+final categoryFundingStateProvider =
+    Provider.family<CategoryFundingState?, int>((ref, categoryId) {
+      final p = ref
+          .watch(budgetProgressProvider)
+          .where((p) => p.budget.categoryId == categoryId)
+          .firstOrNull;
+      if (p == null) return null;
+      if (p.overspent) return CategoryFundingState.overspent;
+      final balance = ref.watch(categoryBalanceProvider(categoryId));
+      return balance >= p.budget.amount
+          ? CategoryFundingState.funded
+          : CategoryFundingState.underfunded;
+    });
 
 /// `Σ(currentBalance) − Σ(category_balance > 0)`, across every account in
 /// [envelopeModeAccountsProvider] — GitHub #48: one shared Ready to Assign
@@ -575,7 +582,8 @@ final groupExpensesProvider = StreamProvider.family<List<GroupExpenseRow>, int>(
 /// [personBalancesProvider] over exactly that group's member ids. Not new
 /// balance math; a group is never a second source of truth for money.
 final groupBalanceProvider = Provider.family<Money, int>((ref, groupId) {
-  final members = ref.watch(groupMembersProvider(groupId)).valueOrNull ?? const [];
+  final members =
+      ref.watch(groupMembersProvider(groupId)).valueOrNull ?? const [];
   final balances =
       ref.watch(personBalancesProvider).valueOrNull ?? const <int, Money>{};
   return members.fold(
@@ -821,7 +829,10 @@ final hasMasterPhraseProvider = Provider<bool>((ref) {
 });
 
 final masterPhraseAttemptThresholdProvider = Provider<int>((ref) {
-  return ref.watch(settingsProvider).valueOrNull?.masterPhraseAttemptThreshold ??
+  return ref
+          .watch(settingsProvider)
+          .valueOrNull
+          ?.masterPhraseAttemptThreshold ??
       5;
 });
 

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -245,6 +245,36 @@ class Categories extends Table {
   IntColumn get parentId => integer().nullable()();
 }
 
+/// A saved snapshot of a category/sub-category structure (GitHub #101) — its
+/// rows live in [CategoryTemplateItems]. Independent of [Categories]: saving
+/// or applying a template never touches a transaction, only which
+/// `Categories` rows are archived vs. active. See
+/// `docs/superpowers/specs/2026-09-06-category-templates-design.md`.
+@DataClassName('CategoryTemplateRow')
+class CategoryTemplates extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text().withLength(min: 1, max: 60)();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+/// One category in a saved template. Mirrors [Categories]' own shape (name,
+/// kind, colour, icon, two-level parent nesting) but [parentItemId] resolves
+/// against *other rows of the same template*, never a live [Categories.id] —
+/// a template must be applicable on a device that has never seen these
+/// categories before. [AppDatabase.applyCategoryTemplate] matches these
+/// against live categories by name, not id.
+@DataClassName('CategoryTemplateItemRow')
+class CategoryTemplateItems extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get templateId => integer().references(CategoryTemplates, #id)();
+  TextColumn get name => text().withLength(min: 1, max: 40)();
+  TextColumn get kind => textEnum<CategoryKind>()();
+  IntColumn get colorValue => integer()();
+  TextColumn get iconKey => text().withLength(min: 1, max: 40)();
+  IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+  IntColumn get parentItemId => integer().nullable()();
+}
+
 @DataClassName('TransactionRow')
 class Transactions extends Table {
   IntColumn get id => integer().autoIncrement()();
@@ -346,7 +376,8 @@ class Transactions extends Table {
   /// destination leg — the two accounts can each be a different currency
   /// from the parent (and from each other), so the destination needs its
   /// own independent snapshot.
-  TextColumn get toCurrencyCode => text().withLength(min: 3, max: 3).nullable()();
+  TextColumn get toCurrencyCode =>
+      text().withLength(min: 3, max: 3).nullable()();
   IntColumn get toFxRateToBaseMicros => integer().nullable()();
 }
 
@@ -565,16 +596,20 @@ class GroupExpenseShares extends Table {
   /// at any time. This share row survives with the link cleared, reading
   /// exactly like any other untracked share — a graceful downgrade, not a
   /// dangling reference `deleteGroupExpense` has to work around blind.
-  IntColumn get personEntryId => integer()
-      .nullable()
-      .references(PersonEntries, #id, onDelete: KeyAction.setNull)();
+  IntColumn get personEntryId => integer().nullable().references(
+    PersonEntries,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
 
   /// Set (with [personEntryId] null) only for my own share when I'm the
   /// payer — a real [TxType.expense] transaction, not a debt. Same
   /// `onDelete: setNull` reasoning as [personEntryId].
-  IntColumn get transactionId => integer()
-      .nullable()
-      .references(Transactions, #id, onDelete: KeyAction.setNull)();
+  IntColumn get transactionId => integer().nullable().references(
+    Transactions,
+    #id,
+    onDelete: KeyAction.setNull,
+  )();
 }
 
 /// Cash Reminders. A reminder **posts nothing on its own** — the user taps
@@ -632,8 +667,7 @@ class RecurringRules extends Table {
   /// [accountId] to this goal or loan account instead of an
   /// income/expense transaction. Null (the common case) means the rule
   /// posts an ordinary expense/income per [kind].
-  IntColumn get toAccountId =>
-      integer().nullable().references(Accounts, #id)();
+  IntColumn get toAccountId => integer().nullable().references(Accounts, #id)();
 
   /// Same free-text field as [Transactions.payee] — who the rule pays (an
   /// expense) or who it's paid by (income, e.g. an employer for a salary
@@ -766,12 +800,10 @@ class Settings extends Table {
   BoolColumn get upiEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for PayPal.
-  BoolColumn get paypalEnabled =>
-      boolean().withDefault(const Constant(true))();
+  BoolColumn get paypalEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for Venmo.
-  BoolColumn get venmoEnabled =>
-      boolean().withDefault(const Constant(true))();
+  BoolColumn get venmoEnabled => boolean().withDefault(const Constant(true))();
 
   /// Same as [upiEnabled], for Cash App.
   BoolColumn get cashappEnabled =>
@@ -987,8 +1019,7 @@ class Settings extends Table {
   /// (GitHub #78). Applied once, in `XpencApp`'s `builder`, to the `padding`
   /// every `SafeArea` in the app reads from — see `AppShell` and
   /// `LockScreen`, neither of which needed any change themselves.
-  IntColumn get extraBottomInset =>
-      integer().withDefault(const Constant(0))();
+  IntColumn get extraBottomInset => integer().withDefault(const Constant(0))();
 
   /// Icon keys (see `AppIcons`) picked from the icon sheet, most-recent-first,
   /// comma-joined — same convention as [bottomNavSlots]. Powers the

--- a/lib/features/categories/categories_screen.dart
+++ b/lib/features/categories/categories_screen.dart
@@ -1,6 +1,7 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../core/app_icons.dart';
 import '../../core/widgets/error_view.dart';
@@ -53,6 +54,13 @@ class _CategoriesScreenState extends ConsumerState<CategoriesScreen>
     return Scaffold(
       appBar: AppBar(
         title: const Text('Categories'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.dashboard_customize_outlined),
+            tooltip: 'Templates',
+            onPressed: () => context.push('/more/categories/templates'),
+          ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: const [

--- a/lib/features/categories/category_templates_screen.dart
+++ b/lib/features/categories/category_templates_screen.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/widgets/error_view.dart';
+import '../../data/database.dart';
+import '../../data/providers.dart';
+
+/// Save the current category structure as a reusable template, and switch
+/// between saved templates (GitHub #101). Switching never touches a
+/// transaction — it only archives categories the target template doesn't
+/// have and (re)creates the ones it does, exactly like a manual archive.
+class CategoryTemplatesScreen extends ConsumerWidget {
+  const CategoryTemplatesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final templatesAsync = ref.watch(categoryTemplatesProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Category templates')),
+      body: templatesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, _) => const Center(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: InlineErrorView(message: "Couldn't load templates"),
+          ),
+        ),
+        data: (templates) => ListView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 96),
+          children: [
+            Text(
+              'A template is a saved snapshot of your category and '
+              'sub-category structure. Save your current one before trying '
+              'a reorganization, or switch to another template any time — '
+              "past transactions always keep the category they're already "
+              'tagged with, whether or not it stays in the template you '
+              'switch to.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            if (templates.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 32),
+                child: Column(
+                  children: [
+                    Icon(
+                      Icons.dashboard_customize_outlined,
+                      size: 48,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'No templates saved yet — tap + to save your current '
+                      'categories as one.',
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else
+              Card(
+                clipBehavior: Clip.antiAlias,
+                child: Column(
+                  children: [
+                    for (var i = 0; i < templates.length; i++) ...[
+                      if (i > 0) Divider(height: 1, indent: 60),
+                      _TemplateTile(template: templates[i]),
+                    ],
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        tooltip: 'Save current as template',
+        onPressed: () => _saveCurrentAsTemplate(context, ref),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _TemplateTile extends ConsumerWidget {
+  const _TemplateTile({required this.template});
+
+  final CategoryTemplateRow template;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final itemCount = ref
+        .watch(categoryTemplateItemsProvider(template.id))
+        .valueOrNull
+        ?.length;
+    final subtitle = itemCount == null
+        ? 'Loading…'
+        : '$itemCount ${itemCount == 1 ? 'category' : 'categories'}';
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.primaryContainer,
+        child: Icon(
+          Icons.dashboard_customize_outlined,
+          color: theme.colorScheme.onPrimaryContainer,
+        ),
+      ),
+      title: Text(
+        template.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: PopupMenuButton<_TemplateAction>(
+        onSelected: (action) => switch (action) {
+          _TemplateAction.apply => _applyTemplate(context, ref, template),
+          _TemplateAction.rename => _renameTemplate(context, ref, template),
+          _TemplateAction.delete => _deleteTemplate(context, ref, template),
+        },
+        itemBuilder: (_) => const [
+          PopupMenuItem(
+            value: _TemplateAction.apply,
+            child: Text('Switch to this template'),
+          ),
+          PopupMenuItem(value: _TemplateAction.rename, child: Text('Rename')),
+          PopupMenuItem(value: _TemplateAction.delete, child: Text('Delete')),
+        ],
+      ),
+      onTap: () => _applyTemplate(context, ref, template),
+    );
+  }
+}
+
+enum _TemplateAction { apply, rename, delete }
+
+Future<void> _saveCurrentAsTemplate(BuildContext context, WidgetRef ref) async {
+  final name = await _promptForName(context, title: 'Save as template');
+  if (name == null || name.isEmpty) return;
+  if (!context.mounted) return;
+
+  final messenger = ScaffoldMessenger.of(context);
+  await ref.read(dbProvider).saveCategoriesAsTemplate(name);
+  messenger
+    ..hideCurrentSnackBar()
+    ..showSnackBar(SnackBar(content: Text('Saved "$name"')));
+}
+
+Future<void> _renameTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final name = await _promptForName(
+    context,
+    title: 'Rename template',
+    initialValue: template.name,
+  );
+  if (name == null || name.isEmpty || name == template.name) return;
+  if (!context.mounted) return;
+
+  await ref.read(dbProvider).renameCategoryTemplate(template.id, name);
+}
+
+Future<String?> _promptForName(
+  BuildContext context, {
+  required String title,
+  String initialValue = '',
+}) {
+  final controller = TextEditingController(text: initialValue);
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(title),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        maxLength: 60,
+        textCapitalization: TextCapitalization.words,
+        decoration: const InputDecoration(
+          labelText: 'Name',
+          hintText: 'e.g. Minimalist, Detailed tracking',
+          counterText: '',
+        ),
+        onSubmitted: (v) => Navigator.of(dialogContext).pop(v.trim()),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () =>
+              Navigator.of(dialogContext).pop(controller.text.trim()),
+          child: const Text('Save'),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<void> _applyTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text('Switch to "${template.name}"?'),
+      content: const Text(
+        'Categories not in this template are archived, not deleted — every '
+        "transaction keeps the category it's already tagged with, and "
+        'switching back later brings the same categories back. Categories '
+        'this template adds are created fresh.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          child: const Text('Switch'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true || !context.mounted) return;
+
+  final messenger = ScaffoldMessenger.of(context);
+  try {
+    await ref.read(dbProvider).applyCategoryTemplate(template.id);
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text('Switched to "${template.name}"')));
+  } on ArgumentError catch (e) {
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(content: Text(e.message?.toString() ?? "Couldn't switch.")),
+      );
+  }
+}
+
+Future<void> _deleteTemplate(
+  BuildContext context,
+  WidgetRef ref,
+  CategoryTemplateRow template,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text('Delete "${template.name}"?'),
+      content: const Text(
+        'This only deletes the saved template — your current categories '
+        'and every transaction are untouched.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(dialogContext).colorScheme.error,
+          ),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+  if (confirmed != true) return;
+
+  await ref.read(dbProvider).deleteCategoryTemplate(template.id);
+}

--- a/test/category_templates_test.dart
+++ b/test/category_templates_test.dart
@@ -1,0 +1,167 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xpenc/core/money.dart';
+import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart';
+
+/// Category templates (GitHub #101): save the current category structure as
+/// a named snapshot, then switch between saved structures. Switching must
+/// never touch a transaction — only which `Categories` rows are archived vs.
+/// active, exactly like a manual archive.
+void main() {
+  late AppDatabase db;
+
+  // Fresh databases start pre-seeded with default categories (Salary, Rent,
+  // …). Archive them so each test's active set is exactly what it creates —
+  // template save/apply is about set membership, and asserting against a mix
+  // of test data and seed data would make every expectation unreadable.
+  setUp(() async {
+    db = AppDatabase(NativeDatabase.memory());
+    for (final c in await db.watchAllCategories().first) {
+      await db.archiveCategory(c.id);
+    }
+  });
+  tearDown(() => db.close());
+
+  Future<int> addExpense(String name, {int? parentId}) => db.addCategory(
+    name: name,
+    kind: CategoryKind.expense,
+    colorValue: 0xFF000000,
+    iconKey: 'other',
+    parentId: parentId,
+  );
+
+  Future<List<CategoryRow>> activeCategories() async =>
+      (await db.watchAllCategories().first)
+        ..sort((a, b) => a.id.compareTo(b.id));
+
+  group('saveCategoriesAsTemplate', () {
+    test('snapshots active parents and children', () async {
+      final food = await addExpense('Food');
+      await addExpense('Groceries', parentId: food);
+      await addExpense('Transport');
+
+      final templateId = await db.saveCategoriesAsTemplate('My structure');
+      final items = await db.watchCategoryTemplateItems(templateId).first;
+
+      expect(items.length, 3);
+      final groceriesItem = items.firstWhere((i) => i.name == 'Groceries');
+      final foodItem = items.firstWhere((i) => i.name == 'Food');
+      expect(groceriesItem.parentItemId, foodItem.id);
+      expect(
+        items.firstWhere((i) => i.name == 'Transport').parentItemId,
+        isNull,
+      );
+    });
+
+    test('skips archived categories', () async {
+      final food = await addExpense('Food');
+      await db.archiveCategory(food);
+      await addExpense('Transport');
+
+      final templateId = await db.saveCategoriesAsTemplate('Partial');
+      final items = await db.watchCategoryTemplateItems(templateId).first;
+      expect(items.map((i) => i.name), ['Transport']);
+    });
+  });
+
+  group('applyCategoryTemplate', () {
+    test('creates categories the template has but the app does not', () async {
+      final templateId = await db.saveCategoriesAsTemplate('Empty baseline');
+      // Hand-craft a template with two categories, one nested, since the
+      // live DB starts out empty of custom categories in this test.
+      await db.deleteCategoryTemplate(templateId);
+      final food = await addExpense('Food');
+      await addExpense('Groceries', parentId: food);
+      final richId = await db.saveCategoriesAsTemplate('Rich');
+      await db.archiveCategory(food); // back to empty active set
+
+      await db.applyCategoryTemplate(richId);
+      final active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food', 'Groceries'});
+      final newFood = active.firstWhere((c) => c.name == 'Food');
+      final newGroceries = active.firstWhere((c) => c.name == 'Groceries');
+      expect(newGroceries.parentId, newFood.id);
+    });
+
+    test('archives a live category the target template does not have, '
+        'keeping every transaction that used it', () async {
+      // A template with just "Food" — snapshotted, then archived away
+      // again so the live app doesn't have it yet.
+      await addExpense('Food');
+      final foodTemplateId = await db.saveCategoriesAsTemplate('Food only');
+      await db.archiveCategory((await activeCategories()).single.id);
+
+      // The live app actually uses "Transport", with a real transaction.
+      final transport = await addExpense('Transport');
+      final cashId = (await db.watchAccounts().first)
+          .firstWhere((a) => a.type == AccountType.cash)
+          .id;
+      final txId = await db.addTransaction(
+        type: TxType.expense,
+        accountId: cashId,
+        amount: const Money(500),
+        date: DateTime(2026, 9, 1),
+        categoryId: transport,
+      );
+
+      await db.applyCategoryTemplate(foodTemplateId);
+
+      final active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+
+      final tx = (await db.watchTransactions().first).firstWhere(
+        (t) => t.id == txId,
+      );
+      expect(tx.categoryId, transport);
+      final archivedTransport = await db.categoryById(transport);
+      expect(archivedTransport!.isArchived, isTrue);
+    });
+
+    test('switching back and forth never duplicates categories', () async {
+      final food = await addExpense('Food');
+      final templateA = await db.saveCategoriesAsTemplate('A');
+      await db.archiveCategory(food);
+      await addExpense('Transport');
+      final templateB = await db.saveCategoriesAsTemplate('B');
+
+      await db.applyCategoryTemplate(templateA);
+      var active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+
+      await db.applyCategoryTemplate(templateB);
+      active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Transport'});
+
+      // Switch back to A: Food should be the *same row*, reactivated, not a
+      // freshly created duplicate.
+      await db.applyCategoryTemplate(templateA);
+      active = await activeCategories();
+      expect(active.map((c) => c.name).toSet(), {'Food'});
+      expect(active.single.id, food);
+    });
+
+    test('refuses to apply an empty template', () async {
+      final templateId = await db.saveCategoriesAsTemplate('Empty');
+      expect(() => db.applyCategoryTemplate(templateId), throwsArgumentError);
+    });
+  });
+
+  group('template management', () {
+    test('renameCategoryTemplate updates the name', () async {
+      final id = await db.saveCategoriesAsTemplate('Old name');
+      await db.renameCategoryTemplate(id, 'New name');
+      final templates = await db.watchCategoryTemplates().first;
+      expect(templates.single.name, 'New name');
+    });
+
+    test('deleteCategoryTemplate removes the template and its items', () async {
+      await addExpense('Food');
+      final id = await db.saveCategoriesAsTemplate('Doomed');
+      await db.deleteCategoryTemplate(id);
+
+      expect(await db.watchCategoryTemplates().first, isEmpty);
+      expect(await db.watchCategoryTemplateItems(id).first, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Closes #101 — save the current category/sub-category structure as a named template (Categories → the new templates icon), and switch between saved templates any time.
- Switching never touches a transaction: categories the target template doesn't have are archived (exactly like a manual archive — their transactions keep them), categories it does have are created or relabelled in place, and switching back later reactivates the same categories instead of duplicating them.
- New Drift tables `CategoryTemplates` / `CategoryTemplateItems` (schema v62 → v63), DB methods (`saveCategoriesAsTemplate`, `applyCategoryTemplate`, `renameCategoryTemplate`, `deleteCategoryTemplate`), a new `CategoryTemplatesScreen`, and 8 new tests in `test/category_templates_test.dart`.
- Design notes in `docs/superpowers/specs/2026-09-06-category-templates-design.md`.

This is a clean cherry-pick of the single category-templates commit onto `BETA` (which already has all prior work via #106) — this PR replaces #108, which was mistakenly opened against `master` and has since been reverted there.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test test/category_templates_test.dart` — 8/8 passing

Generated with: CODEAI