### PR TITLE
feat: PIN + Authenticator two-factor unlock, and paste-to-enter for codes

### DIFF
--- a/docs/superpowers/specs/2026-09-06-pin-plus-authenticator-design.md
+++ b/docs/superpowers/specs/2026-09-06-pin-plus-authenticator-design.md
@@ -1,0 +1,147 @@
+# PIN + Authenticator (true 2FA) + paste-to-enter — design spec
+
+Date: 2026-09-06
+Status: implemented
+GitHub: #111
+
+## Background
+
+GitHub #104 gave the lock screen a choice of exactly **one** front door — PIN,
+master password, or authenticator app (TOTP) — deliberately *not* a
+combination, because that issue's reporter explicitly asked for alternatives,
+not stacking (see that spec's "Non-goals").
+
+This issue asks for the opposite for users who want it: a way to require
+**both** a PIN and an authenticator code, entered one after the other, for
+anyone who wants real two-factor protection rather than a single front door.
+It also asks for a "paste" shortcut on the authenticator code entry keypad,
+so a code copied from an authenticator app (or a password manager that also
+stores TOTP secrets) never needs to be retyped digit by digit.
+
+## Data model
+
+`UnlockMethod` (`data/tables.dart`) gains a fourth case, `pinAndTotp`,
+alongside the three GitHub #104 already added. No schema migration is
+needed — the column is a plain `TEXT` (`textEnum<UnlockMethod>()`), and
+Drift's generated converter maps it off `UnlockMethod.values` at runtime, not
+a hardcoded list. Existing rows are unaffected; the new value is only ever
+written when a user explicitly opts in.
+
+`hasUnlockCredential` (`core/security/unlock_method.dart`) requires **both**
+halves for this case:
+
+```dart
+UnlockMethod.pinAndTotp =>
+    settings.passcodeHash != null && settings.totpSecret != null,
+```
+
+— a half-configured combo (say, the TOTP secret got cleared some other way)
+must not read as "locked" on the PIN alone, the same "all or nothing per
+method" rule every other case already follows.
+
+## Setting it up: a two-hop wizard, not a single screen
+
+Settings ▸ Security gains a fourth radio row, "PIN + Authenticator", next to
+the original three. Tapping it when both halves already exist just switches
+`unlockMethod` immediately, same as any other already-configured method.
+
+When one or both halves are missing, there's no dedicated "set up the combo"
+screen — it reuses the existing PIN and TOTP setup screens, chained:
+
+- `_selectUnlockMethod` in `settings_screen.dart` routes to whichever setup
+  screen is missing its credential, with a `?combine=true` query param:
+  `/more/settings/passcode?combine=true` if there's no PIN yet, otherwise
+  `/more/settings/totp/setup?combine=true`.
+- `SetPasscodeScreen.combineWithTotp` / `TotpSetupScreen.combineWithPin` read
+  that flag. On success:
+  - If the *other* half is now also configured, it calls
+    `setUnlockMethod(UnlockMethod.pinAndTotp)` immediately (overriding
+    `setPasscode`/`setupTotp`'s own "activate me alone" default) and pops
+    back to Settings.
+  - If not, it chains onward with `context.pushReplacement` (not `push`) to
+    the other screen, still carrying `combine=true` — `pushReplacement` so
+    backing out of that second step lands on Settings, not back on the first
+    (already-completed) step.
+
+This means the same two screens serve three purposes (set up PIN alone, set
+up TOTP alone, set up either half of the combo) with no new screen to keep in
+sync with the other two.
+
+## Unlocking: PIN, then a code — never either alone
+
+`LockScreen` gets a `_PinTotpStep` (`pin` / `totp`) local to the widget,
+reset to `pin` every time the screen is freshly mounted (i.e. every re-lock).
+`_buildPinBody` and `_buildTotpBody` both take a `combined` flag:
+
+- The PIN step (`combined: true`) uses `_onCombinedPinDigit` /
+  `_submitCombinedPin` instead of the plain-PIN handlers. A **correct** PIN
+  here only advances `_pinTotpStep` to `totp` — it never calls `onUnlocked`
+  and never resets the wrong-attempt counter. A **wrong** PIN increments the
+  same shared `failedPasscodeAttempts` counter every method already uses, and
+  re-prompts for the PIN.
+- The TOTP step (`combined: true`) uses `_onCombinedTotpDigit` /
+  `_submitCombinedTotp`. Only a **correct** code here resets the counter and
+  calls `onUnlocked` — completing both factors is what actually unlocks.
+
+Reusing the shared `failedPasscodeAttempts` counter (rather than a second,
+combo-specific one) means the existing master-phrase fallback
+(`masterPhraseAttemptThreshold`) protects the combo exactly the way it
+already protects every other method, with no new UI concept.
+
+**Biometric is deliberately withheld on the combined PIN step.** It's
+documented (GitHub #104) as a shortcut for PIN entry only; letting a
+fingerprint silently skip straight past the PIN step of a two-factor flow
+would turn "both factors required" into "just a fingerprint", defeating the
+point. `_buildPinBody(combined: true)` passes `extraKey: null` regardless of
+`biometricEnabled`.
+
+## Turning either half off
+
+- `clearPasscode` (removing the PIN) now falls back to `totp` when
+  `pinAndTotp` was active — the authenticator half still works standalone,
+  so there's no reason to leave the app with no unlock method at all.
+- `clearTotp` (turning off the authenticator app) already fell back to `pin`
+  when `totp` alone was active (GitHub #104); this now also covers
+  `pinAndTotp` for the same reason — a `pinAndTotp` setup always has a PIN
+  configured (required to activate the combo in the first place), so `pin`
+  is always a real, working fallback, never a credential that doesn't exist.
+- `TotpVerifyScreen`'s "turned off" snackbar reads "PIN unlock only" instead
+  of the generic message when the combo was active, so the user isn't left
+  guessing what unlock now actually requires.
+
+## Paste-to-enter (GitHub #111's other ask)
+
+`core/security/paste_code_key.dart` adds:
+
+- `pasteDigitsFromClipboard(onCode)` — reads `Clipboard.getData`, strips
+  everything but digits (`RegExp('[^0-9]')`), and calls `onCode` with
+  whatever's left. Silently does nothing on an empty/non-numeric clipboard,
+  rather than clearing whatever the user already typed.
+- `PasteCodeKey` — an `IconButton` (paste icon, "Paste code" tooltip) sized
+  for the same bottom-left `extraKey` slot `LockScreenKeypad` already gives
+  the PIN pad's biometric shortcut.
+
+Wired into every authenticator-code keypad:
+
+- `LockScreen`'s single-method TOTP body and the combined flow's TOTP step
+  (`_onPasteTotp`, dispatching to `_submitTotp` or `_submitCombinedTotp`
+  depending which is live).
+- `TotpSetupScreen`'s confirm step (`_onPaste`).
+- `TotpVerifyScreen` (turning the authenticator off) (`_onPaste`).
+
+Behavior in every case: fill the code field with up to 6 digits from the
+clipboard, and if that reaches the full 6, submit immediately — exactly as
+if it had been typed key by key. Fewer than 6 just fills in what's there,
+leaving the keypad free to finish it. This is deliberately **not** offered on
+PIN entry — a PIN is short enough to type and isn't the thing a password
+manager or authenticator app hands you pre-copied; the ask was specifically
+about not having to read six digits off a phone screen and retype them.
+
+## What stays out of scope
+
+- No other combinations (PIN + phrase, phrase + TOTP, all three at once) —
+  #111 asked specifically for PIN + Authenticator; the pattern here
+  (`UnlockMethod` gains one case per supported combo, `hasUnlockCredential`
+  matches it, `LockScreen` gets a step enum) generalizes if that's ever
+  asked for, but isn't built speculatively here.
+- The combined PIN step still doesn't offer biometric — see above.

--- a/docs/superpowers/specs/2026-09-06-unlock-method-choice-design.md
+++ b/docs/superpowers/specs/2026-09-06-unlock-method-choice-design.md
@@ -140,7 +140,13 @@ what the backup file itself contains.
 
 ## Non-goals (v1)
 
-- No multi-factor combination (PIN *and* TOTP, etc.) — the reporter
-  explicitly asked for alternatives, not stacking.
+- ~~No multi-factor combination (PIN *and* TOTP, etc.) — the reporter
+  explicitly asked for alternatives, not stacking.~~ Superseded by GitHub
+  #111 — see
+  `docs/superpowers/specs/2026-09-06-pin-plus-authenticator-design.md`, which
+  adds [UnlockMethod.pinAndTotp] as a fourth, *additional* choice alongside
+  the three alternatives this spec introduced. Nothing here changes: a user
+  who wants "either PIN or TOTP" still picks one of the original three: the
+  combo is an opt-in fourth radio option, not a replacement.
 - No re-showing a previously-generated TOTP secret/QR after setup closes —
   matches the master phrase's own "shown once, then gone" precedent.

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -177,6 +177,8 @@ final appRouter = GoRouter(
                       builder: (_, state) => SetPasscodeScreen(
                         isRemoving:
                             state.uri.queryParameters['remove'] == 'true',
+                        combineWithTotp:
+                            state.uri.queryParameters['combine'] == 'true',
                       ),
                     ),
                     GoRoute(
@@ -192,7 +194,10 @@ final appRouter = GoRouter(
                     GoRoute(
                       path: 'totp/setup',
                       parentNavigatorKey: _rootKey,
-                      builder: (_, _) => const TotpSetupScreen(),
+                      builder: (_, state) => TotpSetupScreen(
+                        combineWithPin:
+                            state.uri.queryParameters['combine'] == 'true',
+                      ),
                     ),
                     GoRoute(
                       path: 'totp/disable',

--- a/lib/core/security/paste_code_key.dart
+++ b/lib/core/security/paste_code_key.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Reads the system clipboard and hands [onCode] every digit it contains,
+/// with anything else (spaces, "Your code is:", dashes an authenticator app
+/// sometimes group digits with, …) stripped out — GitHub #111. The point is
+/// "copy from the authenticator app, then paste" needing no manual cleanup.
+/// Silently does nothing if the clipboard has no digits at all, rather than
+/// clearing whatever the user already typed.
+Future<void> pasteDigitsFromClipboard(ValueChanged<String> onCode) async {
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  final text = data?.text;
+  if (text == null) return;
+  final digits = text.replaceAll(RegExp('[^0-9]'), '');
+  if (digits.isEmpty) return;
+  onCode(digits);
+}
+
+/// A "paste" key for the numeric keypad — the same bottom-left [extraKey]
+/// slot [LockScreenKeypad] already gives the PIN pad's biometric shortcut,
+/// reused here for a TOTP code so it never needs to be retyped digit by
+/// digit: copy it in the authenticator app, then tap this instead of the
+/// keypad (GitHub #111).
+class PasteCodeKey extends StatelessWidget {
+  const PasteCodeKey({required this.onCode, super.key});
+
+  /// Called with the clipboard's digits (already stripped of everything
+  /// else) when there are any. The caller decides how much of it to keep and
+  /// whether to auto-submit.
+  final ValueChanged<String> onCode;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.content_paste_rounded, size: 24),
+      tooltip: 'Paste code',
+      onPressed: () => pasteDigitsFromClipboard(onCode),
+    );
+  }
+}

--- a/lib/core/security/unlock_method.dart
+++ b/lib/core/security/unlock_method.dart
@@ -11,4 +11,10 @@ bool hasUnlockCredential(SettingRow settings) =>
       UnlockMethod.pin => settings.passcodeHash != null,
       UnlockMethod.masterPhrase => settings.masterPhraseHash != null,
       UnlockMethod.totp => settings.totpSecret != null,
+      // Both factors must actually be configured — a half-configured combo
+      // (e.g. the TOTP secret got cleared elsewhere) must not read as "locked"
+      // on just the PIN alone, same "all or nothing per method" rule the
+      // other cases already follow.
+      UnlockMethod.pinAndTotp =>
+        settings.passcodeHash != null && settings.totpSecret != null,
     };

--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -4332,15 +4332,26 @@ class AppDatabase extends _$AppDatabase {
   }
 
   /// Clears the passcode and, since it's meaningless without one, biometric
-  /// unlock along with it.
-  Future<void> clearPasscode() => update(settings).write(
-    const SettingsCompanion(
-      passcodeHash: Value(null),
-      passcodeSalt: Value(null),
-      passcodeLength: Value(null),
-      biometricEnabled: Value(false),
-    ),
-  );
+  /// unlock along with it. If [UnlockMethod.pinAndTotp] was active, the
+  /// authenticator half of it still stands on its own, so this falls back to
+  /// `totp` rather than leaving [Settings.unlockMethod] pointed at a
+  /// combination that's now missing half its credential — same "graceful
+  /// fallback to whatever still works" rule [clearTotp] follows.
+  Future<void> clearPasscode() async {
+    final wasCombined =
+        (await getSettings()).unlockMethod == UnlockMethod.pinAndTotp;
+    await update(settings).write(
+      SettingsCompanion(
+        passcodeHash: const Value(null),
+        passcodeSalt: const Value(null),
+        passcodeLength: const Value(null),
+        biometricEnabled: const Value(false),
+        unlockMethod: wasCombined
+            ? const Value(UnlockMethod.totp)
+            : const Value.absent(),
+      ),
+    );
+  }
 
   Future<bool> verifyPasscode(String pin) async {
     final row = await getSettings();
@@ -4444,14 +4455,20 @@ class AppDatabase extends _$AppDatabase {
     ),
   );
 
-  /// Clears the TOTP secret. If it was the active method, falls back to
-  /// `pin` — same reasoning as [clearMasterPhrase].
+  /// Clears the TOTP secret. If it was the active method — alone or as half
+  /// of [UnlockMethod.pinAndTotp] — falls back to `pin` — same reasoning as
+  /// [clearMasterPhrase]. A [UnlockMethod.pinAndTotp] setup always has a PIN
+  /// configured (it's required to activate the combo in the first place), so
+  /// `pin` is always a real fallback here, never a credential that doesn't
+  /// exist.
   Future<void> clearTotp() async {
-    final wasActive = (await getSettings()).unlockMethod == UnlockMethod.totp;
+    final current = (await getSettings()).unlockMethod;
+    final fallsBackToPin =
+        current == UnlockMethod.totp || current == UnlockMethod.pinAndTotp;
     await update(settings).write(
       SettingsCompanion(
         totpSecret: const Value(null),
-        unlockMethod: wasActive
+        unlockMethod: fallsBackToPin
             ? const Value(UnlockMethod.pin)
             : const Value.absent(),
       ),

--- a/lib/data/tables.dart
+++ b/lib/data/tables.dart
@@ -108,13 +108,17 @@ enum AutoBackupFrequency { daily, monthly, custom }
 /// position can't infer the PIN.
 enum LockScreenStyle { classic, bigNumpad, scrambled }
 
-/// Which credential is the app's active front-door lock (GitHub #104) — the
-/// user picks exactly one, never a combination. `hasUnlockCredential` in
-/// `core/security/unlock_method.dart` maps this to whether that credential
-/// is actually configured; [Settings.masterPhraseHash] can still be set and
-/// used purely as a fallback (see [Settings.masterPhraseAttemptThreshold])
-/// while a *different* method is active.
-enum UnlockMethod { pin, masterPhrase, totp }
+/// Which credential(s) the app's active front-door lock requires. Originally
+/// (GitHub #104) the user picked exactly one, never a combination — that
+/// changed with the addition of [pinAndTotp] (GitHub #111): a true two-factor
+/// front door requiring *both* a correct PIN and a correct authenticator code,
+/// entered one after the other, rather than either alone. `hasUnlockCredential`
+/// in `core/security/unlock_method.dart` maps this to whether the credential(s)
+/// it needs are actually configured; [Settings.masterPhraseHash] can still be
+/// set and used purely as a fallback (see
+/// [Settings.masterPhraseAttemptThreshold]) while a different method is
+/// active.
+enum UnlockMethod { pin, masterPhrase, totp, pinAndTotp }
 
 /// How the More hub (`MoreScreen`) lays out its items. `list` is the
 /// original one-column row layout. `cards` shows two square-ish cards per

--- a/lib/features/security/lock_screen.dart
+++ b/lib/features/security/lock_screen.dart
@@ -5,6 +5,7 @@ import 'package:local_auth/local_auth.dart';
 import '../../core/branding/app_info.dart';
 import '../../core/branding/brand_mark.dart';
 import '../../core/security/master_phrase_field.dart';
+import '../../core/security/paste_code_key.dart';
 import '../../core/security/pin_pad.dart';
 import '../../data/providers.dart';
 import '../../data/tables.dart' show UnlockMethod;
@@ -13,6 +14,11 @@ import 'lock_screen_keypad.dart';
 /// A TOTP code is always 6 digits (GitHub #104) — `Totp.provisioningUri`
 /// hard-codes `digits=6`, so entry here matches.
 const _totpCodeLength = 6;
+
+/// Which half of [UnlockMethod.pinAndTotp] (GitHub #111) is currently being
+/// asked for — the PIN always comes first, the authenticator code second;
+/// both must be correct before [LockScreen.onUnlocked] fires.
+enum _PinTotpStep { pin, totp }
 
 /// Rendered directly by [XpencApp]'s `builder`, outside the router — a
 /// blocking overlay, not a route, so there is no back button and no way
@@ -45,6 +51,12 @@ class _LockScreenState extends ConsumerState<LockScreen> {
 
   /// Same purpose as [_attempt], for the TOTP keypad.
   int _totpAttempt = 0;
+
+  /// Only meaningful while [UnlockMethod.pinAndTotp] is active (GitHub #111)
+  /// — which of the two steps is currently showing. Resets to [_PinTotpStep.
+  /// pin] each time a fresh [LockScreen] is mounted (i.e. every time the app
+  /// re-locks), never mid-session.
+  _PinTotpStep _pinTotpStep = _PinTotpStep.pin;
 
   @override
   void initState() {
@@ -178,6 +190,98 @@ class _LockScreenState extends ConsumerState<LockScreen> {
     });
   }
 
+  // ── PIN + Authenticator, combined (GitHub #111) ─────────────────────────
+  // A correct PIN here only advances to the TOTP step — it never unlocks by
+  // itself, unlike plain [UnlockMethod.pin]. Only a correct code afterward
+  // actually calls `onUnlocked`. Both steps share the shared wrong-attempt
+  // counter with every other method, so the phrase fallback still kicks in
+  // the same way after enough combined failures.
+
+  void _onCombinedPinDigit(String d) {
+    final pinLength = ref.read(passcodeLengthProvider);
+    if (_checking || _pin.length >= pinLength) return;
+    setState(() {
+      _error = false;
+      _pin += d;
+    });
+    if (_pin.length == pinLength) _submitCombinedPin();
+  }
+
+  Future<void> _submitCombinedPin() async {
+    setState(() => _checking = true);
+    final db = ref.read(dbProvider);
+    final ok = await db.verifyPasscode(_pin);
+    if (!mounted) return;
+    if (ok) {
+      setState(() {
+        _checking = false;
+        _pin = '';
+        _pinTotpStep = _PinTotpStep.totp;
+      });
+      return;
+    }
+    await db.recordFailedPasscodeAttempt();
+    if (!mounted) return;
+    setState(() {
+      _error = true;
+      _checking = false;
+      _pin = '';
+      _attempt++;
+    });
+  }
+
+  void _onCombinedTotpDigit(String d) {
+    if (_totpChecking || _totp.length >= _totpCodeLength) return;
+    setState(() {
+      _totpError = false;
+      _totp += d;
+    });
+    if (_totp.length == _totpCodeLength) _submitCombinedTotp();
+  }
+
+  Future<void> _submitCombinedTotp() async {
+    setState(() => _totpChecking = true);
+    final db = ref.read(dbProvider);
+    final ok = await db.verifyTotp(_totp);
+    if (!mounted) return;
+    if (ok) {
+      // The counter only resets once *both* factors are satisfied — a
+      // correct PIN alone (see `_submitCombinedPin`) never touches it.
+      await db.resetFailedPasscodeAttempts();
+      if (!mounted) return;
+      widget.onUnlocked();
+      return;
+    }
+    await db.recordFailedPasscodeAttempt();
+    if (!mounted) return;
+    setState(() {
+      _totpError = true;
+      _totpChecking = false;
+      _totp = '';
+      _totpAttempt++;
+    });
+  }
+
+  /// The TOTP keypad's paste key (GitHub #111), shared by [_buildTotpBody]'s
+  /// single-method and combined-flow cases — fills [_totp] from the
+  /// clipboard's digits and submits through whichever of [_submitTotp] /
+  /// [_submitCombinedTotp] actually applies right now.
+  void _onPasteTotp(String digits, {required bool combined}) {
+    if (_totpChecking) return;
+    setState(() {
+      _totpError = false;
+      _totp = digits.length > _totpCodeLength
+          ? digits.substring(0, _totpCodeLength)
+          : digits;
+    });
+    if (_totp.length != _totpCodeLength) return;
+    if (combined) {
+      _submitCombinedTotp();
+    } else {
+      _submitTotp();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -236,6 +340,13 @@ class _LockScreenState extends ConsumerState<LockScreen> {
                                   isFallback: false,
                                 ),
                                 UnlockMethod.totp => _buildTotpBody(context),
+                                UnlockMethod.pinAndTotp =>
+                                  _pinTotpStep == _PinTotpStep.pin
+                                      ? _buildPinBody(context, combined: true)
+                                      : _buildTotpBody(
+                                          context,
+                                          combined: true,
+                                        ),
                               },
                       ],
                     ),
@@ -249,7 +360,13 @@ class _LockScreenState extends ConsumerState<LockScreen> {
     );
   }
 
-  Widget _buildPinBody(BuildContext context) {
+  /// [combined] is true for the PIN half of [UnlockMethod.pinAndTotp]
+  /// (GitHub #111) — a correct PIN there only advances to the code step
+  /// (see [_onCombinedPinDigit]), so the biometric shortcut is withheld:
+  /// fingerprint unlock is documented as a PIN-only shortcut, and letting it
+  /// also skip the authenticator half would silently turn "both factors" into
+  /// "just a fingerprint".
+  Widget _buildPinBody(BuildContext context, {bool combined = false}) {
     final theme = Theme.of(context);
     final biometricEnabled = ref.watch(biometricEnabledProvider);
     final pinLength = ref.watch(passcodeLengthProvider);
@@ -266,6 +383,15 @@ class _LockScreenState extends ConsumerState<LockScreen> {
                 : theme.colorScheme.onSurfaceVariant,
           ),
         ),
+        if (combined) ...[
+          const SizedBox(height: 4),
+          Text(
+            'Step 1 of 2 — an authenticator code is needed next',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
         const SizedBox(height: 18),
         PinDots(entered: _pin.length, length: pinLength, error: _error),
         const SizedBox(height: 40),
@@ -274,9 +400,9 @@ class _LockScreenState extends ConsumerState<LockScreen> {
           child: LockScreenKeypad(
             style: lockScreenStyle,
             attempt: _attempt,
-            onDigit: _onDigit,
+            onDigit: combined ? _onCombinedPinDigit : _onDigit,
             onBackspace: _onBackspace,
-            extraKey: biometricEnabled
+            extraKey: !combined && biometricEnabled
                 ? IconButton(
                     icon: const Icon(Icons.fingerprint_rounded, size: 28),
                     tooltip: 'Use biometric unlock',
@@ -300,6 +426,7 @@ class _LockScreenState extends ConsumerState<LockScreen> {
     final fallbackHeading = switch (unlockMethod) {
       UnlockMethod.pin => 'Too many wrong PINs',
       UnlockMethod.totp => 'Too many wrong codes',
+      UnlockMethod.pinAndTotp => 'Too many wrong attempts',
       UnlockMethod.masterPhrase =>
         '', // unreachable — the phrase can't fall back to itself
     };
@@ -338,7 +465,12 @@ class _LockScreenState extends ConsumerState<LockScreen> {
     );
   }
 
-  Widget _buildTotpBody(BuildContext context) {
+  /// [combined] is true for the code half of [UnlockMethod.pinAndTotp]
+  /// (GitHub #111), reached only after [_buildPinBody]'s combined PIN step
+  /// already verified — routes digit entry and the paste key to
+  /// [_submitCombinedTotp] instead of [_submitTotp] so a correct code here
+  /// actually unlocks, rather than the single-method TOTP flow's own submit.
+  Widget _buildTotpBody(BuildContext context, {bool combined = false}) {
     final theme = Theme.of(context);
     final lockScreenStyle = ref.watch(lockScreenStyleProvider);
 
@@ -353,6 +485,15 @@ class _LockScreenState extends ConsumerState<LockScreen> {
                 : theme.colorScheme.onSurfaceVariant,
           ),
         ),
+        if (combined) ...[
+          const SizedBox(height: 4),
+          Text(
+            'Step 2 of 2',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
         const SizedBox(height: 18),
         PinDots(
           entered: _totp.length,
@@ -365,8 +506,11 @@ class _LockScreenState extends ConsumerState<LockScreen> {
           child: LockScreenKeypad(
             style: lockScreenStyle,
             attempt: _totpAttempt,
-            onDigit: _onTotpDigit,
+            onDigit: combined ? _onCombinedTotpDigit : _onTotpDigit,
             onBackspace: _onTotpBackspace,
+            extraKey: PasteCodeKey(
+              onCode: (d) => _onPasteTotp(d, combined: combined),
+            ),
           ),
         ),
       ],

--- a/lib/features/security/set_passcode_screen.dart
+++ b/lib/features/security/set_passcode_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../core/security/pin_pad.dart';
 import '../../data/providers.dart';
+import '../../data/tables.dart' show UnlockMethod;
 import 'lock_screen_keypad.dart';
 
 const _pinLengthOptions = [4, 5, 6];
@@ -12,9 +14,21 @@ enum _Step { verifyCurrent, enterNew, confirmNew }
 /// Set, change, or remove the passcode. [isRemoving] skips straight to
 /// clearing it once the current PIN verifies — there's no "new PIN" step.
 class SetPasscodeScreen extends ConsumerStatefulWidget {
-  const SetPasscodeScreen({this.isRemoving = false, super.key});
+  const SetPasscodeScreen({
+    this.isRemoving = false,
+    this.combineWithTotp = false,
+    super.key,
+  });
 
   final bool isRemoving;
+
+  /// Set when this setup was reached from the Settings "PIN + Authenticator"
+  /// combined-method radio (GitHub #111), rather than the plain "PIN" one.
+  /// On success, activates [UnlockMethod.pinAndTotp] instead of the usual
+  /// "just activate PIN alone" rule — chaining onward to the authenticator
+  /// setup first if it isn't configured yet, since the combo needs both.
+  /// Meaningless (and ignored) together with [isRemoving].
+  final bool combineWithTotp;
 
   @override
   ConsumerState<SetPasscodeScreen> createState() => _SetPasscodeScreenState();
@@ -131,6 +145,32 @@ class _SetPasscodeScreenState extends ConsumerState<SetPasscodeScreen> {
         setState(() => _checking = true);
         await ref.read(dbProvider).setPasscode(_pin);
         if (!mounted) return;
+
+        if (widget.combineWithTotp) {
+          if (ref.read(hasTotpProvider)) {
+            // Both halves exist now — activate the combo instead of leaving
+            // `setPasscode`'s own "activate PIN alone" default in place.
+            await ref
+                .read(dbProvider)
+                .setUnlockMethod(UnlockMethod.pinAndTotp);
+            if (!mounted) return;
+            Navigator.of(context).pop();
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(
+                const SnackBar(
+                  content: Text('PIN + Authenticator unlock set'),
+                ),
+              );
+          } else {
+            // No authenticator yet — chain onward rather than leaving the
+            // combo half-configured. `pushReplacement` (not push) so
+            // cancelling out of that step lands back on Settings, not here.
+            context.pushReplacement('/more/settings/totp/setup?combine=true');
+          }
+          return;
+        }
+
         Navigator.of(context).pop();
         ScaffoldMessenger.of(context)
           ..hideCurrentSnackBar()

--- a/lib/features/security/totp_setup_screen.dart
+++ b/lib/features/security/totp_setup_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
+import '../../core/security/paste_code_key.dart';
 import '../../core/security/pin_pad.dart';
 import '../../core/security/totp.dart';
 import '../../data/providers.dart';
+import '../../data/tables.dart' show UnlockMethod;
 import 'lock_screen_keypad.dart';
 
 enum _Step { scan, confirm }
@@ -17,7 +20,15 @@ const _codeLength = 6;
 /// committing" shape as [MasterPhraseSetupScreen]'s tap-back-in-order step.
 /// GitHub #104.
 class TotpSetupScreen extends ConsumerStatefulWidget {
-  const TotpSetupScreen({super.key});
+  const TotpSetupScreen({this.combineWithPin = false, super.key});
+
+  /// Set when this setup was reached from the Settings "PIN + Authenticator"
+  /// combined-method radio (GitHub #111), rather than the plain
+  /// "Authenticator app" one. On success, activates
+  /// [UnlockMethod.pinAndTotp] instead of the usual "just activate TOTP
+  /// alone" rule — chaining onward to the PIN setup first if a PIN isn't
+  /// configured yet, since the combo needs both.
+  final bool combineWithPin;
 
   @override
   ConsumerState<TotpSetupScreen> createState() => _TotpSetupScreenState();
@@ -53,6 +64,21 @@ class _TotpSetupScreenState extends ConsumerState<TotpSetupScreen> {
     setState(() => _code = _code.substring(0, _code.length - 1));
   }
 
+  /// The keypad's "paste" key (GitHub #111) — fills in whatever digits the
+  /// clipboard holds (from the authenticator app's own "copy code" action,
+  /// say) and submits immediately once there are enough of them, exactly as
+  /// if they'd been typed one by one.
+  void _onPaste(String digits) {
+    if (_saving) return;
+    setState(() {
+      _error = false;
+      _code = digits.length > _codeLength
+          ? digits.substring(0, _codeLength)
+          : digits;
+    });
+    if (_code.length == _codeLength) _submit();
+  }
+
   Future<void> _submit() async {
     // Verified locally against the not-yet-saved secret — nothing is
     // persisted until the code proves the authenticator app actually has it.
@@ -67,6 +93,28 @@ class _TotpSetupScreenState extends ConsumerState<TotpSetupScreen> {
     setState(() => _saving = true);
     await ref.read(dbProvider).setupTotp(_secret);
     if (!mounted) return;
+
+    if (widget.combineWithPin) {
+      if (ref.read(hasPasscodeProvider)) {
+        // Both halves exist now — activate the combo instead of leaving
+        // `setupTotp`'s own "activate TOTP alone" default in place.
+        await ref.read(dbProvider).setUnlockMethod(UnlockMethod.pinAndTotp);
+        if (!mounted) return;
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(content: Text('PIN + Authenticator unlock set')),
+          );
+      } else {
+        // No PIN yet — chain onward rather than leaving the combo
+        // half-configured. `pushReplacement` (not push) so cancelling out of
+        // the PIN step lands back on Settings, not back here.
+        context.pushReplacement('/more/settings/passcode?combine=true');
+      }
+      return;
+    }
+
     Navigator.of(context).pop();
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
@@ -197,6 +245,7 @@ class _TotpSetupScreenState extends ConsumerState<TotpSetupScreen> {
               attempt: _attempt,
               onDigit: _onDigit,
               onBackspace: _onBackspace,
+              extraKey: PasteCodeKey(onCode: _onPaste),
             ),
           ),
         const Spacer(),

--- a/lib/features/security/totp_verify_screen.dart
+++ b/lib/features/security/totp_verify_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/security/paste_code_key.dart';
 import '../../core/security/pin_pad.dart';
 import '../../data/providers.dart';
+import '../../data/tables.dart' show UnlockMethod;
 import 'lock_screen_keypad.dart';
 
 const _codeLength = 6;
@@ -37,6 +39,20 @@ class _TotpVerifyScreenState extends ConsumerState<TotpVerifyScreen> {
     setState(() => _code = _code.substring(0, _code.length - 1));
   }
 
+  /// The keypad's "paste" key (GitHub #111) — same shortcut
+  /// [TotpSetupScreen] offers, so turning the authenticator off never needs
+  /// a code retyped by hand either.
+  void _onPaste(String digits) {
+    if (_checking) return;
+    setState(() {
+      _error = false;
+      _code = digits.length > _codeLength
+          ? digits.substring(0, _codeLength)
+          : digits;
+    });
+    if (_code.length == _codeLength) _submit();
+  }
+
   Future<void> _submit() async {
     setState(() => _checking = true);
     final ok = await ref.read(dbProvider).verifyTotp(_code);
@@ -50,13 +66,24 @@ class _TotpVerifyScreenState extends ConsumerState<TotpVerifyScreen> {
       });
       return;
     }
+    // Read before clearing — GitHub #111: PIN + Authenticator loses its
+    // authenticator half here, so the message should say what unlock now
+    // actually requires instead of implying nothing changed.
+    final wasCombined =
+        ref.read(unlockMethodProvider) == UnlockMethod.pinAndTotp;
     await ref.read(dbProvider).clearTotp();
     if (!mounted) return;
     Navigator.of(context).pop();
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(
-        const SnackBar(content: Text('Authenticator app turned off')),
+        SnackBar(
+          content: Text(
+            wasCombined
+                ? 'Authenticator app turned off — PIN unlock only'
+                : 'Authenticator app turned off',
+          ),
+        ),
       );
   }
 
@@ -99,6 +126,7 @@ class _TotpVerifyScreenState extends ConsumerState<TotpVerifyScreen> {
                   attempt: _attempt,
                   onDigit: _onDigit,
                   onBackspace: _onBackspace,
+                  extraKey: PasteCodeKey(onCode: _onPaste),
                 ),
               ),
             const Spacer(),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -528,6 +528,34 @@ class SettingsScreen extends ConsumerWidget {
                   ),
                 ),
                 Divider(height: 1, indent: 60, color: cs.outline),
+                // ── PIN + Authenticator — a true two-factor front door
+                // (GitHub #111): both a correct PIN *and* a correct code are
+                // required, entered one after the other, not either alone.
+                RadioListTile<UnlockMethod>(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                  secondary: const Icon(Icons.security_rounded),
+                  title: const Text('PIN + Authenticator'),
+                  subtitle: Text(
+                    hasPasscode && hasTotp
+                        ? 'Both a PIN and a code are required to unlock'
+                        : 'Requires setting up both a PIN and an '
+                              'authenticator app',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                  value: UnlockMethod.pinAndTotp,
+                  // ignore: deprecated_member_use
+                  groupValue: unlockMethod,
+                  // ignore: deprecated_member_use
+                  onChanged: (_) => _selectUnlockMethod(
+                    context,
+                    ref,
+                    UnlockMethod.pinAndTotp,
+                    configured: hasPasscode && hasTotp,
+                  ),
+                ),
+                Divider(height: 1, indent: 60, color: cs.outline),
 
                 // ── PIN management — visible whether or not PIN is active ──
                 ListTile(
@@ -1073,6 +1101,12 @@ class SettingsScreen extends ConsumerWidget {
   /// credential and activates it (see [AppDatabase.setupTotp]/
   /// [AppDatabase.setMasterPhrase]/[AppDatabase.setPasscode]), so there's
   /// nothing left to do here in that case.
+  ///
+  /// [UnlockMethod.pinAndTotp] (GitHub #111) needs *both* a PIN and a TOTP
+  /// secret before it's "configured" — when only one is missing, this routes
+  /// to that one's setup screen with `combine=true`, which chains on to the
+  /// other automatically if it's missing too (see [SetPasscodeScreen] /
+  /// [TotpSetupScreen]).
   void _selectUnlockMethod(
     BuildContext context,
     WidgetRef ref,
@@ -1088,6 +1122,9 @@ class SettingsScreen extends ConsumerWidget {
       UnlockMethod.pin => '/more/settings/passcode',
       UnlockMethod.masterPhrase => '/more/settings/master-phrase/setup',
       UnlockMethod.totp => '/more/settings/totp/setup',
+      UnlockMethod.pinAndTotp => ref.read(hasPasscodeProvider)
+          ? '/more/settings/totp/setup?combine=true'
+          : '/more/settings/passcode?combine=true',
     });
   }
 

--- a/test/unlock_method_test.dart
+++ b/test/unlock_method_test.dart
@@ -122,6 +122,28 @@ void main() {
         expect(hasUnlockCredential(await db.getSettings()), isFalse);
       },
     );
+
+    // GitHub #111: PIN + Authenticator needs *both* halves configured.
+    group('pinAndTotp', () {
+      test('false with only a PIN set', () async {
+        await db.setPasscode('4269');
+        await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+        expect(hasUnlockCredential(await db.getSettings()), isFalse);
+      });
+
+      test('false with only a TOTP secret set', () async {
+        await db.setupTotp(Totp.generateSecret());
+        await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+        expect(hasUnlockCredential(await db.getSettings()), isFalse);
+      });
+
+      test('true once both a PIN and a TOTP secret are set', () async {
+        await db.setPasscode('4269');
+        await db.setupTotp(Totp.generateSecret());
+        await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+        expect(hasUnlockCredential(await db.getSettings()), isTrue);
+      });
+    });
   });
 
   group('AppDatabase unlock method + TOTP round-trip (GitHub #104)', () {
@@ -225,6 +247,68 @@ void main() {
         expect(settings.totpSecret, secret);
       },
     );
+
+    // GitHub #111: a true two-factor front door — both a PIN *and* a TOTP
+    // code, not either alone — plus graceful fallback when either half is
+    // later removed.
+    group('pinAndTotp', () {
+      test(
+        'setUnlockMethod activates the combo once both halves exist',
+        () async {
+          await db.setPasscode('4269');
+          await db.setupTotp(Totp.generateSecret());
+          await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+          expect(
+            (await db.getSettings()).unlockMethod,
+            UnlockMethod.pinAndTotp,
+          );
+        },
+      );
+
+      test(
+        'clearPasscode falls back to totp when the combo was active — the '
+        'authenticator half still works on its own',
+        () async {
+          await db.setPasscode('4269');
+          await db.setupTotp(Totp.generateSecret());
+          await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+
+          await db.clearPasscode();
+          final settings = await db.getSettings();
+          expect(settings.unlockMethod, UnlockMethod.totp);
+          expect(settings.passcodeHash, isNull);
+          expect(settings.totpSecret, isNotNull);
+        },
+      );
+
+      test(
+        'clearTotp falls back to pin when the combo was active — the PIN '
+        'half still works on its own',
+        () async {
+          await db.setPasscode('4269');
+          await db.setupTotp(Totp.generateSecret());
+          await db.setUnlockMethod(UnlockMethod.pinAndTotp);
+
+          await db.clearTotp();
+          final settings = await db.getSettings();
+          expect(settings.unlockMethod, UnlockMethod.pin);
+          expect(settings.totpSecret, isNull);
+          expect(settings.passcodeHash, isNotNull);
+          expect(await db.verifyPasscode('4269'), isTrue);
+        },
+      );
+
+      test(
+        'clearPasscode leaves the active method alone when the combo was '
+        'not active',
+        () async {
+          await db.setPasscode('4269');
+          await db.setupTotp(Totp.generateSecret()); // activates totp alone
+          await db.clearPasscode();
+          expect((await db.getSettings()).unlockMethod, UnlockMethod.totp);
+        },
+      );
+    });
 
     test('unlockMethodProvider/hasTotpProvider reflect the stored row', () async {
       final container = ProviderContainer(


### PR DESCRIPTION
## Summary
- Adds a fourth "Unlock method" choice in Settings ▸ Security: **PIN + Authenticator** — a true two-factor front door requiring both a correct PIN *and* a correct authenticator code (entered one after the other), for users who want stacked protection rather than the single alternative-method choice #104 introduced.
- Adds a **Paste** key to every authenticator-code keypad (lock screen, authenticator setup, turn-off-authenticator screen) — copy a code from an authenticator app and paste it in directly instead of retyping six digits.
- Setting up the combo reuses the existing PIN/TOTP setup screens (chained via a `combine=true` flag) rather than a new dedicated screen.
- Turning off either half gracefully falls back to the other (PIN alone or authenticator alone) instead of leaving the app in a broken lock state.
- Biometric unlock is deliberately withheld during the PIN step of the combined flow, so a fingerprint can't silently bypass the second factor.
- See `docs/superpowers/specs/2026-09-06-pin-plus-authenticator-design.md` for full design notes.

## Test plan
- [x] `dart analyze` — no issues
- [x] `flutter test test/unlock_method_test.dart` — 27/27 passing, including new `pinAndTotp` coverage (hasUnlockCredential, activation, clearPasscode/clearTotp fallback)
- [x] `flutter test test/auto_backup_test.dart test/lock_screen_style_test.dart test/screens_smoke_test.dart test/migration_version_drift_test.dart` — all passing
- [x] `flutter test test/passcode_test.dart test/currency_settings_screen_test.dart test/font_settings_test.dart test/theme_test.dart` — all passing
- [ ] Manual check on device: set up PIN + Authenticator from Settings, lock/unlock the app, and try the Paste key with a code copied from an authenticator app

🤖 Generated with [Claude Code](https://claude.com/claude-code)