### PR TITLE
fix: coalesce any NULL settings column, not just unlock-method ones (#112)

### DIFF
--- a/lib/data/database.dart
+++ b/lib/data/database.dart
@@ -599,6 +599,7 @@ class AppDatabase extends _$AppDatabase {
       // Must run before the typed `select(settings)` below — see doc
       // comment on [_repairInvalidUnlockMethod].
       await _repairInvalidUnlockMethod();
+      await _repairNullSettingsColumns();
       final hasSettings = await select(settings).get();
       if (hasSettings.isEmpty) {
         await into(settings).insert(const SettingsCompanion());
@@ -712,6 +713,54 @@ class AppDatabase extends _$AppDatabase {
       await customStatement(
         'UPDATE settings SET totp_unlock_enabled = '
         '(totp_secret IS NOT NULL) WHERE totp_unlock_enabled IS NULL',
+      );
+    }
+  }
+
+  /// Catch-all for the same rolling-BETA root cause as
+  /// [_repairInvalidUnlockMethod], for every *other* `settings` column.
+  ///
+  /// That fix (PR #117) hand-patched only the unlock-method columns because
+  /// those were the ones a user had actually hit. But issue #112 kept
+  /// recurring afterward (see the issue's comment thread — reports on
+  /// commits after #117 had already merged): the same "an early rolling-BETA
+  /// build added this NOT NULL column nullable, before the officially
+  /// released migration added it NOT NULL DEFAULT, so `_addColumnIfMissing`
+  /// leaves it stuck NULL forever" shape applies to *any* column ever added
+  /// after the initial schema, not just the unlock-method ones — e.g.
+  /// [Settings.rtaEnabled] or [Settings.showCurrencySymbol]. Hand-patching
+  /// one column at a time only fixes the specific report that already came
+  /// in, leaving the same crash waiting on the next column.
+  ///
+  /// This walks every `settings` column and, for the ones that are `NOT
+  /// NULL` with a plain constant default (which is every column added this
+  /// way — see `database.g.dart`), coalesces a stray `NULL` to that default.
+  /// It runs *after* [_repairInvalidUnlockMethod] so the smarter
+  /// credential-aware defaults above still win for the columns they cover;
+  /// this only catches whatever they don't.
+  Future<void> _repairNullSettingsColumns() async {
+    for (final column in settings.$columns) {
+      if (column.$nullable) continue;
+      final defaultValue = column.defaultValue;
+      if (defaultValue is! Constant) continue;
+      final value = defaultValue.value;
+      if (value == null) continue;
+
+      final Variable? variable = switch (value) {
+        bool v => Variable.withBool(v),
+        int v => Variable.withInt(v),
+        String v => Variable.withString(v),
+        double v => Variable.withReal(v),
+        DateTime v => Variable.withDateTime(v),
+        _ => null,
+      };
+      if (variable == null) continue;
+
+      await customUpdate(
+        'UPDATE settings SET "${column.name}" = ? '
+        'WHERE "${column.name}" IS NULL',
+        variables: [variable],
+        updates: {settings},
       );
     }
   }

--- a/test/migration_version_drift_test.dart
+++ b/test/migration_version_drift_test.dart
@@ -246,4 +246,35 @@ void main() {
       await reopened.close();
     },
   );
+
+  test(
+    'GitHub #112 (take 3): any other NOT NULL settings column left NULL by '
+    "the same rolling-BETA shape (e.g. rta_enabled) — not just the "
+    'unlock-method ones PR #117 hand-patched — is coalesced back to its '
+    'schema default instead of crashing "Couldn\'t open your data"',
+    () async {
+      final file = File('${tempDir.path}/null_rta_enabled.sqlite');
+      var db = AppDatabase(NativeDatabase(file));
+      await db.customStatement('PRAGMA writable_schema = 1');
+      await dropNotNull(
+        db,
+        'rta_enabled',
+        'INTEGER NOT NULL DEFAULT 0 CHECK ("rta_enabled" IN (0, 1))',
+      );
+      await db.customStatement('PRAGMA writable_schema = 0');
+      await db.close();
+
+      db = AppDatabase(NativeDatabase(file));
+      await db.customStatement('UPDATE settings SET rta_enabled = NULL');
+      await db.close();
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      // Before this fix, `data['rta_enabled']!` threw "Null check operator
+      // used on a null value" here — the exact same crash shape as #112,
+      // just on a column the earlier hand-patch never covered.
+      final row = await reopened.select(reopened.settings).getSingle();
+      expect(row.rtaEnabled, isFalse);
+      await reopened.close();
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Closes #112 (for real, hopefully) — the issue kept recurring even after PR #117 merged (see the issue's comment thread: a report on commit `3abf435`, which is #117's own merge commit).

## Root cause
PR #117 hand-patched `unlock_method`/`pin_unlock_enabled`/`master_phrase_unlock_enabled`/`totp_unlock_enabled` because those were the columns a real user had actually hit. But the underlying shape isn't specific to those four columns: an early rolling-BETA build can add **any** column nullable, with no default, before the officially released migration adds the same column `NOT NULL DEFAULT`. Once a device already has the column, `_addColumnIfMissing` skips re-adding it forever, so that device is stuck with a genuinely `NULL` value in a Dart-side non-nullable field — and the generated row mapper reads it with `!`, throwing "Null check operator used on a null value" and surfacing as "Couldn't open your data" with no recovery. Hand-patching one column at a time only fixes the specific report that already came in; the next column this bites (e.g. `rta_enabled`, from the #100 Ready-to-Assign redesign) would reproduce the exact same crash.

## Fix
`_repairNullSettingsColumns` (in `lib/data/database.dart`, run in `beforeOpen` right after `_repairInvalidUnlockMethod`) walks every `settings` column and, for any `NOT NULL` column with a plain constant default, coalesces a stray `NULL` back to that default. It runs *after* the existing unlock-method repair so the smarter credential-aware defaults there (e.g. `pin_unlock_enabled` following whether a passcode is actually set) still win for the columns they cover — this only catches whatever isn't already handled.

## Test plan
- [x] Added a regression test (`test/migration_version_drift_test.dart`) that reproduces the real-device shape for `rta_enabled` — a column *not* covered by PR #117's hand-patch — using the same `writable_schema` trick as the existing #112 tests. Confirmed it fails without this fix and passes with it.
- [x] `flutter analyze` — no issues.
- [x] `flutter test` — full suite, 703/703 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NYnrWjNHVxCMYRbzUQBHE