### PR TITLE
fix: repair NULL unlock_method/toggle columns, not just invalid names (#112)

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -643,42 +643,76 @@ class AppDatabase extends _$AppDatabase {
     await m.addColumn(table, column);
   }
 
-  /// Repairs a `settings.unlock_method` value that doesn't match any of
-  /// today's [UnlockMethod] names.
+  /// Repairs a `settings.unlock_method`/toggle value the generated row
+  /// mapper can't decode: a name outside today's [UnlockMethod] set, or —
+  /// the case the first attempt at this (GitHub #112) missed — outright
+  /// `NULL`.
   ///
-  /// Same root cause as [_addColumnIfMissing]'s doc — a rolling-BETA build
-  /// (an earlier iteration of GitHub #104 or #111) could have stamped
-  /// `schemaVersion` to its current number while writing an `unlock_method`
-  /// string that a later, renamed/reordered [UnlockMethod] no longer
-  /// recognizes. Drift's `textEnum` column decodes with `.byName(...)`,
-  /// which throws on an unrecognized string instead of falling back — and
-  /// because a device already on the latest `schemaVersion` never re-runs
-  /// `onUpgrade`, nothing else would ever fix it. Every subsequent launch
-  /// would then crash before the settings row can even be read, surfacing
-  /// as "Couldn't open your data" with no way for the user to recover
-  /// (GitHub #112).
+  /// Same rolling-BETA root cause as [_addColumnIfMissing]'s doc: an early
+  /// iteration of GitHub #104/#111/#116 could have added `unlock_method`
+  /// (or `pin_unlock_enabled`/`master_phrase_unlock_enabled`/
+  /// `totp_unlock_enabled`) as nullable, with no default, before the
+  /// released migration that added the same column `NOT NULL DEFAULT`. Once
+  /// a device already has the column, [_addColumnIfMissing] skips re-adding
+  /// it — so that device keeps a nullable column with real `NULL` rows,
+  /// forever. `database.g.dart`'s row mapper reads every one of these with
+  /// a `!` (non-nullable Dart fields), so `NULL` throws "Null check
+  /// operator used on a null value" — not the enum-decode exception the
+  /// first fix (PR #114) targeted — crashing every launch before the
+  /// settings row can even be read, as "Couldn't open your data" with no
+  /// way for the user to recover.
   ///
   /// This runs with raw SQL rather than a typed `select`/`update`, so an
-  /// already-bad value is inspected and fixed *before* Drift's enum
-  /// converter ever gets a chance to throw on it.
+  /// already-bad value is inspected and fixed *before* Drift's generated
+  /// mapper ever gets a chance to throw on it.
   Future<void> _repairInvalidUnlockMethod() async {
-    if (!await _hasColumn('settings', 'unlock_method')) return;
-    final validNames = UnlockMethod.values.map((e) => e.name).toSet();
-    final rows = await customSelect(
-      'SELECT DISTINCT unlock_method FROM settings',
-    ).get();
-    for (final row in rows) {
-      final value = row.read<String?>('unlock_method');
-      if (value != null && !validNames.contains(value)) {
-        await customUpdate(
-          'UPDATE settings SET unlock_method = ? WHERE unlock_method = ?',
-          variables: [
-            Variable.withString(UnlockMethod.pin.name),
-            Variable.withString(value),
-          ],
-          updates: {settings},
-        );
+    if (await _hasColumn('settings', 'unlock_method')) {
+      final validNames = UnlockMethod.values.map((e) => e.name).toSet();
+      final rows = await customSelect(
+        'SELECT DISTINCT unlock_method FROM settings',
+      ).get();
+      for (final row in rows) {
+        final value = row.read<String?>('unlock_method');
+        if (value == null) {
+          await customUpdate(
+            'UPDATE settings SET unlock_method = ? WHERE unlock_method IS NULL',
+            variables: [Variable.withString(UnlockMethod.pin.name)],
+            updates: {settings},
+          );
+        } else if (!validNames.contains(value)) {
+          await customUpdate(
+            'UPDATE settings SET unlock_method = ? WHERE unlock_method = ?',
+            variables: [
+              Variable.withString(UnlockMethod.pin.name),
+              Variable.withString(value),
+            ],
+            updates: {settings},
+          );
+        }
       }
+    }
+    // The three toggles default to "on" only for whichever method already
+    // has a credential — same rule the v65 migration itself backfills new
+    // rows with — rather than blindly flipping every stale NULL to off,
+    // which could silently drop a still-configured method's only way in.
+    if (await _hasColumn('settings', 'pin_unlock_enabled')) {
+      await customStatement(
+        'UPDATE settings SET pin_unlock_enabled = '
+        '(passcode_hash IS NOT NULL) WHERE pin_unlock_enabled IS NULL',
+      );
+    }
+    if (await _hasColumn('settings', 'master_phrase_unlock_enabled')) {
+      await customStatement(
+        'UPDATE settings SET master_phrase_unlock_enabled = '
+        '(master_phrase_hash IS NOT NULL) '
+        'WHERE master_phrase_unlock_enabled IS NULL',
+      );
+    }
+    if (await _hasColumn('settings', 'totp_unlock_enabled')) {
+      await customStatement(
+        'UPDATE settings SET totp_unlock_enabled = '
+        '(totp_secret IS NOT NULL) WHERE totp_unlock_enabled IS NULL',
+      );
     }
   }
 

--- a/test/migration_version_drift_test.dart
+++ b/test/migration_version_drift_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Variable;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:xpenc/data/database.dart';
@@ -168,4 +169,81 @@ void main() {
     expect(row.unlockMethod, UnlockMethod.pin);
     await reopened.close();
   });
+
+  /// Strips the `NOT NULL`/`DEFAULT` clause off one `settings` column's
+  /// stored `CREATE TABLE` text via SQLite's `writable_schema` trick — the
+  /// only way to reproduce, from a *current*-schema database, the shape an
+  /// early rolling-BETA build actually left on a real device: the column
+  /// already exists (so `_addColumnIfMissing` skips it forever), but
+  /// without the constraint the officially released migration added, so it
+  /// can hold a real `NULL`. Requires closing and reopening the connection
+  /// afterward — SQLite caches parsed schema per-connection.
+  Future<void> dropNotNull(AppDatabase db, String column, String ddlSuffix) =>
+      db.customUpdate(
+        "UPDATE sqlite_master SET sql = REPLACE(sql, ?, ?) "
+        "WHERE type = 'table' AND name = 'settings'",
+        variables: [
+          Variable.withString('"$column" $ddlSuffix'),
+          Variable.withString('"$column" ${ddlSuffix.split(' ').first}'),
+        ],
+      );
+
+  test(
+    'GitHub #112 (take 2): unlock_method/pin_unlock_enabled/'
+    'master_phrase_unlock_enabled/totp_unlock_enabled columns that are '
+    "literally NULL — an early rolling-BETA build's column added without "
+    'the released NOT NULL/DEFAULT, so _addColumnIfMissing never touches '
+    'it again — no longer throw "Null check operator used on a null '
+    'value" on reopen, and are repaired to sane defaults',
+    () async {
+      final file = File('${tempDir.path}/null_unlock_columns.sqlite');
+      var db = AppDatabase(NativeDatabase(file));
+      await db.customStatement('PRAGMA writable_schema = 1');
+      await dropNotNull(db, 'unlock_method', "TEXT NOT NULL DEFAULT 'pin'");
+      await dropNotNull(
+        db,
+        'pin_unlock_enabled',
+        'INTEGER NOT NULL DEFAULT 1 CHECK ("pin_unlock_enabled" IN (0, 1))',
+      );
+      await dropNotNull(
+        db,
+        'master_phrase_unlock_enabled',
+        'INTEGER NOT NULL DEFAULT 0 CHECK '
+            '("master_phrase_unlock_enabled" IN (0, 1))',
+      );
+      await dropNotNull(
+        db,
+        'totp_unlock_enabled',
+        'INTEGER NOT NULL DEFAULT 0 CHECK ("totp_unlock_enabled" IN (0, 1))',
+      );
+      await db.customStatement('PRAGMA writable_schema = 0');
+      await db.close();
+
+      // A fresh connection to actually pick up the rewritten schema, so the
+      // columns below are genuinely nullable rather than still cached as
+      // NOT NULL from the connection that just edited sqlite_master.
+      db = AppDatabase(NativeDatabase(file));
+      await db.customStatement(
+        'UPDATE settings SET unlock_method = NULL, pin_unlock_enabled = '
+        'NULL, master_phrase_unlock_enabled = NULL, totp_unlock_enabled = '
+        'NULL',
+      );
+      await db.close();
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      // Before this fix, `data['...pin_unlock_enabled']!`  (and the other
+      // three `!`-asserted reads) threw here — surfacing on a real device
+      // exactly as the screenshot on GitHub #112 shows: "Couldn't open
+      // your data" / "Null check operator used on a null value".
+      final row = await reopened.select(reopened.settings).getSingle();
+      expect(row.unlockMethod, UnlockMethod.pin);
+      // Repaired toggles fall back to "on" only where a credential already
+      // exists — this seeded row has none, so all three land off, which is
+      // the same "nothing configured yet" shape a brand-new install has.
+      expect(row.pinUnlockEnabled, isFalse);
+      expect(row.masterPhraseUnlockEnabled, isFalse);
+      expect(row.totpUnlockEnabled, isFalse);
+      await reopened.close();
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Closes #112 for real — the earlier fix (#114) only handled an `unlock_method` value that decoded to an *unrecognized* enum name. It missed the actual failure mode a user hit (screenshot on the issue): **`unlock_method` (or the new `pin_unlock_enabled`/`master_phrase_unlock_enabled`/`totp_unlock_enabled` toggle columns) can be genuinely `NULL`** on a real device.

## Root cause
An early rolling-BETA build could have added one of these columns as nullable, with no default, before the officially released migration added the same column `NOT NULL DEFAULT`. Once a device already has the column, `_addColumnIfMissing` skips re-adding it forever — so that device is stuck with a nullable column holding a real `NULL`. The generated row mapper in `database.g.dart` reads every one of these non-nullable Dart fields with `!`, so a stored `NULL` throws **"Null check operator used on a null value"** — not the enum-decode exception #114 targeted — crashing every launch as "Couldn't open your data" with no way to recover. This matches the exact error text in the screenshot on #112.

## Fix
`_repairInvalidUnlockMethod` (run in `beforeOpen`, before any typed read) now also:
- Coalesces a `NULL` `unlock_method` to `pin`.
- Coalesces a `NULL` toggle column to "on" only if that method's own credential is already configured — the same rule the v65 migration itself uses to backfill new rows — rather than blindly flipping every stale `NULL` to off, which could silently drop a still-configured method's only way in.

## Test plan
- [x] Added a regression test that reproduces the exact real-device shape: builds a fully-migrated database, then uses SQLite's `writable_schema` trick to strip `NOT NULL`/`DEFAULT` off the affected columns (the only way to get a genuinely nullable column on an otherwise current-schema database, since `AppDatabase()` always creates columns with today's constraints), sets them to `NULL`, and reopens. Confirmed it **fails without this fix** (throws the exact "Null check operator" error) and **passes with it**.
- [x] `flutter analyze` — no issues.
- [x] `flutter test` — full suite, 702/702 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)