### PR TITLE
fix: repair invalid stored unlock_method instead of crashing on open (#112)

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -548,6 +548,9 @@ class AppDatabase extends _$AppDatabase {
     },
     beforeOpen: (details) async {
       await customStatement('PRAGMA foreign_keys = ON');
+      // Must run before the typed `select(settings)` below — see doc
+      // comment on [_repairInvalidUnlockMethod].
+      await _repairInvalidUnlockMethod();
       final hasSettings = await select(settings).get();
       if (hasSettings.isEmpty) {
         await into(settings).insert(const SettingsCompanion());
@@ -590,6 +593,45 @@ class AppDatabase extends _$AppDatabase {
   ) async {
     if (await _hasColumn(table.actualTableName, column.name)) return;
     await m.addColumn(table, column);
+  }
+
+  /// Repairs a `settings.unlock_method` value that doesn't match any of
+  /// today's [UnlockMethod] names.
+  ///
+  /// Same root cause as [_addColumnIfMissing]'s doc — a rolling-BETA build
+  /// (an earlier iteration of GitHub #104 or #111) could have stamped
+  /// `schemaVersion` to its current number while writing an `unlock_method`
+  /// string that a later, renamed/reordered [UnlockMethod] no longer
+  /// recognizes. Drift's `textEnum` column decodes with `.byName(...)`,
+  /// which throws on an unrecognized string instead of falling back — and
+  /// because a device already on the latest `schemaVersion` never re-runs
+  /// `onUpgrade`, nothing else would ever fix it. Every subsequent launch
+  /// would then crash before the settings row can even be read, surfacing
+  /// as "Couldn't open your data" with no way for the user to recover
+  /// (GitHub #112).
+  ///
+  /// This runs with raw SQL rather than a typed `select`/`update`, so an
+  /// already-bad value is inspected and fixed *before* Drift's enum
+  /// converter ever gets a chance to throw on it.
+  Future<void> _repairInvalidUnlockMethod() async {
+    if (!await _hasColumn('settings', 'unlock_method')) return;
+    final validNames = UnlockMethod.values.map((e) => e.name).toSet();
+    final rows = await customSelect(
+      'SELECT DISTINCT unlock_method FROM settings',
+    ).get();
+    for (final row in rows) {
+      final value = row.read<String?>('unlock_method');
+      if (value != null && !validNames.contains(value)) {
+        await customUpdate(
+          'UPDATE settings SET unlock_method = ? WHERE unlock_method = ?',
+          variables: [
+            Variable.withString(UnlockMethod.pin.name),
+            Variable.withString(value),
+          ],
+          updates: {settings},
+        );
+      }
+    }
   }
 
   /// v2 → v3: person entries used to poke the account balance directly, with no

--- a/test/migration_version_drift_test.dart
+++ b/test/migration_version_drift_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xpenc/data/database.dart';
+import 'package:xpenc/data/tables.dart' show UnlockMethod;
 
 /// GitHub #49 / #50: some real devices ended up with a database whose
 /// stored `PRAGMA user_version` was *lower* than the schema version its
@@ -150,6 +151,34 @@ void main() {
 
       final reopened = AppDatabase(NativeDatabase(file));
       await expectLater(reopened.select(reopened.settings).get(), completes);
+      await reopened.close();
+    },
+  );
+
+  test(
+    'GitHub #112: a settings row whose stored unlock_method is not a '
+    "current UnlockMethod name (e.g. a rolling-BETA build's stale value) "
+    'no longer crashes "Couldn\'t open your data" on reopen, and is '
+    'repaired back to pin',
+    () async {
+      final file = File('${tempDir.path}/stale_unlock_method.sqlite');
+      final db = AppDatabase(NativeDatabase(file));
+      // Fully migrated already (schemaVersion == 64), but the stored text
+      // doesn't match any current UnlockMethod.values name — as if an
+      // earlier beta iteration of #104/#111 wrote a value under a name
+      // since renamed. Written with raw SQL so this doesn't itself throw
+      // going through the typed enum converter.
+      await db.customStatement(
+        "UPDATE settings SET unlock_method = 'stale_value_from_old_beta'",
+      );
+      await db.close();
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      // Before the fix, `EnumNameConverter.fromSql`'s `.byName(...)` threw
+      // here, surfacing as the app's "Couldn't open your data" screen with
+      // no way for the user to recover.
+      final row = await reopened.select(reopened.settings).getSingle();
+      expect(row.unlockMethod, UnlockMethod.pin);
       await reopened.close();
     },
   );


### PR DESCRIPTION
## Summary
- Fixes #112 — the "Couldn't open your data" crash some users hit after the beta update that added the PIN/Authenticator unlock method (#104, #111).
- Root cause: `settings.unlock_method` is a `textEnum<UnlockMethod>()` column decoded via Drift's `EnumNameConverter`, which throws if the stored text doesn't match any current `UnlockMethod` name. A rolling-BETA build of an earlier iteration of #104/#111 could have written a value under a name later renamed/reordered. Since a device already on the latest `schemaVersion` never re-runs `onUpgrade`, nothing ever repaired it — every subsequent launch crashed before the settings row could even be read.
- Fix: `beforeOpen` now runs a new `_repairInvalidUnlockMethod()` step, using raw SQL (not a typed query, so it can't itself throw), which normalizes any unrecognized `unlock_method` value back to `pin` *before* any typed read hits the enum converter.

## Test plan
- [x] Added a regression test (`test/migration_version_drift_test.dart`) that writes an invalid `unlock_method` string via raw SQL, reopens the database, and asserts it opens cleanly with the value repaired to `pin` instead of crashing.
- [x] `dart analyze lib/data/database.dart` — no issues.
- [x] All existing tests in `test/migration_version_drift_test.dart` (10/10) and `test/unlock_method_test.dart` (27/27) pass — no behavior change for anyone with a valid `unlock_method`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)